### PR TITLE
Add New About Screen

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -6,6 +6,7 @@ import '../features/history/presentation/screens/history_list_screen.dart';
 import '../features/history/presentation/screens/workout_detail_screen.dart';
 import '../features/history/presentation/screens/exercise_progress_screen.dart';
 import '../features/settings/presentation/screens/settings_screen.dart';
+import '../features/settings/presentation/screens/about_screen.dart';
 import '../features/templates/presentation/screens/template_list_screen.dart';
 import '../features/templates/presentation/screens/template_edit_screen.dart';
 import '../features/exercises/presentation/screens/exercise_picker_screen.dart';
@@ -51,6 +52,12 @@ final routerProvider = Provider<GoRouter>((ref) {
           GoRoute(
             path: '/settings',
             builder: (context, state) => const SettingsScreen(),
+            routes: [
+              GoRoute(
+                path: 'about',
+                builder: (context, state) => const AboutScreen(),
+              ),
+            ],
           ),
         ],
       ),

--- a/lib/features/settings/presentation/screens/about_screen.dart
+++ b/lib/features/settings/presentation/screens/about_screen.dart
@@ -1,0 +1,189 @@
+import 'package:flutter/material.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:url_launcher/url_launcher.dart';
+import '../../../../l10n/generated/app_localizations.dart';
+
+class AboutScreen extends StatelessWidget {
+  const AboutScreen({super.key});
+
+  static const _gitHubUrl = 'https://github.com/bovinemagnet/RepFoundry';
+
+  @override
+  Widget build(BuildContext context) {
+    final s = S.of(context)!;
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(title: Text(s.aboutScreenTitle)),
+      body: FutureBuilder<PackageInfo>(
+        future: PackageInfo.fromPlatform(),
+        builder: (context, snapshot) {
+          final version = snapshot.data?.version ?? '1.0.0';
+          final buildNumber = snapshot.data?.buildNumber ?? '';
+          final versionDisplay =
+              buildNumber.isNotEmpty ? '$version+$buildNumber' : version;
+
+          return ListView(
+            padding: const EdgeInsets.symmetric(vertical: 24),
+            children: [
+              // App icon and name
+              Center(
+                child: Column(
+                  children: [
+                    Icon(
+                      Icons.fitness_center,
+                      size: 64,
+                      color: theme.colorScheme.primary,
+                    ),
+                    const SizedBox(height: 12),
+                    Text(
+                      s.aboutAppName,
+                      style: theme.textTheme.headlineMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      s.aboutVersion(versionDisplay),
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 32),
+                      child: Text(
+                        s.aboutDescription,
+                        textAlign: TextAlign.center,
+                        style: theme.textTheme.bodyLarge,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+
+              const SizedBox(height: 24),
+              const Divider(),
+
+              // Author
+              ListTile(
+                leading: const Icon(Icons.person_outline),
+                title: Text(s.aboutAuthorLabel),
+                subtitle: Text(s.aboutAuthor),
+              ),
+
+              // GitHub
+              ListTile(
+                leading: const Icon(Icons.code),
+                title: Text(s.aboutGitHub),
+                subtitle: const Text(_gitHubUrl),
+                trailing: const Icon(Icons.open_in_new),
+                onTap: () => _openUrl(_gitHubUrl),
+              ),
+
+              const Divider(),
+
+              // Features
+              _SectionHeader(title: s.aboutFeatures),
+              _FeatureTile(
+                icon: Icons.cloud_off,
+                text: s.aboutFeatureOffline,
+              ),
+              _FeatureTile(
+                icon: Icons.monitor_heart_outlined,
+                text: s.aboutFeatureHeartRate,
+              ),
+              _FeatureTile(
+                icon: Icons.library_books_outlined,
+                text: s.aboutFeatureTemplates,
+              ),
+              _FeatureTile(
+                icon: Icons.trending_up,
+                text: s.aboutFeatureProgress,
+              ),
+              _FeatureTile(
+                icon: Icons.file_download_outlined,
+                text: s.aboutFeatureExport,
+              ),
+              _FeatureTile(
+                icon: Icons.directions_run,
+                text: s.aboutFeatureCardio,
+              ),
+
+              const Divider(),
+
+              // Built with
+              ListTile(
+                leading: const Icon(Icons.build_outlined),
+                title: Text(s.aboutBuiltWith),
+              ),
+
+              // Licences
+              ListTile(
+                leading: const Icon(Icons.description_outlined),
+                title: Text(s.aboutViewLicences),
+                trailing: const Icon(Icons.chevron_right),
+                onTap: () => showLicensePage(
+                  context: context,
+                  applicationName: s.aboutAppName,
+                  applicationVersion: versionDisplay,
+                  applicationIcon: Padding(
+                    padding: const EdgeInsets.all(8),
+                    child: Icon(
+                      Icons.fitness_center,
+                      size: 48,
+                      color: theme.colorScheme.primary,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  Future<void> _openUrl(String url) async {
+    final uri = Uri.parse(url);
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader({required this.title});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 20, 16, 4),
+      child: Text(
+        title,
+        style: Theme.of(context).textTheme.labelLarge?.copyWith(
+              color: Theme.of(context).colorScheme.primary,
+            ),
+      ),
+    );
+  }
+}
+
+class _FeatureTile extends StatelessWidget {
+  const _FeatureTile({required this.icon, required this.text});
+
+  final IconData icon;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      leading: Icon(icon, size: 20),
+      title: Text(text, style: Theme.of(context).textTheme.bodyMedium),
+      dense: true,
+      visualDensity: VisualDensity.compact,
+    );
+  }
+}

--- a/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/lib/features/settings/presentation/screens/settings_screen.dart
@@ -427,7 +427,8 @@ class SettingsScreen extends ConsumerWidget {
           ListTile(
             leading: const Icon(Icons.info_outline),
             title: Text(s.aboutAppName),
-            subtitle: Text(s.aboutVersion),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () => context.push('/settings/about'),
           ),
         ],
       ),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -139,7 +139,24 @@
   "allDataCleared": "All data cleared.",
 
   "aboutAppName": "RepFoundry",
-  "aboutVersion": "Version 1.0.0",
+  "aboutVersion": "Version {version}",
+  "@aboutVersion": {
+    "placeholders": { "version": { "type": "String" } }
+  },
+  "aboutScreenTitle": "About RepFoundry",
+  "aboutDescription": "A simple, fast workout tracking app for gym-goers.",
+  "aboutAuthorLabel": "Author",
+  "aboutAuthor": "Paul Snow",
+  "aboutGitHub": "GitHub Repository",
+  "aboutFeatures": "Features",
+  "aboutFeatureOffline": "Offline-first \u2014 your data stays on your device",
+  "aboutFeatureHeartRate": "Bluetooth heart rate monitor support",
+  "aboutFeatureTemplates": "Workout templates for quick session setup",
+  "aboutFeatureProgress": "Progress tracking with personal records",
+  "aboutFeatureExport": "Export your data as JSON or CSV",
+  "aboutFeatureCardio": "GPS-tracked cardio sessions",
+  "aboutBuiltWith": "Built with Flutter",
+  "aboutViewLicences": "Open-source licences",
 
   "heartRateTitle": "Heart Rate",
   "connectHrMonitor": "Connect HR Monitor",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -139,7 +139,7 @@
   "allDataCleared": "所有数据已清除。",
 
   "aboutAppName": "RepFoundry",
-  "aboutVersion": "版本 1.0.0",
+  "aboutVersion": "版本 {version}",
 
   "heartRateTitle": "心率",
   "connectHrMonitor": "连接心率监测器",

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -139,7 +139,7 @@
   "allDataCleared": "所有数据已清除。",
 
   "aboutAppName": "RepFoundry",
-  "aboutVersion": "版本 1.0.0",
+  "aboutVersion": "版本 {version}",
 
   "heartRateTitle": "心率",
   "connectHrMonitor": "连接心率监测器",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -659,8 +659,92 @@ abstract class S {
   /// No description provided for @aboutVersion.
   ///
   /// In en, this message translates to:
-  /// **'Version 1.0.0'**
-  String get aboutVersion;
+  /// **'Version {version}'**
+  String aboutVersion(String version);
+
+  /// No description provided for @aboutScreenTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'About RepFoundry'**
+  String get aboutScreenTitle;
+
+  /// No description provided for @aboutDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'A simple, fast workout tracking app for gym-goers.'**
+  String get aboutDescription;
+
+  /// No description provided for @aboutAuthorLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Author'**
+  String get aboutAuthorLabel;
+
+  /// No description provided for @aboutAuthor.
+  ///
+  /// In en, this message translates to:
+  /// **'Paul Snow'**
+  String get aboutAuthor;
+
+  /// No description provided for @aboutGitHub.
+  ///
+  /// In en, this message translates to:
+  /// **'GitHub Repository'**
+  String get aboutGitHub;
+
+  /// No description provided for @aboutFeatures.
+  ///
+  /// In en, this message translates to:
+  /// **'Features'**
+  String get aboutFeatures;
+
+  /// No description provided for @aboutFeatureOffline.
+  ///
+  /// In en, this message translates to:
+  /// **'Offline-first — your data stays on your device'**
+  String get aboutFeatureOffline;
+
+  /// No description provided for @aboutFeatureHeartRate.
+  ///
+  /// In en, this message translates to:
+  /// **'Bluetooth heart rate monitor support'**
+  String get aboutFeatureHeartRate;
+
+  /// No description provided for @aboutFeatureTemplates.
+  ///
+  /// In en, this message translates to:
+  /// **'Workout templates for quick session setup'**
+  String get aboutFeatureTemplates;
+
+  /// No description provided for @aboutFeatureProgress.
+  ///
+  /// In en, this message translates to:
+  /// **'Progress tracking with personal records'**
+  String get aboutFeatureProgress;
+
+  /// No description provided for @aboutFeatureExport.
+  ///
+  /// In en, this message translates to:
+  /// **'Export your data as JSON or CSV'**
+  String get aboutFeatureExport;
+
+  /// No description provided for @aboutFeatureCardio.
+  ///
+  /// In en, this message translates to:
+  /// **'GPS-tracked cardio sessions'**
+  String get aboutFeatureCardio;
+
+  /// No description provided for @aboutBuiltWith.
+  ///
+  /// In en, this message translates to:
+  /// **'Built with Flutter'**
+  String get aboutBuiltWith;
+
+  /// No description provided for @aboutViewLicences.
+  ///
+  /// In en, this message translates to:
+  /// **'Open-source licences'**
+  String get aboutViewLicences;
 
   /// No description provided for @heartRateTitle.
   ///

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -306,7 +306,54 @@ class SEn extends S {
   String get aboutAppName => 'RepFoundry';
 
   @override
-  String get aboutVersion => 'Version 1.0.0';
+  String aboutVersion(String version) {
+    return 'Version $version';
+  }
+
+  @override
+  String get aboutScreenTitle => 'About RepFoundry';
+
+  @override
+  String get aboutDescription =>
+      'A simple, fast workout tracking app for gym-goers.';
+
+  @override
+  String get aboutAuthorLabel => 'Author';
+
+  @override
+  String get aboutAuthor => 'Paul Snow';
+
+  @override
+  String get aboutGitHub => 'GitHub Repository';
+
+  @override
+  String get aboutFeatures => 'Features';
+
+  @override
+  String get aboutFeatureOffline =>
+      'Offline-first — your data stays on your device';
+
+  @override
+  String get aboutFeatureHeartRate => 'Bluetooth heart rate monitor support';
+
+  @override
+  String get aboutFeatureTemplates =>
+      'Workout templates for quick session setup';
+
+  @override
+  String get aboutFeatureProgress => 'Progress tracking with personal records';
+
+  @override
+  String get aboutFeatureExport => 'Export your data as JSON or CSV';
+
+  @override
+  String get aboutFeatureCardio => 'GPS-tracked cardio sessions';
+
+  @override
+  String get aboutBuiltWith => 'Built with Flutter';
+
+  @override
+  String get aboutViewLicences => 'Open-source licences';
 
   @override
   String get heartRateTitle => 'Heart Rate';

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -300,7 +300,54 @@ class SZh extends S {
   String get aboutAppName => 'RepFoundry';
 
   @override
-  String get aboutVersion => '版本 1.0.0';
+  String aboutVersion(String version) {
+    return '版本 $version';
+  }
+
+  @override
+  String get aboutScreenTitle => 'About RepFoundry';
+
+  @override
+  String get aboutDescription =>
+      'A simple, fast workout tracking app for gym-goers.';
+
+  @override
+  String get aboutAuthorLabel => 'Author';
+
+  @override
+  String get aboutAuthor => 'Paul Snow';
+
+  @override
+  String get aboutGitHub => 'GitHub Repository';
+
+  @override
+  String get aboutFeatures => 'Features';
+
+  @override
+  String get aboutFeatureOffline =>
+      'Offline-first — your data stays on your device';
+
+  @override
+  String get aboutFeatureHeartRate => 'Bluetooth heart rate monitor support';
+
+  @override
+  String get aboutFeatureTemplates =>
+      'Workout templates for quick session setup';
+
+  @override
+  String get aboutFeatureProgress => 'Progress tracking with personal records';
+
+  @override
+  String get aboutFeatureExport => 'Export your data as JSON or CSV';
+
+  @override
+  String get aboutFeatureCardio => 'GPS-tracked cardio sessions';
+
+  @override
+  String get aboutBuiltWith => 'Built with Flutter';
+
+  @override
+  String get aboutViewLicences => 'Open-source licences';
 
   @override
   String get heartRateTitle => '心率';
@@ -1727,7 +1774,9 @@ class SZhHans extends SZh {
   String get aboutAppName => 'RepFoundry';
 
   @override
-  String get aboutVersion => '版本 1.0.0';
+  String aboutVersion(String version) {
+    return '版本 $version';
+  }
 
   @override
   String get heartRateTitle => '心率';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,6 +33,8 @@ dependencies:
   googleapis_auth: ^2.0.0
   connectivity_plus: ^7.0.0
   http: ^1.2.2
+  url_launcher: ^6.2.5
+  package_info_plus: ^8.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
 Title: Add About screen accessible from Settings

  Body:

  Summary

  - Adds a dedicated About screen navigable from the Settings About section, replacing the static app name/version display with a tappable list tile
  - Displays app name, dynamic version (via package_info_plus), description, author, feature highlights, and a tappable GitHub repository link that opens
  in the browser
  - Includes an open-source licences button using Flutter's built-in showLicensePage

  Changes

  - New file: lib/features/settings/presentation/screens/about_screen.dart
  - Router: Added /settings/about child route
  - Settings screen: About tile now navigates to the new screen
  - Localisation: 14 new strings in app_en.arb; aboutVersion now accepts a dynamic version parameter (Chinese ARB files updated accordingly)
  - Dependencies: Added url_launcher and package_info_plus

  Test plan

  - All 365 existing tests pass (flutter test)
  - dart analyze clean (no new issues)
  - Navigate Settings → About section → tap to open About screen
  - Verify version displayed matches pubspec.yaml
  - Tap GitHub link → opens browser to https://github.com/bovinemagnet/RepFoundry
  - Tap "Open-source licences" → Flutter licence page appears
  - Verify back navigation returns to Settings