### PR TITLE
fix: cloud sync correctness sprint (#20-#24)

### DIFF
--- a/lib/core/database/app_database.dart
+++ b/lib/core/database/app_database.dart
@@ -36,8 +36,12 @@ class AppDatabase extends _$AppDatabase {
   /// Constructor for tests — accepts any [QueryExecutor].
   AppDatabase.forTesting(super.e);
 
+  /// Static accessor for the schema version, usable from non-database code
+  /// (e.g. the sync serialiser) without an `AppDatabase` instance.
+  static const int schemaVersionConst = 10;
+
   @override
-  int get schemaVersion => 9;
+  int get schemaVersion => schemaVersionConst;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -175,6 +179,79 @@ class AppDatabase extends _$AppDatabase {
                     'ON stretching_sessions (type, updated_at)',
               ),
             );
+          }
+          if (from < 10) {
+            // Tombstone columns: 9 tables that were missing soft-delete.
+            // Exercise / Workout / StretchingSession already have deleted_at.
+            const tablesToAddDeletedAt = [
+              'workout_sets',
+              'cardio_sessions',
+              'personal_records',
+              'workout_templates',
+              'template_exercises',
+              'body_metrics',
+              'programmes',
+              'programme_days',
+              'progression_rules',
+            ];
+            for (final t in tablesToAddDeletedAt) {
+              await customStatement(
+                'ALTER TABLE $t ADD COLUMN deleted_at INTEGER',
+              );
+            }
+
+            // Backfill: the v6 migration defaulted updated_at to 0, which
+            // poisons last-write-wins (any post-v6 write always beats a
+            // pre-v6 row). Where the table carries a meaningful timestamp
+            // column, lift updated_at to that value.
+            await customStatement(
+              "UPDATE workout_sets SET updated_at = "
+              "MAX(updated_at, COALESCE(timestamp, 0)) "
+              "WHERE updated_at = 0",
+            );
+            await customStatement(
+              "UPDATE personal_records SET updated_at = "
+              "MAX(updated_at, COALESCE(achieved_at, 0)) "
+              "WHERE updated_at = 0",
+            );
+            await customStatement(
+              "UPDATE body_metrics SET updated_at = "
+              "MAX(updated_at, COALESCE(date, 0)) "
+              "WHERE updated_at = 0",
+            );
+            await customStatement(
+              "UPDATE workouts SET updated_at = "
+              "MAX(updated_at, COALESCE(started_at, 0)) "
+              "WHERE updated_at = 0",
+            );
+            await customStatement(
+              "UPDATE workout_templates SET updated_at = "
+              "MAX(updated_at, COALESCE(created_at, 0)) "
+              "WHERE updated_at = 0",
+            );
+            await customStatement(
+              "UPDATE programmes SET updated_at = "
+              "MAX(updated_at, COALESCE(created_at, 0)) "
+              "WHERE updated_at = 0",
+            );
+
+            // Tables without their own meaningful timestamp: stamp the
+            // migration moment so post-migration rows do not always win.
+            const migrationNow =
+                "CAST((strftime('%s','now') * 1000) AS INTEGER)";
+            const tablesWithoutOwnTimestamp = [
+              'exercises',
+              'cardio_sessions',
+              'template_exercises',
+              'programme_days',
+              'progression_rules',
+            ];
+            for (final t in tablesWithoutOwnTimestamp) {
+              await customStatement(
+                'UPDATE $t SET updated_at = $migrationNow '
+                'WHERE updated_at = 0',
+              );
+            }
           }
         },
       );

--- a/lib/core/database/app_database.g.dart
+++ b/lib/core/database/app_database.g.dart
@@ -43,9 +43,15 @@ class $BodyMetricsTable extends BodyMetrics
       type: DriftSqlType.int,
       requiredDuringInsert: false,
       defaultValue: const Constant(0));
+  static const VerificationMeta _deletedAtMeta =
+      const VerificationMeta('deletedAt');
+  @override
+  late final GeneratedColumn<int> deletedAt = GeneratedColumn<int>(
+      'deleted_at', aliasedName, true,
+      type: DriftSqlType.int, requiredDuringInsert: false);
   @override
   List<GeneratedColumn> get $columns =>
-      [id, date, weight, bodyFatPercent, notes, updatedAt];
+      [id, date, weight, bodyFatPercent, notes, updatedAt, deletedAt];
   @override
   String get aliasedName => _alias ?? actualTableName;
   @override
@@ -87,6 +93,10 @@ class $BodyMetricsTable extends BodyMetrics
       context.handle(_updatedAtMeta,
           updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta));
     }
+    if (data.containsKey('deleted_at')) {
+      context.handle(_deletedAtMeta,
+          deletedAt.isAcceptableOrUnknown(data['deleted_at']!, _deletedAtMeta));
+    }
     return context;
   }
 
@@ -108,6 +118,8 @@ class $BodyMetricsTable extends BodyMetrics
           .read(DriftSqlType.string, data['${effectivePrefix}notes']),
       updatedAt: attachedDatabase.typeMapping
           .read(DriftSqlType.int, data['${effectivePrefix}updated_at'])!,
+      deletedAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}deleted_at']),
     );
   }
 
@@ -124,13 +136,15 @@ class BodyMetric extends DataClass implements Insertable<BodyMetric> {
   final double? bodyFatPercent;
   final String? notes;
   final int updatedAt;
+  final int? deletedAt;
   const BodyMetric(
       {required this.id,
       required this.date,
       required this.weight,
       this.bodyFatPercent,
       this.notes,
-      required this.updatedAt});
+      required this.updatedAt,
+      this.deletedAt});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
@@ -144,6 +158,9 @@ class BodyMetric extends DataClass implements Insertable<BodyMetric> {
       map['notes'] = Variable<String>(notes);
     }
     map['updated_at'] = Variable<int>(updatedAt);
+    if (!nullToAbsent || deletedAt != null) {
+      map['deleted_at'] = Variable<int>(deletedAt);
+    }
     return map;
   }
 
@@ -158,6 +175,9 @@ class BodyMetric extends DataClass implements Insertable<BodyMetric> {
       notes:
           notes == null && nullToAbsent ? const Value.absent() : Value(notes),
       updatedAt: Value(updatedAt),
+      deletedAt: deletedAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(deletedAt),
     );
   }
 
@@ -171,6 +191,7 @@ class BodyMetric extends DataClass implements Insertable<BodyMetric> {
       bodyFatPercent: serializer.fromJson<double?>(json['bodyFatPercent']),
       notes: serializer.fromJson<String?>(json['notes']),
       updatedAt: serializer.fromJson<int>(json['updatedAt']),
+      deletedAt: serializer.fromJson<int?>(json['deletedAt']),
     );
   }
   @override
@@ -183,6 +204,7 @@ class BodyMetric extends DataClass implements Insertable<BodyMetric> {
       'bodyFatPercent': serializer.toJson<double?>(bodyFatPercent),
       'notes': serializer.toJson<String?>(notes),
       'updatedAt': serializer.toJson<int>(updatedAt),
+      'deletedAt': serializer.toJson<int?>(deletedAt),
     };
   }
 
@@ -192,7 +214,8 @@ class BodyMetric extends DataClass implements Insertable<BodyMetric> {
           double? weight,
           Value<double?> bodyFatPercent = const Value.absent(),
           Value<String?> notes = const Value.absent(),
-          int? updatedAt}) =>
+          int? updatedAt,
+          Value<int?> deletedAt = const Value.absent()}) =>
       BodyMetric(
         id: id ?? this.id,
         date: date ?? this.date,
@@ -201,6 +224,7 @@ class BodyMetric extends DataClass implements Insertable<BodyMetric> {
             bodyFatPercent.present ? bodyFatPercent.value : this.bodyFatPercent,
         notes: notes.present ? notes.value : this.notes,
         updatedAt: updatedAt ?? this.updatedAt,
+        deletedAt: deletedAt.present ? deletedAt.value : this.deletedAt,
       );
   BodyMetric copyWithCompanion(BodyMetricsCompanion data) {
     return BodyMetric(
@@ -212,6 +236,7 @@ class BodyMetric extends DataClass implements Insertable<BodyMetric> {
           : this.bodyFatPercent,
       notes: data.notes.present ? data.notes.value : this.notes,
       updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
+      deletedAt: data.deletedAt.present ? data.deletedAt.value : this.deletedAt,
     );
   }
 
@@ -223,14 +248,15 @@ class BodyMetric extends DataClass implements Insertable<BodyMetric> {
           ..write('weight: $weight, ')
           ..write('bodyFatPercent: $bodyFatPercent, ')
           ..write('notes: $notes, ')
-          ..write('updatedAt: $updatedAt')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('deletedAt: $deletedAt')
           ..write(')'))
         .toString();
   }
 
   @override
-  int get hashCode =>
-      Object.hash(id, date, weight, bodyFatPercent, notes, updatedAt);
+  int get hashCode => Object.hash(
+      id, date, weight, bodyFatPercent, notes, updatedAt, deletedAt);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -240,7 +266,8 @@ class BodyMetric extends DataClass implements Insertable<BodyMetric> {
           other.weight == this.weight &&
           other.bodyFatPercent == this.bodyFatPercent &&
           other.notes == this.notes &&
-          other.updatedAt == this.updatedAt);
+          other.updatedAt == this.updatedAt &&
+          other.deletedAt == this.deletedAt);
 }
 
 class BodyMetricsCompanion extends UpdateCompanion<BodyMetric> {
@@ -250,6 +277,7 @@ class BodyMetricsCompanion extends UpdateCompanion<BodyMetric> {
   final Value<double?> bodyFatPercent;
   final Value<String?> notes;
   final Value<int> updatedAt;
+  final Value<int?> deletedAt;
   final Value<int> rowid;
   const BodyMetricsCompanion({
     this.id = const Value.absent(),
@@ -258,6 +286,7 @@ class BodyMetricsCompanion extends UpdateCompanion<BodyMetric> {
     this.bodyFatPercent = const Value.absent(),
     this.notes = const Value.absent(),
     this.updatedAt = const Value.absent(),
+    this.deletedAt = const Value.absent(),
     this.rowid = const Value.absent(),
   });
   BodyMetricsCompanion.insert({
@@ -267,6 +296,7 @@ class BodyMetricsCompanion extends UpdateCompanion<BodyMetric> {
     this.bodyFatPercent = const Value.absent(),
     this.notes = const Value.absent(),
     this.updatedAt = const Value.absent(),
+    this.deletedAt = const Value.absent(),
     this.rowid = const Value.absent(),
   })  : id = Value(id),
         date = Value(date),
@@ -278,6 +308,7 @@ class BodyMetricsCompanion extends UpdateCompanion<BodyMetric> {
     Expression<double>? bodyFatPercent,
     Expression<String>? notes,
     Expression<int>? updatedAt,
+    Expression<int>? deletedAt,
     Expression<int>? rowid,
   }) {
     return RawValuesInsertable({
@@ -287,6 +318,7 @@ class BodyMetricsCompanion extends UpdateCompanion<BodyMetric> {
       if (bodyFatPercent != null) 'body_fat_percent': bodyFatPercent,
       if (notes != null) 'notes': notes,
       if (updatedAt != null) 'updated_at': updatedAt,
+      if (deletedAt != null) 'deleted_at': deletedAt,
       if (rowid != null) 'rowid': rowid,
     });
   }
@@ -298,6 +330,7 @@ class BodyMetricsCompanion extends UpdateCompanion<BodyMetric> {
       Value<double?>? bodyFatPercent,
       Value<String?>? notes,
       Value<int>? updatedAt,
+      Value<int?>? deletedAt,
       Value<int>? rowid}) {
     return BodyMetricsCompanion(
       id: id ?? this.id,
@@ -306,6 +339,7 @@ class BodyMetricsCompanion extends UpdateCompanion<BodyMetric> {
       bodyFatPercent: bodyFatPercent ?? this.bodyFatPercent,
       notes: notes ?? this.notes,
       updatedAt: updatedAt ?? this.updatedAt,
+      deletedAt: deletedAt ?? this.deletedAt,
       rowid: rowid ?? this.rowid,
     );
   }
@@ -331,6 +365,9 @@ class BodyMetricsCompanion extends UpdateCompanion<BodyMetric> {
     if (updatedAt.present) {
       map['updated_at'] = Variable<int>(updatedAt.value);
     }
+    if (deletedAt.present) {
+      map['deleted_at'] = Variable<int>(deletedAt.value);
+    }
     if (rowid.present) {
       map['rowid'] = Variable<int>(rowid.value);
     }
@@ -346,6 +383,7 @@ class BodyMetricsCompanion extends UpdateCompanion<BodyMetric> {
           ..write('bodyFatPercent: $bodyFatPercent, ')
           ..write('notes: $notes, ')
           ..write('updatedAt: $updatedAt, ')
+          ..write('deletedAt: $deletedAt, ')
           ..write('rowid: $rowid')
           ..write(')'))
         .toString();
@@ -1303,6 +1341,12 @@ class $WorkoutSetsTable extends WorkoutSets
       type: DriftSqlType.int,
       requiredDuringInsert: false,
       defaultValue: const Constant(0));
+  static const VerificationMeta _deletedAtMeta =
+      const VerificationMeta('deletedAt');
+  @override
+  late final GeneratedColumn<int> deletedAt = GeneratedColumn<int>(
+      'deleted_at', aliasedName, true,
+      type: DriftSqlType.int, requiredDuringInsert: false);
   @override
   List<GeneratedColumn> get $columns => [
         id,
@@ -1315,7 +1359,8 @@ class $WorkoutSetsTable extends WorkoutSets
         timestamp,
         isWarmUp,
         groupId,
-        updatedAt
+        updatedAt,
+        deletedAt
       ];
   @override
   String get aliasedName => _alias ?? actualTableName;
@@ -1386,6 +1431,10 @@ class $WorkoutSetsTable extends WorkoutSets
       context.handle(_updatedAtMeta,
           updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta));
     }
+    if (data.containsKey('deleted_at')) {
+      context.handle(_deletedAtMeta,
+          deletedAt.isAcceptableOrUnknown(data['deleted_at']!, _deletedAtMeta));
+    }
     return context;
   }
 
@@ -1417,6 +1466,8 @@ class $WorkoutSetsTable extends WorkoutSets
           .read(DriftSqlType.string, data['${effectivePrefix}group_id']),
       updatedAt: attachedDatabase.typeMapping
           .read(DriftSqlType.int, data['${effectivePrefix}updated_at'])!,
+      deletedAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}deleted_at']),
     );
   }
 
@@ -1438,6 +1489,7 @@ class WorkoutSet extends DataClass implements Insertable<WorkoutSet> {
   final bool isWarmUp;
   final String? groupId;
   final int updatedAt;
+  final int? deletedAt;
   const WorkoutSet(
       {required this.id,
       required this.workoutId,
@@ -1449,7 +1501,8 @@ class WorkoutSet extends DataClass implements Insertable<WorkoutSet> {
       required this.timestamp,
       required this.isWarmUp,
       this.groupId,
-      required this.updatedAt});
+      required this.updatedAt,
+      this.deletedAt});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
@@ -1468,6 +1521,9 @@ class WorkoutSet extends DataClass implements Insertable<WorkoutSet> {
       map['group_id'] = Variable<String>(groupId);
     }
     map['updated_at'] = Variable<int>(updatedAt);
+    if (!nullToAbsent || deletedAt != null) {
+      map['deleted_at'] = Variable<int>(deletedAt);
+    }
     return map;
   }
 
@@ -1486,6 +1542,9 @@ class WorkoutSet extends DataClass implements Insertable<WorkoutSet> {
           ? const Value.absent()
           : Value(groupId),
       updatedAt: Value(updatedAt),
+      deletedAt: deletedAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(deletedAt),
     );
   }
 
@@ -1504,6 +1563,7 @@ class WorkoutSet extends DataClass implements Insertable<WorkoutSet> {
       isWarmUp: serializer.fromJson<bool>(json['isWarmUp']),
       groupId: serializer.fromJson<String?>(json['groupId']),
       updatedAt: serializer.fromJson<int>(json['updatedAt']),
+      deletedAt: serializer.fromJson<int?>(json['deletedAt']),
     );
   }
   @override
@@ -1521,6 +1581,7 @@ class WorkoutSet extends DataClass implements Insertable<WorkoutSet> {
       'isWarmUp': serializer.toJson<bool>(isWarmUp),
       'groupId': serializer.toJson<String?>(groupId),
       'updatedAt': serializer.toJson<int>(updatedAt),
+      'deletedAt': serializer.toJson<int?>(deletedAt),
     };
   }
 
@@ -1535,7 +1596,8 @@ class WorkoutSet extends DataClass implements Insertable<WorkoutSet> {
           int? timestamp,
           bool? isWarmUp,
           Value<String?> groupId = const Value.absent(),
-          int? updatedAt}) =>
+          int? updatedAt,
+          Value<int?> deletedAt = const Value.absent()}) =>
       WorkoutSet(
         id: id ?? this.id,
         workoutId: workoutId ?? this.workoutId,
@@ -1548,6 +1610,7 @@ class WorkoutSet extends DataClass implements Insertable<WorkoutSet> {
         isWarmUp: isWarmUp ?? this.isWarmUp,
         groupId: groupId.present ? groupId.value : this.groupId,
         updatedAt: updatedAt ?? this.updatedAt,
+        deletedAt: deletedAt.present ? deletedAt.value : this.deletedAt,
       );
   WorkoutSet copyWithCompanion(WorkoutSetsCompanion data) {
     return WorkoutSet(
@@ -1563,6 +1626,7 @@ class WorkoutSet extends DataClass implements Insertable<WorkoutSet> {
       isWarmUp: data.isWarmUp.present ? data.isWarmUp.value : this.isWarmUp,
       groupId: data.groupId.present ? data.groupId.value : this.groupId,
       updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
+      deletedAt: data.deletedAt.present ? data.deletedAt.value : this.deletedAt,
     );
   }
 
@@ -1579,14 +1643,15 @@ class WorkoutSet extends DataClass implements Insertable<WorkoutSet> {
           ..write('timestamp: $timestamp, ')
           ..write('isWarmUp: $isWarmUp, ')
           ..write('groupId: $groupId, ')
-          ..write('updatedAt: $updatedAt')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('deletedAt: $deletedAt')
           ..write(')'))
         .toString();
   }
 
   @override
   int get hashCode => Object.hash(id, workoutId, exerciseId, setOrder, weight,
-      reps, rpe, timestamp, isWarmUp, groupId, updatedAt);
+      reps, rpe, timestamp, isWarmUp, groupId, updatedAt, deletedAt);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -1601,7 +1666,8 @@ class WorkoutSet extends DataClass implements Insertable<WorkoutSet> {
           other.timestamp == this.timestamp &&
           other.isWarmUp == this.isWarmUp &&
           other.groupId == this.groupId &&
-          other.updatedAt == this.updatedAt);
+          other.updatedAt == this.updatedAt &&
+          other.deletedAt == this.deletedAt);
 }
 
 class WorkoutSetsCompanion extends UpdateCompanion<WorkoutSet> {
@@ -1616,6 +1682,7 @@ class WorkoutSetsCompanion extends UpdateCompanion<WorkoutSet> {
   final Value<bool> isWarmUp;
   final Value<String?> groupId;
   final Value<int> updatedAt;
+  final Value<int?> deletedAt;
   final Value<int> rowid;
   const WorkoutSetsCompanion({
     this.id = const Value.absent(),
@@ -1629,6 +1696,7 @@ class WorkoutSetsCompanion extends UpdateCompanion<WorkoutSet> {
     this.isWarmUp = const Value.absent(),
     this.groupId = const Value.absent(),
     this.updatedAt = const Value.absent(),
+    this.deletedAt = const Value.absent(),
     this.rowid = const Value.absent(),
   });
   WorkoutSetsCompanion.insert({
@@ -1643,6 +1711,7 @@ class WorkoutSetsCompanion extends UpdateCompanion<WorkoutSet> {
     this.isWarmUp = const Value.absent(),
     this.groupId = const Value.absent(),
     this.updatedAt = const Value.absent(),
+    this.deletedAt = const Value.absent(),
     this.rowid = const Value.absent(),
   })  : id = Value(id),
         workoutId = Value(workoutId),
@@ -1663,6 +1732,7 @@ class WorkoutSetsCompanion extends UpdateCompanion<WorkoutSet> {
     Expression<bool>? isWarmUp,
     Expression<String>? groupId,
     Expression<int>? updatedAt,
+    Expression<int>? deletedAt,
     Expression<int>? rowid,
   }) {
     return RawValuesInsertable({
@@ -1677,6 +1747,7 @@ class WorkoutSetsCompanion extends UpdateCompanion<WorkoutSet> {
       if (isWarmUp != null) 'is_warm_up': isWarmUp,
       if (groupId != null) 'group_id': groupId,
       if (updatedAt != null) 'updated_at': updatedAt,
+      if (deletedAt != null) 'deleted_at': deletedAt,
       if (rowid != null) 'rowid': rowid,
     });
   }
@@ -1693,6 +1764,7 @@ class WorkoutSetsCompanion extends UpdateCompanion<WorkoutSet> {
       Value<bool>? isWarmUp,
       Value<String?>? groupId,
       Value<int>? updatedAt,
+      Value<int?>? deletedAt,
       Value<int>? rowid}) {
     return WorkoutSetsCompanion(
       id: id ?? this.id,
@@ -1706,6 +1778,7 @@ class WorkoutSetsCompanion extends UpdateCompanion<WorkoutSet> {
       isWarmUp: isWarmUp ?? this.isWarmUp,
       groupId: groupId ?? this.groupId,
       updatedAt: updatedAt ?? this.updatedAt,
+      deletedAt: deletedAt ?? this.deletedAt,
       rowid: rowid ?? this.rowid,
     );
   }
@@ -1746,6 +1819,9 @@ class WorkoutSetsCompanion extends UpdateCompanion<WorkoutSet> {
     if (updatedAt.present) {
       map['updated_at'] = Variable<int>(updatedAt.value);
     }
+    if (deletedAt.present) {
+      map['deleted_at'] = Variable<int>(deletedAt.value);
+    }
     if (rowid.present) {
       map['rowid'] = Variable<int>(rowid.value);
     }
@@ -1766,6 +1842,7 @@ class WorkoutSetsCompanion extends UpdateCompanion<WorkoutSet> {
           ..write('isWarmUp: $isWarmUp, ')
           ..write('groupId: $groupId, ')
           ..write('updatedAt: $updatedAt, ')
+          ..write('deletedAt: $deletedAt, ')
           ..write('rowid: $rowid')
           ..write(')'))
         .toString();
@@ -1833,6 +1910,12 @@ class $CardioSessionsTable extends CardioSessions
       type: DriftSqlType.int,
       requiredDuringInsert: false,
       defaultValue: const Constant(0));
+  static const VerificationMeta _deletedAtMeta =
+      const VerificationMeta('deletedAt');
+  @override
+  late final GeneratedColumn<int> deletedAt = GeneratedColumn<int>(
+      'deleted_at', aliasedName, true,
+      type: DriftSqlType.int, requiredDuringInsert: false);
   @override
   List<GeneratedColumn> get $columns => [
         id,
@@ -1842,7 +1925,8 @@ class $CardioSessionsTable extends CardioSessions
         distanceMeters,
         incline,
         avgHeartRate,
-        updatedAt
+        updatedAt,
+        deletedAt
       ];
   @override
   String get aliasedName => _alias ?? actualTableName;
@@ -1901,6 +1985,10 @@ class $CardioSessionsTable extends CardioSessions
       context.handle(_updatedAtMeta,
           updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta));
     }
+    if (data.containsKey('deleted_at')) {
+      context.handle(_deletedAtMeta,
+          deletedAt.isAcceptableOrUnknown(data['deleted_at']!, _deletedAtMeta));
+    }
     return context;
   }
 
@@ -1926,6 +2014,8 @@ class $CardioSessionsTable extends CardioSessions
           .read(DriftSqlType.int, data['${effectivePrefix}avg_heart_rate']),
       updatedAt: attachedDatabase.typeMapping
           .read(DriftSqlType.int, data['${effectivePrefix}updated_at'])!,
+      deletedAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}deleted_at']),
     );
   }
 
@@ -1944,6 +2034,7 @@ class CardioSession extends DataClass implements Insertable<CardioSession> {
   final double? incline;
   final int? avgHeartRate;
   final int updatedAt;
+  final int? deletedAt;
   const CardioSession(
       {required this.id,
       required this.workoutId,
@@ -1952,7 +2043,8 @@ class CardioSession extends DataClass implements Insertable<CardioSession> {
       this.distanceMeters,
       this.incline,
       this.avgHeartRate,
-      required this.updatedAt});
+      required this.updatedAt,
+      this.deletedAt});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
@@ -1970,6 +2062,9 @@ class CardioSession extends DataClass implements Insertable<CardioSession> {
       map['avg_heart_rate'] = Variable<int>(avgHeartRate);
     }
     map['updated_at'] = Variable<int>(updatedAt);
+    if (!nullToAbsent || deletedAt != null) {
+      map['deleted_at'] = Variable<int>(deletedAt);
+    }
     return map;
   }
 
@@ -1989,6 +2084,9 @@ class CardioSession extends DataClass implements Insertable<CardioSession> {
           ? const Value.absent()
           : Value(avgHeartRate),
       updatedAt: Value(updatedAt),
+      deletedAt: deletedAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(deletedAt),
     );
   }
 
@@ -2004,6 +2102,7 @@ class CardioSession extends DataClass implements Insertable<CardioSession> {
       incline: serializer.fromJson<double?>(json['incline']),
       avgHeartRate: serializer.fromJson<int?>(json['avgHeartRate']),
       updatedAt: serializer.fromJson<int>(json['updatedAt']),
+      deletedAt: serializer.fromJson<int?>(json['deletedAt']),
     );
   }
   @override
@@ -2018,6 +2117,7 @@ class CardioSession extends DataClass implements Insertable<CardioSession> {
       'incline': serializer.toJson<double?>(incline),
       'avgHeartRate': serializer.toJson<int?>(avgHeartRate),
       'updatedAt': serializer.toJson<int>(updatedAt),
+      'deletedAt': serializer.toJson<int?>(deletedAt),
     };
   }
 
@@ -2029,7 +2129,8 @@ class CardioSession extends DataClass implements Insertable<CardioSession> {
           Value<double?> distanceMeters = const Value.absent(),
           Value<double?> incline = const Value.absent(),
           Value<int?> avgHeartRate = const Value.absent(),
-          int? updatedAt}) =>
+          int? updatedAt,
+          Value<int?> deletedAt = const Value.absent()}) =>
       CardioSession(
         id: id ?? this.id,
         workoutId: workoutId ?? this.workoutId,
@@ -2041,6 +2142,7 @@ class CardioSession extends DataClass implements Insertable<CardioSession> {
         avgHeartRate:
             avgHeartRate.present ? avgHeartRate.value : this.avgHeartRate,
         updatedAt: updatedAt ?? this.updatedAt,
+        deletedAt: deletedAt.present ? deletedAt.value : this.deletedAt,
       );
   CardioSession copyWithCompanion(CardioSessionsCompanion data) {
     return CardioSession(
@@ -2059,6 +2161,7 @@ class CardioSession extends DataClass implements Insertable<CardioSession> {
           ? data.avgHeartRate.value
           : this.avgHeartRate,
       updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
+      deletedAt: data.deletedAt.present ? data.deletedAt.value : this.deletedAt,
     );
   }
 
@@ -2072,14 +2175,15 @@ class CardioSession extends DataClass implements Insertable<CardioSession> {
           ..write('distanceMeters: $distanceMeters, ')
           ..write('incline: $incline, ')
           ..write('avgHeartRate: $avgHeartRate, ')
-          ..write('updatedAt: $updatedAt')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('deletedAt: $deletedAt')
           ..write(')'))
         .toString();
   }
 
   @override
   int get hashCode => Object.hash(id, workoutId, exerciseId, durationSeconds,
-      distanceMeters, incline, avgHeartRate, updatedAt);
+      distanceMeters, incline, avgHeartRate, updatedAt, deletedAt);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -2091,7 +2195,8 @@ class CardioSession extends DataClass implements Insertable<CardioSession> {
           other.distanceMeters == this.distanceMeters &&
           other.incline == this.incline &&
           other.avgHeartRate == this.avgHeartRate &&
-          other.updatedAt == this.updatedAt);
+          other.updatedAt == this.updatedAt &&
+          other.deletedAt == this.deletedAt);
 }
 
 class CardioSessionsCompanion extends UpdateCompanion<CardioSession> {
@@ -2103,6 +2208,7 @@ class CardioSessionsCompanion extends UpdateCompanion<CardioSession> {
   final Value<double?> incline;
   final Value<int?> avgHeartRate;
   final Value<int> updatedAt;
+  final Value<int?> deletedAt;
   final Value<int> rowid;
   const CardioSessionsCompanion({
     this.id = const Value.absent(),
@@ -2113,6 +2219,7 @@ class CardioSessionsCompanion extends UpdateCompanion<CardioSession> {
     this.incline = const Value.absent(),
     this.avgHeartRate = const Value.absent(),
     this.updatedAt = const Value.absent(),
+    this.deletedAt = const Value.absent(),
     this.rowid = const Value.absent(),
   });
   CardioSessionsCompanion.insert({
@@ -2124,6 +2231,7 @@ class CardioSessionsCompanion extends UpdateCompanion<CardioSession> {
     this.incline = const Value.absent(),
     this.avgHeartRate = const Value.absent(),
     this.updatedAt = const Value.absent(),
+    this.deletedAt = const Value.absent(),
     this.rowid = const Value.absent(),
   })  : id = Value(id),
         workoutId = Value(workoutId),
@@ -2138,6 +2246,7 @@ class CardioSessionsCompanion extends UpdateCompanion<CardioSession> {
     Expression<double>? incline,
     Expression<int>? avgHeartRate,
     Expression<int>? updatedAt,
+    Expression<int>? deletedAt,
     Expression<int>? rowid,
   }) {
     return RawValuesInsertable({
@@ -2149,6 +2258,7 @@ class CardioSessionsCompanion extends UpdateCompanion<CardioSession> {
       if (incline != null) 'incline': incline,
       if (avgHeartRate != null) 'avg_heart_rate': avgHeartRate,
       if (updatedAt != null) 'updated_at': updatedAt,
+      if (deletedAt != null) 'deleted_at': deletedAt,
       if (rowid != null) 'rowid': rowid,
     });
   }
@@ -2162,6 +2272,7 @@ class CardioSessionsCompanion extends UpdateCompanion<CardioSession> {
       Value<double?>? incline,
       Value<int?>? avgHeartRate,
       Value<int>? updatedAt,
+      Value<int?>? deletedAt,
       Value<int>? rowid}) {
     return CardioSessionsCompanion(
       id: id ?? this.id,
@@ -2172,6 +2283,7 @@ class CardioSessionsCompanion extends UpdateCompanion<CardioSession> {
       incline: incline ?? this.incline,
       avgHeartRate: avgHeartRate ?? this.avgHeartRate,
       updatedAt: updatedAt ?? this.updatedAt,
+      deletedAt: deletedAt ?? this.deletedAt,
       rowid: rowid ?? this.rowid,
     );
   }
@@ -2203,6 +2315,9 @@ class CardioSessionsCompanion extends UpdateCompanion<CardioSession> {
     if (updatedAt.present) {
       map['updated_at'] = Variable<int>(updatedAt.value);
     }
+    if (deletedAt.present) {
+      map['deleted_at'] = Variable<int>(deletedAt.value);
+    }
     if (rowid.present) {
       map['rowid'] = Variable<int>(rowid.value);
     }
@@ -2220,6 +2335,7 @@ class CardioSessionsCompanion extends UpdateCompanion<CardioSession> {
           ..write('incline: $incline, ')
           ..write('avgHeartRate: $avgHeartRate, ')
           ..write('updatedAt: $updatedAt, ')
+          ..write('deletedAt: $deletedAt, ')
           ..write('rowid: $rowid')
           ..write(')'))
         .toString();
@@ -2280,9 +2396,23 @@ class $PersonalRecordsTable extends PersonalRecords
       type: DriftSqlType.int,
       requiredDuringInsert: false,
       defaultValue: const Constant(0));
+  static const VerificationMeta _deletedAtMeta =
+      const VerificationMeta('deletedAt');
   @override
-  List<GeneratedColumn> get $columns =>
-      [id, exerciseId, recordType, value, achievedAt, workoutSetId, updatedAt];
+  late final GeneratedColumn<int> deletedAt = GeneratedColumn<int>(
+      'deleted_at', aliasedName, true,
+      type: DriftSqlType.int, requiredDuringInsert: false);
+  @override
+  List<GeneratedColumn> get $columns => [
+        id,
+        exerciseId,
+        recordType,
+        value,
+        achievedAt,
+        workoutSetId,
+        updatedAt,
+        deletedAt
+      ];
   @override
   String get aliasedName => _alias ?? actualTableName;
   @override
@@ -2338,6 +2468,10 @@ class $PersonalRecordsTable extends PersonalRecords
       context.handle(_updatedAtMeta,
           updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta));
     }
+    if (data.containsKey('deleted_at')) {
+      context.handle(_deletedAtMeta,
+          deletedAt.isAcceptableOrUnknown(data['deleted_at']!, _deletedAtMeta));
+    }
     return context;
   }
 
@@ -2361,6 +2495,8 @@ class $PersonalRecordsTable extends PersonalRecords
           .read(DriftSqlType.string, data['${effectivePrefix}workout_set_id']),
       updatedAt: attachedDatabase.typeMapping
           .read(DriftSqlType.int, data['${effectivePrefix}updated_at'])!,
+      deletedAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}deleted_at']),
     );
   }
 
@@ -2378,6 +2514,7 @@ class PersonalRecord extends DataClass implements Insertable<PersonalRecord> {
   final int achievedAt;
   final String? workoutSetId;
   final int updatedAt;
+  final int? deletedAt;
   const PersonalRecord(
       {required this.id,
       required this.exerciseId,
@@ -2385,7 +2522,8 @@ class PersonalRecord extends DataClass implements Insertable<PersonalRecord> {
       required this.value,
       required this.achievedAt,
       this.workoutSetId,
-      required this.updatedAt});
+      required this.updatedAt,
+      this.deletedAt});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
@@ -2398,6 +2536,9 @@ class PersonalRecord extends DataClass implements Insertable<PersonalRecord> {
       map['workout_set_id'] = Variable<String>(workoutSetId);
     }
     map['updated_at'] = Variable<int>(updatedAt);
+    if (!nullToAbsent || deletedAt != null) {
+      map['deleted_at'] = Variable<int>(deletedAt);
+    }
     return map;
   }
 
@@ -2412,6 +2553,9 @@ class PersonalRecord extends DataClass implements Insertable<PersonalRecord> {
           ? const Value.absent()
           : Value(workoutSetId),
       updatedAt: Value(updatedAt),
+      deletedAt: deletedAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(deletedAt),
     );
   }
 
@@ -2426,6 +2570,7 @@ class PersonalRecord extends DataClass implements Insertable<PersonalRecord> {
       achievedAt: serializer.fromJson<int>(json['achievedAt']),
       workoutSetId: serializer.fromJson<String?>(json['workoutSetId']),
       updatedAt: serializer.fromJson<int>(json['updatedAt']),
+      deletedAt: serializer.fromJson<int?>(json['deletedAt']),
     );
   }
   @override
@@ -2439,6 +2584,7 @@ class PersonalRecord extends DataClass implements Insertable<PersonalRecord> {
       'achievedAt': serializer.toJson<int>(achievedAt),
       'workoutSetId': serializer.toJson<String?>(workoutSetId),
       'updatedAt': serializer.toJson<int>(updatedAt),
+      'deletedAt': serializer.toJson<int?>(deletedAt),
     };
   }
 
@@ -2449,7 +2595,8 @@ class PersonalRecord extends DataClass implements Insertable<PersonalRecord> {
           double? value,
           int? achievedAt,
           Value<String?> workoutSetId = const Value.absent(),
-          int? updatedAt}) =>
+          int? updatedAt,
+          Value<int?> deletedAt = const Value.absent()}) =>
       PersonalRecord(
         id: id ?? this.id,
         exerciseId: exerciseId ?? this.exerciseId,
@@ -2459,6 +2606,7 @@ class PersonalRecord extends DataClass implements Insertable<PersonalRecord> {
         workoutSetId:
             workoutSetId.present ? workoutSetId.value : this.workoutSetId,
         updatedAt: updatedAt ?? this.updatedAt,
+        deletedAt: deletedAt.present ? deletedAt.value : this.deletedAt,
       );
   PersonalRecord copyWithCompanion(PersonalRecordsCompanion data) {
     return PersonalRecord(
@@ -2474,6 +2622,7 @@ class PersonalRecord extends DataClass implements Insertable<PersonalRecord> {
           ? data.workoutSetId.value
           : this.workoutSetId,
       updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
+      deletedAt: data.deletedAt.present ? data.deletedAt.value : this.deletedAt,
     );
   }
 
@@ -2486,14 +2635,15 @@ class PersonalRecord extends DataClass implements Insertable<PersonalRecord> {
           ..write('value: $value, ')
           ..write('achievedAt: $achievedAt, ')
           ..write('workoutSetId: $workoutSetId, ')
-          ..write('updatedAt: $updatedAt')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('deletedAt: $deletedAt')
           ..write(')'))
         .toString();
   }
 
   @override
-  int get hashCode => Object.hash(
-      id, exerciseId, recordType, value, achievedAt, workoutSetId, updatedAt);
+  int get hashCode => Object.hash(id, exerciseId, recordType, value, achievedAt,
+      workoutSetId, updatedAt, deletedAt);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -2504,7 +2654,8 @@ class PersonalRecord extends DataClass implements Insertable<PersonalRecord> {
           other.value == this.value &&
           other.achievedAt == this.achievedAt &&
           other.workoutSetId == this.workoutSetId &&
-          other.updatedAt == this.updatedAt);
+          other.updatedAt == this.updatedAt &&
+          other.deletedAt == this.deletedAt);
 }
 
 class PersonalRecordsCompanion extends UpdateCompanion<PersonalRecord> {
@@ -2515,6 +2666,7 @@ class PersonalRecordsCompanion extends UpdateCompanion<PersonalRecord> {
   final Value<int> achievedAt;
   final Value<String?> workoutSetId;
   final Value<int> updatedAt;
+  final Value<int?> deletedAt;
   final Value<int> rowid;
   const PersonalRecordsCompanion({
     this.id = const Value.absent(),
@@ -2524,6 +2676,7 @@ class PersonalRecordsCompanion extends UpdateCompanion<PersonalRecord> {
     this.achievedAt = const Value.absent(),
     this.workoutSetId = const Value.absent(),
     this.updatedAt = const Value.absent(),
+    this.deletedAt = const Value.absent(),
     this.rowid = const Value.absent(),
   });
   PersonalRecordsCompanion.insert({
@@ -2534,6 +2687,7 @@ class PersonalRecordsCompanion extends UpdateCompanion<PersonalRecord> {
     required int achievedAt,
     this.workoutSetId = const Value.absent(),
     this.updatedAt = const Value.absent(),
+    this.deletedAt = const Value.absent(),
     this.rowid = const Value.absent(),
   })  : id = Value(id),
         exerciseId = Value(exerciseId),
@@ -2548,6 +2702,7 @@ class PersonalRecordsCompanion extends UpdateCompanion<PersonalRecord> {
     Expression<int>? achievedAt,
     Expression<String>? workoutSetId,
     Expression<int>? updatedAt,
+    Expression<int>? deletedAt,
     Expression<int>? rowid,
   }) {
     return RawValuesInsertable({
@@ -2558,6 +2713,7 @@ class PersonalRecordsCompanion extends UpdateCompanion<PersonalRecord> {
       if (achievedAt != null) 'achieved_at': achievedAt,
       if (workoutSetId != null) 'workout_set_id': workoutSetId,
       if (updatedAt != null) 'updated_at': updatedAt,
+      if (deletedAt != null) 'deleted_at': deletedAt,
       if (rowid != null) 'rowid': rowid,
     });
   }
@@ -2570,6 +2726,7 @@ class PersonalRecordsCompanion extends UpdateCompanion<PersonalRecord> {
       Value<int>? achievedAt,
       Value<String?>? workoutSetId,
       Value<int>? updatedAt,
+      Value<int?>? deletedAt,
       Value<int>? rowid}) {
     return PersonalRecordsCompanion(
       id: id ?? this.id,
@@ -2579,6 +2736,7 @@ class PersonalRecordsCompanion extends UpdateCompanion<PersonalRecord> {
       achievedAt: achievedAt ?? this.achievedAt,
       workoutSetId: workoutSetId ?? this.workoutSetId,
       updatedAt: updatedAt ?? this.updatedAt,
+      deletedAt: deletedAt ?? this.deletedAt,
       rowid: rowid ?? this.rowid,
     );
   }
@@ -2607,6 +2765,9 @@ class PersonalRecordsCompanion extends UpdateCompanion<PersonalRecord> {
     if (updatedAt.present) {
       map['updated_at'] = Variable<int>(updatedAt.value);
     }
+    if (deletedAt.present) {
+      map['deleted_at'] = Variable<int>(deletedAt.value);
+    }
     if (rowid.present) {
       map['rowid'] = Variable<int>(rowid.value);
     }
@@ -2623,6 +2784,7 @@ class PersonalRecordsCompanion extends UpdateCompanion<PersonalRecord> {
           ..write('achievedAt: $achievedAt, ')
           ..write('workoutSetId: $workoutSetId, ')
           ..write('updatedAt: $updatedAt, ')
+          ..write('deletedAt: $deletedAt, ')
           ..write('rowid: $rowid')
           ..write(')'))
         .toString();
@@ -2660,8 +2822,15 @@ class $WorkoutTemplatesTable extends WorkoutTemplates
   late final GeneratedColumn<int> updatedAt = GeneratedColumn<int>(
       'updated_at', aliasedName, false,
       type: DriftSqlType.int, requiredDuringInsert: true);
+  static const VerificationMeta _deletedAtMeta =
+      const VerificationMeta('deletedAt');
   @override
-  List<GeneratedColumn> get $columns => [id, name, createdAt, updatedAt];
+  late final GeneratedColumn<int> deletedAt = GeneratedColumn<int>(
+      'deleted_at', aliasedName, true,
+      type: DriftSqlType.int, requiredDuringInsert: false);
+  @override
+  List<GeneratedColumn> get $columns =>
+      [id, name, createdAt, updatedAt, deletedAt];
   @override
   String get aliasedName => _alias ?? actualTableName;
   @override
@@ -2695,6 +2864,10 @@ class $WorkoutTemplatesTable extends WorkoutTemplates
     } else if (isInserting) {
       context.missing(_updatedAtMeta);
     }
+    if (data.containsKey('deleted_at')) {
+      context.handle(_deletedAtMeta,
+          deletedAt.isAcceptableOrUnknown(data['deleted_at']!, _deletedAtMeta));
+    }
     return context;
   }
 
@@ -2712,6 +2885,8 @@ class $WorkoutTemplatesTable extends WorkoutTemplates
           .read(DriftSqlType.int, data['${effectivePrefix}created_at'])!,
       updatedAt: attachedDatabase.typeMapping
           .read(DriftSqlType.int, data['${effectivePrefix}updated_at'])!,
+      deletedAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}deleted_at']),
     );
   }
 
@@ -2726,11 +2901,13 @@ class WorkoutTemplate extends DataClass implements Insertable<WorkoutTemplate> {
   final String name;
   final int createdAt;
   final int updatedAt;
+  final int? deletedAt;
   const WorkoutTemplate(
       {required this.id,
       required this.name,
       required this.createdAt,
-      required this.updatedAt});
+      required this.updatedAt,
+      this.deletedAt});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
@@ -2738,6 +2915,9 @@ class WorkoutTemplate extends DataClass implements Insertable<WorkoutTemplate> {
     map['name'] = Variable<String>(name);
     map['created_at'] = Variable<int>(createdAt);
     map['updated_at'] = Variable<int>(updatedAt);
+    if (!nullToAbsent || deletedAt != null) {
+      map['deleted_at'] = Variable<int>(deletedAt);
+    }
     return map;
   }
 
@@ -2747,6 +2927,9 @@ class WorkoutTemplate extends DataClass implements Insertable<WorkoutTemplate> {
       name: Value(name),
       createdAt: Value(createdAt),
       updatedAt: Value(updatedAt),
+      deletedAt: deletedAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(deletedAt),
     );
   }
 
@@ -2758,6 +2941,7 @@ class WorkoutTemplate extends DataClass implements Insertable<WorkoutTemplate> {
       name: serializer.fromJson<String>(json['name']),
       createdAt: serializer.fromJson<int>(json['createdAt']),
       updatedAt: serializer.fromJson<int>(json['updatedAt']),
+      deletedAt: serializer.fromJson<int?>(json['deletedAt']),
     );
   }
   @override
@@ -2768,16 +2952,22 @@ class WorkoutTemplate extends DataClass implements Insertable<WorkoutTemplate> {
       'name': serializer.toJson<String>(name),
       'createdAt': serializer.toJson<int>(createdAt),
       'updatedAt': serializer.toJson<int>(updatedAt),
+      'deletedAt': serializer.toJson<int?>(deletedAt),
     };
   }
 
   WorkoutTemplate copyWith(
-          {String? id, String? name, int? createdAt, int? updatedAt}) =>
+          {String? id,
+          String? name,
+          int? createdAt,
+          int? updatedAt,
+          Value<int?> deletedAt = const Value.absent()}) =>
       WorkoutTemplate(
         id: id ?? this.id,
         name: name ?? this.name,
         createdAt: createdAt ?? this.createdAt,
         updatedAt: updatedAt ?? this.updatedAt,
+        deletedAt: deletedAt.present ? deletedAt.value : this.deletedAt,
       );
   WorkoutTemplate copyWithCompanion(WorkoutTemplatesCompanion data) {
     return WorkoutTemplate(
@@ -2785,6 +2975,7 @@ class WorkoutTemplate extends DataClass implements Insertable<WorkoutTemplate> {
       name: data.name.present ? data.name.value : this.name,
       createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
       updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
+      deletedAt: data.deletedAt.present ? data.deletedAt.value : this.deletedAt,
     );
   }
 
@@ -2794,13 +2985,14 @@ class WorkoutTemplate extends DataClass implements Insertable<WorkoutTemplate> {
           ..write('id: $id, ')
           ..write('name: $name, ')
           ..write('createdAt: $createdAt, ')
-          ..write('updatedAt: $updatedAt')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('deletedAt: $deletedAt')
           ..write(')'))
         .toString();
   }
 
   @override
-  int get hashCode => Object.hash(id, name, createdAt, updatedAt);
+  int get hashCode => Object.hash(id, name, createdAt, updatedAt, deletedAt);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -2808,7 +3000,8 @@ class WorkoutTemplate extends DataClass implements Insertable<WorkoutTemplate> {
           other.id == this.id &&
           other.name == this.name &&
           other.createdAt == this.createdAt &&
-          other.updatedAt == this.updatedAt);
+          other.updatedAt == this.updatedAt &&
+          other.deletedAt == this.deletedAt);
 }
 
 class WorkoutTemplatesCompanion extends UpdateCompanion<WorkoutTemplate> {
@@ -2816,12 +3009,14 @@ class WorkoutTemplatesCompanion extends UpdateCompanion<WorkoutTemplate> {
   final Value<String> name;
   final Value<int> createdAt;
   final Value<int> updatedAt;
+  final Value<int?> deletedAt;
   final Value<int> rowid;
   const WorkoutTemplatesCompanion({
     this.id = const Value.absent(),
     this.name = const Value.absent(),
     this.createdAt = const Value.absent(),
     this.updatedAt = const Value.absent(),
+    this.deletedAt = const Value.absent(),
     this.rowid = const Value.absent(),
   });
   WorkoutTemplatesCompanion.insert({
@@ -2829,6 +3024,7 @@ class WorkoutTemplatesCompanion extends UpdateCompanion<WorkoutTemplate> {
     required String name,
     required int createdAt,
     required int updatedAt,
+    this.deletedAt = const Value.absent(),
     this.rowid = const Value.absent(),
   })  : id = Value(id),
         name = Value(name),
@@ -2839,6 +3035,7 @@ class WorkoutTemplatesCompanion extends UpdateCompanion<WorkoutTemplate> {
     Expression<String>? name,
     Expression<int>? createdAt,
     Expression<int>? updatedAt,
+    Expression<int>? deletedAt,
     Expression<int>? rowid,
   }) {
     return RawValuesInsertable({
@@ -2846,6 +3043,7 @@ class WorkoutTemplatesCompanion extends UpdateCompanion<WorkoutTemplate> {
       if (name != null) 'name': name,
       if (createdAt != null) 'created_at': createdAt,
       if (updatedAt != null) 'updated_at': updatedAt,
+      if (deletedAt != null) 'deleted_at': deletedAt,
       if (rowid != null) 'rowid': rowid,
     });
   }
@@ -2855,12 +3053,14 @@ class WorkoutTemplatesCompanion extends UpdateCompanion<WorkoutTemplate> {
       Value<String>? name,
       Value<int>? createdAt,
       Value<int>? updatedAt,
+      Value<int?>? deletedAt,
       Value<int>? rowid}) {
     return WorkoutTemplatesCompanion(
       id: id ?? this.id,
       name: name ?? this.name,
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
+      deletedAt: deletedAt ?? this.deletedAt,
       rowid: rowid ?? this.rowid,
     );
   }
@@ -2880,6 +3080,9 @@ class WorkoutTemplatesCompanion extends UpdateCompanion<WorkoutTemplate> {
     if (updatedAt.present) {
       map['updated_at'] = Variable<int>(updatedAt.value);
     }
+    if (deletedAt.present) {
+      map['deleted_at'] = Variable<int>(deletedAt.value);
+    }
     if (rowid.present) {
       map['rowid'] = Variable<int>(rowid.value);
     }
@@ -2893,6 +3096,7 @@ class WorkoutTemplatesCompanion extends UpdateCompanion<WorkoutTemplate> {
           ..write('name: $name, ')
           ..write('createdAt: $createdAt, ')
           ..write('updatedAt: $updatedAt, ')
+          ..write('deletedAt: $deletedAt, ')
           ..write('rowid: $rowid')
           ..write(')'))
         .toString();
@@ -2963,6 +3167,12 @@ class $TemplateExercisesTable extends TemplateExercises
       type: DriftSqlType.int,
       requiredDuringInsert: false,
       defaultValue: const Constant(0));
+  static const VerificationMeta _deletedAtMeta =
+      const VerificationMeta('deletedAt');
+  @override
+  late final GeneratedColumn<int> deletedAt = GeneratedColumn<int>(
+      'deleted_at', aliasedName, true,
+      type: DriftSqlType.int, requiredDuringInsert: false);
   @override
   List<GeneratedColumn> get $columns => [
         id,
@@ -2972,7 +3182,8 @@ class $TemplateExercisesTable extends TemplateExercises
         targetSets,
         targetReps,
         orderIndex,
-        updatedAt
+        updatedAt,
+        deletedAt
       ];
   @override
   String get aliasedName => _alias ?? actualTableName;
@@ -3041,6 +3252,10 @@ class $TemplateExercisesTable extends TemplateExercises
       context.handle(_updatedAtMeta,
           updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta));
     }
+    if (data.containsKey('deleted_at')) {
+      context.handle(_deletedAtMeta,
+          deletedAt.isAcceptableOrUnknown(data['deleted_at']!, _deletedAtMeta));
+    }
     return context;
   }
 
@@ -3066,6 +3281,8 @@ class $TemplateExercisesTable extends TemplateExercises
           .read(DriftSqlType.int, data['${effectivePrefix}order_index'])!,
       updatedAt: attachedDatabase.typeMapping
           .read(DriftSqlType.int, data['${effectivePrefix}updated_at'])!,
+      deletedAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}deleted_at']),
     );
   }
 
@@ -3085,6 +3302,7 @@ class TemplateExercise extends DataClass
   final int targetReps;
   final int orderIndex;
   final int updatedAt;
+  final int? deletedAt;
   const TemplateExercise(
       {required this.id,
       required this.templateId,
@@ -3093,7 +3311,8 @@ class TemplateExercise extends DataClass
       required this.targetSets,
       required this.targetReps,
       required this.orderIndex,
-      required this.updatedAt});
+      required this.updatedAt,
+      this.deletedAt});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
@@ -3105,6 +3324,9 @@ class TemplateExercise extends DataClass
     map['target_reps'] = Variable<int>(targetReps);
     map['order_index'] = Variable<int>(orderIndex);
     map['updated_at'] = Variable<int>(updatedAt);
+    if (!nullToAbsent || deletedAt != null) {
+      map['deleted_at'] = Variable<int>(deletedAt);
+    }
     return map;
   }
 
@@ -3118,6 +3340,9 @@ class TemplateExercise extends DataClass
       targetReps: Value(targetReps),
       orderIndex: Value(orderIndex),
       updatedAt: Value(updatedAt),
+      deletedAt: deletedAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(deletedAt),
     );
   }
 
@@ -3133,6 +3358,7 @@ class TemplateExercise extends DataClass
       targetReps: serializer.fromJson<int>(json['targetReps']),
       orderIndex: serializer.fromJson<int>(json['orderIndex']),
       updatedAt: serializer.fromJson<int>(json['updatedAt']),
+      deletedAt: serializer.fromJson<int?>(json['deletedAt']),
     );
   }
   @override
@@ -3147,6 +3373,7 @@ class TemplateExercise extends DataClass
       'targetReps': serializer.toJson<int>(targetReps),
       'orderIndex': serializer.toJson<int>(orderIndex),
       'updatedAt': serializer.toJson<int>(updatedAt),
+      'deletedAt': serializer.toJson<int?>(deletedAt),
     };
   }
 
@@ -3158,7 +3385,8 @@ class TemplateExercise extends DataClass
           int? targetSets,
           int? targetReps,
           int? orderIndex,
-          int? updatedAt}) =>
+          int? updatedAt,
+          Value<int?> deletedAt = const Value.absent()}) =>
       TemplateExercise(
         id: id ?? this.id,
         templateId: templateId ?? this.templateId,
@@ -3168,6 +3396,7 @@ class TemplateExercise extends DataClass
         targetReps: targetReps ?? this.targetReps,
         orderIndex: orderIndex ?? this.orderIndex,
         updatedAt: updatedAt ?? this.updatedAt,
+        deletedAt: deletedAt.present ? deletedAt.value : this.deletedAt,
       );
   TemplateExercise copyWithCompanion(TemplateExercisesCompanion data) {
     return TemplateExercise(
@@ -3186,6 +3415,7 @@ class TemplateExercise extends DataClass
       orderIndex:
           data.orderIndex.present ? data.orderIndex.value : this.orderIndex,
       updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
+      deletedAt: data.deletedAt.present ? data.deletedAt.value : this.deletedAt,
     );
   }
 
@@ -3199,14 +3429,15 @@ class TemplateExercise extends DataClass
           ..write('targetSets: $targetSets, ')
           ..write('targetReps: $targetReps, ')
           ..write('orderIndex: $orderIndex, ')
-          ..write('updatedAt: $updatedAt')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('deletedAt: $deletedAt')
           ..write(')'))
         .toString();
   }
 
   @override
   int get hashCode => Object.hash(id, templateId, exerciseId, exerciseName,
-      targetSets, targetReps, orderIndex, updatedAt);
+      targetSets, targetReps, orderIndex, updatedAt, deletedAt);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -3218,7 +3449,8 @@ class TemplateExercise extends DataClass
           other.targetSets == this.targetSets &&
           other.targetReps == this.targetReps &&
           other.orderIndex == this.orderIndex &&
-          other.updatedAt == this.updatedAt);
+          other.updatedAt == this.updatedAt &&
+          other.deletedAt == this.deletedAt);
 }
 
 class TemplateExercisesCompanion extends UpdateCompanion<TemplateExercise> {
@@ -3230,6 +3462,7 @@ class TemplateExercisesCompanion extends UpdateCompanion<TemplateExercise> {
   final Value<int> targetReps;
   final Value<int> orderIndex;
   final Value<int> updatedAt;
+  final Value<int?> deletedAt;
   final Value<int> rowid;
   const TemplateExercisesCompanion({
     this.id = const Value.absent(),
@@ -3240,6 +3473,7 @@ class TemplateExercisesCompanion extends UpdateCompanion<TemplateExercise> {
     this.targetReps = const Value.absent(),
     this.orderIndex = const Value.absent(),
     this.updatedAt = const Value.absent(),
+    this.deletedAt = const Value.absent(),
     this.rowid = const Value.absent(),
   });
   TemplateExercisesCompanion.insert({
@@ -3251,6 +3485,7 @@ class TemplateExercisesCompanion extends UpdateCompanion<TemplateExercise> {
     required int targetReps,
     required int orderIndex,
     this.updatedAt = const Value.absent(),
+    this.deletedAt = const Value.absent(),
     this.rowid = const Value.absent(),
   })  : id = Value(id),
         templateId = Value(templateId),
@@ -3268,6 +3503,7 @@ class TemplateExercisesCompanion extends UpdateCompanion<TemplateExercise> {
     Expression<int>? targetReps,
     Expression<int>? orderIndex,
     Expression<int>? updatedAt,
+    Expression<int>? deletedAt,
     Expression<int>? rowid,
   }) {
     return RawValuesInsertable({
@@ -3279,6 +3515,7 @@ class TemplateExercisesCompanion extends UpdateCompanion<TemplateExercise> {
       if (targetReps != null) 'target_reps': targetReps,
       if (orderIndex != null) 'order_index': orderIndex,
       if (updatedAt != null) 'updated_at': updatedAt,
+      if (deletedAt != null) 'deleted_at': deletedAt,
       if (rowid != null) 'rowid': rowid,
     });
   }
@@ -3292,6 +3529,7 @@ class TemplateExercisesCompanion extends UpdateCompanion<TemplateExercise> {
       Value<int>? targetReps,
       Value<int>? orderIndex,
       Value<int>? updatedAt,
+      Value<int?>? deletedAt,
       Value<int>? rowid}) {
     return TemplateExercisesCompanion(
       id: id ?? this.id,
@@ -3302,6 +3540,7 @@ class TemplateExercisesCompanion extends UpdateCompanion<TemplateExercise> {
       targetReps: targetReps ?? this.targetReps,
       orderIndex: orderIndex ?? this.orderIndex,
       updatedAt: updatedAt ?? this.updatedAt,
+      deletedAt: deletedAt ?? this.deletedAt,
       rowid: rowid ?? this.rowid,
     );
   }
@@ -3333,6 +3572,9 @@ class TemplateExercisesCompanion extends UpdateCompanion<TemplateExercise> {
     if (updatedAt.present) {
       map['updated_at'] = Variable<int>(updatedAt.value);
     }
+    if (deletedAt.present) {
+      map['deleted_at'] = Variable<int>(deletedAt.value);
+    }
     if (rowid.present) {
       map['rowid'] = Variable<int>(rowid.value);
     }
@@ -3350,6 +3592,7 @@ class TemplateExercisesCompanion extends UpdateCompanion<TemplateExercise> {
           ..write('targetReps: $targetReps, ')
           ..write('orderIndex: $orderIndex, ')
           ..write('updatedAt: $updatedAt, ')
+          ..write('deletedAt: $deletedAt, ')
           ..write('rowid: $rowid')
           ..write(')'))
         .toString();
@@ -3396,9 +3639,15 @@ class $ProgrammesTable extends Programmes
   late final GeneratedColumn<int> startedAt = GeneratedColumn<int>(
       'started_at', aliasedName, true,
       type: DriftSqlType.int, requiredDuringInsert: false);
+  static const VerificationMeta _deletedAtMeta =
+      const VerificationMeta('deletedAt');
+  @override
+  late final GeneratedColumn<int> deletedAt = GeneratedColumn<int>(
+      'deleted_at', aliasedName, true,
+      type: DriftSqlType.int, requiredDuringInsert: false);
   @override
   List<GeneratedColumn> get $columns =>
-      [id, name, durationWeeks, createdAt, updatedAt, startedAt];
+      [id, name, durationWeeks, createdAt, updatedAt, startedAt, deletedAt];
   @override
   String get aliasedName => _alias ?? actualTableName;
   @override
@@ -3444,6 +3693,10 @@ class $ProgrammesTable extends Programmes
       context.handle(_startedAtMeta,
           startedAt.isAcceptableOrUnknown(data['started_at']!, _startedAtMeta));
     }
+    if (data.containsKey('deleted_at')) {
+      context.handle(_deletedAtMeta,
+          deletedAt.isAcceptableOrUnknown(data['deleted_at']!, _deletedAtMeta));
+    }
     return context;
   }
 
@@ -3465,6 +3718,8 @@ class $ProgrammesTable extends Programmes
           .read(DriftSqlType.int, data['${effectivePrefix}updated_at'])!,
       startedAt: attachedDatabase.typeMapping
           .read(DriftSqlType.int, data['${effectivePrefix}started_at']),
+      deletedAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}deleted_at']),
     );
   }
 
@@ -3484,13 +3739,15 @@ class Programme extends DataClass implements Insertable<Programme> {
   /// Epoch ms when the user activated the programme. Null = not yet started.
   /// Used to compute the current week for [Programme.currentWeek].
   final int? startedAt;
+  final int? deletedAt;
   const Programme(
       {required this.id,
       required this.name,
       required this.durationWeeks,
       required this.createdAt,
       required this.updatedAt,
-      this.startedAt});
+      this.startedAt,
+      this.deletedAt});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
@@ -3501,6 +3758,9 @@ class Programme extends DataClass implements Insertable<Programme> {
     map['updated_at'] = Variable<int>(updatedAt);
     if (!nullToAbsent || startedAt != null) {
       map['started_at'] = Variable<int>(startedAt);
+    }
+    if (!nullToAbsent || deletedAt != null) {
+      map['deleted_at'] = Variable<int>(deletedAt);
     }
     return map;
   }
@@ -3515,6 +3775,9 @@ class Programme extends DataClass implements Insertable<Programme> {
       startedAt: startedAt == null && nullToAbsent
           ? const Value.absent()
           : Value(startedAt),
+      deletedAt: deletedAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(deletedAt),
     );
   }
 
@@ -3528,6 +3791,7 @@ class Programme extends DataClass implements Insertable<Programme> {
       createdAt: serializer.fromJson<int>(json['createdAt']),
       updatedAt: serializer.fromJson<int>(json['updatedAt']),
       startedAt: serializer.fromJson<int?>(json['startedAt']),
+      deletedAt: serializer.fromJson<int?>(json['deletedAt']),
     );
   }
   @override
@@ -3540,6 +3804,7 @@ class Programme extends DataClass implements Insertable<Programme> {
       'createdAt': serializer.toJson<int>(createdAt),
       'updatedAt': serializer.toJson<int>(updatedAt),
       'startedAt': serializer.toJson<int?>(startedAt),
+      'deletedAt': serializer.toJson<int?>(deletedAt),
     };
   }
 
@@ -3549,7 +3814,8 @@ class Programme extends DataClass implements Insertable<Programme> {
           int? durationWeeks,
           int? createdAt,
           int? updatedAt,
-          Value<int?> startedAt = const Value.absent()}) =>
+          Value<int?> startedAt = const Value.absent(),
+          Value<int?> deletedAt = const Value.absent()}) =>
       Programme(
         id: id ?? this.id,
         name: name ?? this.name,
@@ -3557,6 +3823,7 @@ class Programme extends DataClass implements Insertable<Programme> {
         createdAt: createdAt ?? this.createdAt,
         updatedAt: updatedAt ?? this.updatedAt,
         startedAt: startedAt.present ? startedAt.value : this.startedAt,
+        deletedAt: deletedAt.present ? deletedAt.value : this.deletedAt,
       );
   Programme copyWithCompanion(ProgrammesCompanion data) {
     return Programme(
@@ -3568,6 +3835,7 @@ class Programme extends DataClass implements Insertable<Programme> {
       createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
       updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
       startedAt: data.startedAt.present ? data.startedAt.value : this.startedAt,
+      deletedAt: data.deletedAt.present ? data.deletedAt.value : this.deletedAt,
     );
   }
 
@@ -3579,14 +3847,15 @@ class Programme extends DataClass implements Insertable<Programme> {
           ..write('durationWeeks: $durationWeeks, ')
           ..write('createdAt: $createdAt, ')
           ..write('updatedAt: $updatedAt, ')
-          ..write('startedAt: $startedAt')
+          ..write('startedAt: $startedAt, ')
+          ..write('deletedAt: $deletedAt')
           ..write(')'))
         .toString();
   }
 
   @override
-  int get hashCode =>
-      Object.hash(id, name, durationWeeks, createdAt, updatedAt, startedAt);
+  int get hashCode => Object.hash(
+      id, name, durationWeeks, createdAt, updatedAt, startedAt, deletedAt);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -3596,7 +3865,8 @@ class Programme extends DataClass implements Insertable<Programme> {
           other.durationWeeks == this.durationWeeks &&
           other.createdAt == this.createdAt &&
           other.updatedAt == this.updatedAt &&
-          other.startedAt == this.startedAt);
+          other.startedAt == this.startedAt &&
+          other.deletedAt == this.deletedAt);
 }
 
 class ProgrammesCompanion extends UpdateCompanion<Programme> {
@@ -3606,6 +3876,7 @@ class ProgrammesCompanion extends UpdateCompanion<Programme> {
   final Value<int> createdAt;
   final Value<int> updatedAt;
   final Value<int?> startedAt;
+  final Value<int?> deletedAt;
   final Value<int> rowid;
   const ProgrammesCompanion({
     this.id = const Value.absent(),
@@ -3614,6 +3885,7 @@ class ProgrammesCompanion extends UpdateCompanion<Programme> {
     this.createdAt = const Value.absent(),
     this.updatedAt = const Value.absent(),
     this.startedAt = const Value.absent(),
+    this.deletedAt = const Value.absent(),
     this.rowid = const Value.absent(),
   });
   ProgrammesCompanion.insert({
@@ -3623,6 +3895,7 @@ class ProgrammesCompanion extends UpdateCompanion<Programme> {
     required int createdAt,
     required int updatedAt,
     this.startedAt = const Value.absent(),
+    this.deletedAt = const Value.absent(),
     this.rowid = const Value.absent(),
   })  : id = Value(id),
         name = Value(name),
@@ -3636,6 +3909,7 @@ class ProgrammesCompanion extends UpdateCompanion<Programme> {
     Expression<int>? createdAt,
     Expression<int>? updatedAt,
     Expression<int>? startedAt,
+    Expression<int>? deletedAt,
     Expression<int>? rowid,
   }) {
     return RawValuesInsertable({
@@ -3645,6 +3919,7 @@ class ProgrammesCompanion extends UpdateCompanion<Programme> {
       if (createdAt != null) 'created_at': createdAt,
       if (updatedAt != null) 'updated_at': updatedAt,
       if (startedAt != null) 'started_at': startedAt,
+      if (deletedAt != null) 'deleted_at': deletedAt,
       if (rowid != null) 'rowid': rowid,
     });
   }
@@ -3656,6 +3931,7 @@ class ProgrammesCompanion extends UpdateCompanion<Programme> {
       Value<int>? createdAt,
       Value<int>? updatedAt,
       Value<int?>? startedAt,
+      Value<int?>? deletedAt,
       Value<int>? rowid}) {
     return ProgrammesCompanion(
       id: id ?? this.id,
@@ -3664,6 +3940,7 @@ class ProgrammesCompanion extends UpdateCompanion<Programme> {
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
       startedAt: startedAt ?? this.startedAt,
+      deletedAt: deletedAt ?? this.deletedAt,
       rowid: rowid ?? this.rowid,
     );
   }
@@ -3689,6 +3966,9 @@ class ProgrammesCompanion extends UpdateCompanion<Programme> {
     if (startedAt.present) {
       map['started_at'] = Variable<int>(startedAt.value);
     }
+    if (deletedAt.present) {
+      map['deleted_at'] = Variable<int>(deletedAt.value);
+    }
     if (rowid.present) {
       map['rowid'] = Variable<int>(rowid.value);
     }
@@ -3704,6 +3984,7 @@ class ProgrammesCompanion extends UpdateCompanion<Programme> {
           ..write('createdAt: $createdAt, ')
           ..write('updatedAt: $updatedAt, ')
           ..write('startedAt: $startedAt, ')
+          ..write('deletedAt: $deletedAt, ')
           ..write('rowid: $rowid')
           ..write(')'))
         .toString();
@@ -3759,6 +4040,12 @@ class $ProgrammeDaysTable extends ProgrammeDays
       type: DriftSqlType.int,
       requiredDuringInsert: false,
       defaultValue: const Constant(0));
+  static const VerificationMeta _deletedAtMeta =
+      const VerificationMeta('deletedAt');
+  @override
+  late final GeneratedColumn<int> deletedAt = GeneratedColumn<int>(
+      'deleted_at', aliasedName, true,
+      type: DriftSqlType.int, requiredDuringInsert: false);
   @override
   List<GeneratedColumn> get $columns => [
         id,
@@ -3767,7 +4054,8 @@ class $ProgrammeDaysTable extends ProgrammeDays
         dayOfWeek,
         templateId,
         templateName,
-        updatedAt
+        updatedAt,
+        deletedAt
       ];
   @override
   String get aliasedName => _alias ?? actualTableName;
@@ -3828,6 +4116,10 @@ class $ProgrammeDaysTable extends ProgrammeDays
       context.handle(_updatedAtMeta,
           updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta));
     }
+    if (data.containsKey('deleted_at')) {
+      context.handle(_deletedAtMeta,
+          deletedAt.isAcceptableOrUnknown(data['deleted_at']!, _deletedAtMeta));
+    }
     return context;
   }
 
@@ -3851,6 +4143,8 @@ class $ProgrammeDaysTable extends ProgrammeDays
           .read(DriftSqlType.string, data['${effectivePrefix}template_name'])!,
       updatedAt: attachedDatabase.typeMapping
           .read(DriftSqlType.int, data['${effectivePrefix}updated_at'])!,
+      deletedAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}deleted_at']),
     );
   }
 
@@ -3868,6 +4162,7 @@ class ProgrammeDay extends DataClass implements Insertable<ProgrammeDay> {
   final String templateId;
   final String templateName;
   final int updatedAt;
+  final int? deletedAt;
   const ProgrammeDay(
       {required this.id,
       required this.programmeId,
@@ -3875,7 +4170,8 @@ class ProgrammeDay extends DataClass implements Insertable<ProgrammeDay> {
       required this.dayOfWeek,
       required this.templateId,
       required this.templateName,
-      required this.updatedAt});
+      required this.updatedAt,
+      this.deletedAt});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
@@ -3886,6 +4182,9 @@ class ProgrammeDay extends DataClass implements Insertable<ProgrammeDay> {
     map['template_id'] = Variable<String>(templateId);
     map['template_name'] = Variable<String>(templateName);
     map['updated_at'] = Variable<int>(updatedAt);
+    if (!nullToAbsent || deletedAt != null) {
+      map['deleted_at'] = Variable<int>(deletedAt);
+    }
     return map;
   }
 
@@ -3898,6 +4197,9 @@ class ProgrammeDay extends DataClass implements Insertable<ProgrammeDay> {
       templateId: Value(templateId),
       templateName: Value(templateName),
       updatedAt: Value(updatedAt),
+      deletedAt: deletedAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(deletedAt),
     );
   }
 
@@ -3912,6 +4214,7 @@ class ProgrammeDay extends DataClass implements Insertable<ProgrammeDay> {
       templateId: serializer.fromJson<String>(json['templateId']),
       templateName: serializer.fromJson<String>(json['templateName']),
       updatedAt: serializer.fromJson<int>(json['updatedAt']),
+      deletedAt: serializer.fromJson<int?>(json['deletedAt']),
     );
   }
   @override
@@ -3925,6 +4228,7 @@ class ProgrammeDay extends DataClass implements Insertable<ProgrammeDay> {
       'templateId': serializer.toJson<String>(templateId),
       'templateName': serializer.toJson<String>(templateName),
       'updatedAt': serializer.toJson<int>(updatedAt),
+      'deletedAt': serializer.toJson<int?>(deletedAt),
     };
   }
 
@@ -3935,7 +4239,8 @@ class ProgrammeDay extends DataClass implements Insertable<ProgrammeDay> {
           int? dayOfWeek,
           String? templateId,
           String? templateName,
-          int? updatedAt}) =>
+          int? updatedAt,
+          Value<int?> deletedAt = const Value.absent()}) =>
       ProgrammeDay(
         id: id ?? this.id,
         programmeId: programmeId ?? this.programmeId,
@@ -3944,6 +4249,7 @@ class ProgrammeDay extends DataClass implements Insertable<ProgrammeDay> {
         templateId: templateId ?? this.templateId,
         templateName: templateName ?? this.templateName,
         updatedAt: updatedAt ?? this.updatedAt,
+        deletedAt: deletedAt.present ? deletedAt.value : this.deletedAt,
       );
   ProgrammeDay copyWithCompanion(ProgrammeDaysCompanion data) {
     return ProgrammeDay(
@@ -3959,6 +4265,7 @@ class ProgrammeDay extends DataClass implements Insertable<ProgrammeDay> {
           ? data.templateName.value
           : this.templateName,
       updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
+      deletedAt: data.deletedAt.present ? data.deletedAt.value : this.deletedAt,
     );
   }
 
@@ -3971,14 +4278,15 @@ class ProgrammeDay extends DataClass implements Insertable<ProgrammeDay> {
           ..write('dayOfWeek: $dayOfWeek, ')
           ..write('templateId: $templateId, ')
           ..write('templateName: $templateName, ')
-          ..write('updatedAt: $updatedAt')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('deletedAt: $deletedAt')
           ..write(')'))
         .toString();
   }
 
   @override
   int get hashCode => Object.hash(id, programmeId, weekNumber, dayOfWeek,
-      templateId, templateName, updatedAt);
+      templateId, templateName, updatedAt, deletedAt);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -3989,7 +4297,8 @@ class ProgrammeDay extends DataClass implements Insertable<ProgrammeDay> {
           other.dayOfWeek == this.dayOfWeek &&
           other.templateId == this.templateId &&
           other.templateName == this.templateName &&
-          other.updatedAt == this.updatedAt);
+          other.updatedAt == this.updatedAt &&
+          other.deletedAt == this.deletedAt);
 }
 
 class ProgrammeDaysCompanion extends UpdateCompanion<ProgrammeDay> {
@@ -4000,6 +4309,7 @@ class ProgrammeDaysCompanion extends UpdateCompanion<ProgrammeDay> {
   final Value<String> templateId;
   final Value<String> templateName;
   final Value<int> updatedAt;
+  final Value<int?> deletedAt;
   final Value<int> rowid;
   const ProgrammeDaysCompanion({
     this.id = const Value.absent(),
@@ -4009,6 +4319,7 @@ class ProgrammeDaysCompanion extends UpdateCompanion<ProgrammeDay> {
     this.templateId = const Value.absent(),
     this.templateName = const Value.absent(),
     this.updatedAt = const Value.absent(),
+    this.deletedAt = const Value.absent(),
     this.rowid = const Value.absent(),
   });
   ProgrammeDaysCompanion.insert({
@@ -4019,6 +4330,7 @@ class ProgrammeDaysCompanion extends UpdateCompanion<ProgrammeDay> {
     required String templateId,
     required String templateName,
     this.updatedAt = const Value.absent(),
+    this.deletedAt = const Value.absent(),
     this.rowid = const Value.absent(),
   })  : id = Value(id),
         programmeId = Value(programmeId),
@@ -4034,6 +4346,7 @@ class ProgrammeDaysCompanion extends UpdateCompanion<ProgrammeDay> {
     Expression<String>? templateId,
     Expression<String>? templateName,
     Expression<int>? updatedAt,
+    Expression<int>? deletedAt,
     Expression<int>? rowid,
   }) {
     return RawValuesInsertable({
@@ -4044,6 +4357,7 @@ class ProgrammeDaysCompanion extends UpdateCompanion<ProgrammeDay> {
       if (templateId != null) 'template_id': templateId,
       if (templateName != null) 'template_name': templateName,
       if (updatedAt != null) 'updated_at': updatedAt,
+      if (deletedAt != null) 'deleted_at': deletedAt,
       if (rowid != null) 'rowid': rowid,
     });
   }
@@ -4056,6 +4370,7 @@ class ProgrammeDaysCompanion extends UpdateCompanion<ProgrammeDay> {
       Value<String>? templateId,
       Value<String>? templateName,
       Value<int>? updatedAt,
+      Value<int?>? deletedAt,
       Value<int>? rowid}) {
     return ProgrammeDaysCompanion(
       id: id ?? this.id,
@@ -4065,6 +4380,7 @@ class ProgrammeDaysCompanion extends UpdateCompanion<ProgrammeDay> {
       templateId: templateId ?? this.templateId,
       templateName: templateName ?? this.templateName,
       updatedAt: updatedAt ?? this.updatedAt,
+      deletedAt: deletedAt ?? this.deletedAt,
       rowid: rowid ?? this.rowid,
     );
   }
@@ -4093,6 +4409,9 @@ class ProgrammeDaysCompanion extends UpdateCompanion<ProgrammeDay> {
     if (updatedAt.present) {
       map['updated_at'] = Variable<int>(updatedAt.value);
     }
+    if (deletedAt.present) {
+      map['deleted_at'] = Variable<int>(deletedAt.value);
+    }
     if (rowid.present) {
       map['rowid'] = Variable<int>(rowid.value);
     }
@@ -4109,6 +4428,7 @@ class ProgrammeDaysCompanion extends UpdateCompanion<ProgrammeDay> {
           ..write('templateId: $templateId, ')
           ..write('templateName: $templateName, ')
           ..write('updatedAt: $updatedAt, ')
+          ..write('deletedAt: $deletedAt, ')
           ..write('rowid: $rowid')
           ..write(')'))
         .toString();
@@ -4164,9 +4484,23 @@ class $ProgressionRulesTable extends ProgressionRules
       type: DriftSqlType.int,
       requiredDuringInsert: false,
       defaultValue: const Constant(0));
+  static const VerificationMeta _deletedAtMeta =
+      const VerificationMeta('deletedAt');
   @override
-  List<GeneratedColumn> get $columns =>
-      [id, programmeId, exerciseId, type, value, frequencyWeeks, updatedAt];
+  late final GeneratedColumn<int> deletedAt = GeneratedColumn<int>(
+      'deleted_at', aliasedName, true,
+      type: DriftSqlType.int, requiredDuringInsert: false);
+  @override
+  List<GeneratedColumn> get $columns => [
+        id,
+        programmeId,
+        exerciseId,
+        type,
+        value,
+        frequencyWeeks,
+        updatedAt,
+        deletedAt
+      ];
   @override
   String get aliasedName => _alias ?? actualTableName;
   @override
@@ -4220,6 +4554,10 @@ class $ProgressionRulesTable extends ProgressionRules
       context.handle(_updatedAtMeta,
           updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta));
     }
+    if (data.containsKey('deleted_at')) {
+      context.handle(_deletedAtMeta,
+          deletedAt.isAcceptableOrUnknown(data['deleted_at']!, _deletedAtMeta));
+    }
     return context;
   }
 
@@ -4243,6 +4581,8 @@ class $ProgressionRulesTable extends ProgressionRules
           .read(DriftSqlType.int, data['${effectivePrefix}frequency_weeks'])!,
       updatedAt: attachedDatabase.typeMapping
           .read(DriftSqlType.int, data['${effectivePrefix}updated_at'])!,
+      deletedAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}deleted_at']),
     );
   }
 
@@ -4260,6 +4600,7 @@ class ProgressionRule extends DataClass implements Insertable<ProgressionRule> {
   final double value;
   final int frequencyWeeks;
   final int updatedAt;
+  final int? deletedAt;
   const ProgressionRule(
       {required this.id,
       required this.programmeId,
@@ -4267,7 +4608,8 @@ class ProgressionRule extends DataClass implements Insertable<ProgressionRule> {
       required this.type,
       required this.value,
       required this.frequencyWeeks,
-      required this.updatedAt});
+      required this.updatedAt,
+      this.deletedAt});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
@@ -4278,6 +4620,9 @@ class ProgressionRule extends DataClass implements Insertable<ProgressionRule> {
     map['value'] = Variable<double>(value);
     map['frequency_weeks'] = Variable<int>(frequencyWeeks);
     map['updated_at'] = Variable<int>(updatedAt);
+    if (!nullToAbsent || deletedAt != null) {
+      map['deleted_at'] = Variable<int>(deletedAt);
+    }
     return map;
   }
 
@@ -4290,6 +4635,9 @@ class ProgressionRule extends DataClass implements Insertable<ProgressionRule> {
       value: Value(value),
       frequencyWeeks: Value(frequencyWeeks),
       updatedAt: Value(updatedAt),
+      deletedAt: deletedAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(deletedAt),
     );
   }
 
@@ -4304,6 +4652,7 @@ class ProgressionRule extends DataClass implements Insertable<ProgressionRule> {
       value: serializer.fromJson<double>(json['value']),
       frequencyWeeks: serializer.fromJson<int>(json['frequencyWeeks']),
       updatedAt: serializer.fromJson<int>(json['updatedAt']),
+      deletedAt: serializer.fromJson<int?>(json['deletedAt']),
     );
   }
   @override
@@ -4317,6 +4666,7 @@ class ProgressionRule extends DataClass implements Insertable<ProgressionRule> {
       'value': serializer.toJson<double>(value),
       'frequencyWeeks': serializer.toJson<int>(frequencyWeeks),
       'updatedAt': serializer.toJson<int>(updatedAt),
+      'deletedAt': serializer.toJson<int?>(deletedAt),
     };
   }
 
@@ -4327,7 +4677,8 @@ class ProgressionRule extends DataClass implements Insertable<ProgressionRule> {
           String? type,
           double? value,
           int? frequencyWeeks,
-          int? updatedAt}) =>
+          int? updatedAt,
+          Value<int?> deletedAt = const Value.absent()}) =>
       ProgressionRule(
         id: id ?? this.id,
         programmeId: programmeId ?? this.programmeId,
@@ -4336,6 +4687,7 @@ class ProgressionRule extends DataClass implements Insertable<ProgressionRule> {
         value: value ?? this.value,
         frequencyWeeks: frequencyWeeks ?? this.frequencyWeeks,
         updatedAt: updatedAt ?? this.updatedAt,
+        deletedAt: deletedAt.present ? deletedAt.value : this.deletedAt,
       );
   ProgressionRule copyWithCompanion(ProgressionRulesCompanion data) {
     return ProgressionRule(
@@ -4350,6 +4702,7 @@ class ProgressionRule extends DataClass implements Insertable<ProgressionRule> {
           ? data.frequencyWeeks.value
           : this.frequencyWeeks,
       updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
+      deletedAt: data.deletedAt.present ? data.deletedAt.value : this.deletedAt,
     );
   }
 
@@ -4362,14 +4715,15 @@ class ProgressionRule extends DataClass implements Insertable<ProgressionRule> {
           ..write('type: $type, ')
           ..write('value: $value, ')
           ..write('frequencyWeeks: $frequencyWeeks, ')
-          ..write('updatedAt: $updatedAt')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('deletedAt: $deletedAt')
           ..write(')'))
         .toString();
   }
 
   @override
-  int get hashCode => Object.hash(
-      id, programmeId, exerciseId, type, value, frequencyWeeks, updatedAt);
+  int get hashCode => Object.hash(id, programmeId, exerciseId, type, value,
+      frequencyWeeks, updatedAt, deletedAt);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -4380,7 +4734,8 @@ class ProgressionRule extends DataClass implements Insertable<ProgressionRule> {
           other.type == this.type &&
           other.value == this.value &&
           other.frequencyWeeks == this.frequencyWeeks &&
-          other.updatedAt == this.updatedAt);
+          other.updatedAt == this.updatedAt &&
+          other.deletedAt == this.deletedAt);
 }
 
 class ProgressionRulesCompanion extends UpdateCompanion<ProgressionRule> {
@@ -4391,6 +4746,7 @@ class ProgressionRulesCompanion extends UpdateCompanion<ProgressionRule> {
   final Value<double> value;
   final Value<int> frequencyWeeks;
   final Value<int> updatedAt;
+  final Value<int?> deletedAt;
   final Value<int> rowid;
   const ProgressionRulesCompanion({
     this.id = const Value.absent(),
@@ -4400,6 +4756,7 @@ class ProgressionRulesCompanion extends UpdateCompanion<ProgressionRule> {
     this.value = const Value.absent(),
     this.frequencyWeeks = const Value.absent(),
     this.updatedAt = const Value.absent(),
+    this.deletedAt = const Value.absent(),
     this.rowid = const Value.absent(),
   });
   ProgressionRulesCompanion.insert({
@@ -4410,6 +4767,7 @@ class ProgressionRulesCompanion extends UpdateCompanion<ProgressionRule> {
     required double value,
     this.frequencyWeeks = const Value.absent(),
     this.updatedAt = const Value.absent(),
+    this.deletedAt = const Value.absent(),
     this.rowid = const Value.absent(),
   })  : id = Value(id),
         programmeId = Value(programmeId),
@@ -4424,6 +4782,7 @@ class ProgressionRulesCompanion extends UpdateCompanion<ProgressionRule> {
     Expression<double>? value,
     Expression<int>? frequencyWeeks,
     Expression<int>? updatedAt,
+    Expression<int>? deletedAt,
     Expression<int>? rowid,
   }) {
     return RawValuesInsertable({
@@ -4434,6 +4793,7 @@ class ProgressionRulesCompanion extends UpdateCompanion<ProgressionRule> {
       if (value != null) 'value': value,
       if (frequencyWeeks != null) 'frequency_weeks': frequencyWeeks,
       if (updatedAt != null) 'updated_at': updatedAt,
+      if (deletedAt != null) 'deleted_at': deletedAt,
       if (rowid != null) 'rowid': rowid,
     });
   }
@@ -4446,6 +4806,7 @@ class ProgressionRulesCompanion extends UpdateCompanion<ProgressionRule> {
       Value<double>? value,
       Value<int>? frequencyWeeks,
       Value<int>? updatedAt,
+      Value<int?>? deletedAt,
       Value<int>? rowid}) {
     return ProgressionRulesCompanion(
       id: id ?? this.id,
@@ -4455,6 +4816,7 @@ class ProgressionRulesCompanion extends UpdateCompanion<ProgressionRule> {
       value: value ?? this.value,
       frequencyWeeks: frequencyWeeks ?? this.frequencyWeeks,
       updatedAt: updatedAt ?? this.updatedAt,
+      deletedAt: deletedAt ?? this.deletedAt,
       rowid: rowid ?? this.rowid,
     );
   }
@@ -4483,6 +4845,9 @@ class ProgressionRulesCompanion extends UpdateCompanion<ProgressionRule> {
     if (updatedAt.present) {
       map['updated_at'] = Variable<int>(updatedAt.value);
     }
+    if (deletedAt.present) {
+      map['deleted_at'] = Variable<int>(deletedAt.value);
+    }
     if (rowid.present) {
       map['rowid'] = Variable<int>(rowid.value);
     }
@@ -4499,6 +4864,7 @@ class ProgressionRulesCompanion extends UpdateCompanion<ProgressionRule> {
           ..write('value: $value, ')
           ..write('frequencyWeeks: $frequencyWeeks, ')
           ..write('updatedAt: $updatedAt, ')
+          ..write('deletedAt: $deletedAt, ')
           ..write('rowid: $rowid')
           ..write(')'))
         .toString();
@@ -5226,6 +5592,7 @@ typedef $$BodyMetricsTableCreateCompanionBuilder = BodyMetricsCompanion
   Value<double?> bodyFatPercent,
   Value<String?> notes,
   Value<int> updatedAt,
+  Value<int?> deletedAt,
   Value<int> rowid,
 });
 typedef $$BodyMetricsTableUpdateCompanionBuilder = BodyMetricsCompanion
@@ -5236,6 +5603,7 @@ typedef $$BodyMetricsTableUpdateCompanionBuilder = BodyMetricsCompanion
   Value<double?> bodyFatPercent,
   Value<String?> notes,
   Value<int> updatedAt,
+  Value<int?> deletedAt,
   Value<int> rowid,
 });
 
@@ -5266,6 +5634,9 @@ class $$BodyMetricsTableFilterComposer
 
   ColumnFilters<int> get updatedAt => $composableBuilder(
       column: $table.updatedAt, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<int> get deletedAt => $composableBuilder(
+      column: $table.deletedAt, builder: (column) => ColumnFilters(column));
 }
 
 class $$BodyMetricsTableOrderingComposer
@@ -5295,6 +5666,9 @@ class $$BodyMetricsTableOrderingComposer
 
   ColumnOrderings<int> get updatedAt => $composableBuilder(
       column: $table.updatedAt, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<int> get deletedAt => $composableBuilder(
+      column: $table.deletedAt, builder: (column) => ColumnOrderings(column));
 }
 
 class $$BodyMetricsTableAnnotationComposer
@@ -5323,6 +5697,9 @@ class $$BodyMetricsTableAnnotationComposer
 
   GeneratedColumn<int> get updatedAt =>
       $composableBuilder(column: $table.updatedAt, builder: (column) => column);
+
+  GeneratedColumn<int> get deletedAt =>
+      $composableBuilder(column: $table.deletedAt, builder: (column) => column);
 }
 
 class $$BodyMetricsTableTableManager extends RootTableManager<
@@ -5354,6 +5731,7 @@ class $$BodyMetricsTableTableManager extends RootTableManager<
             Value<double?> bodyFatPercent = const Value.absent(),
             Value<String?> notes = const Value.absent(),
             Value<int> updatedAt = const Value.absent(),
+            Value<int?> deletedAt = const Value.absent(),
             Value<int> rowid = const Value.absent(),
           }) =>
               BodyMetricsCompanion(
@@ -5363,6 +5741,7 @@ class $$BodyMetricsTableTableManager extends RootTableManager<
             bodyFatPercent: bodyFatPercent,
             notes: notes,
             updatedAt: updatedAt,
+            deletedAt: deletedAt,
             rowid: rowid,
           ),
           createCompanionCallback: ({
@@ -5372,6 +5751,7 @@ class $$BodyMetricsTableTableManager extends RootTableManager<
             Value<double?> bodyFatPercent = const Value.absent(),
             Value<String?> notes = const Value.absent(),
             Value<int> updatedAt = const Value.absent(),
+            Value<int?> deletedAt = const Value.absent(),
             Value<int> rowid = const Value.absent(),
           }) =>
               BodyMetricsCompanion.insert(
@@ -5381,6 +5761,7 @@ class $$BodyMetricsTableTableManager extends RootTableManager<
             bodyFatPercent: bodyFatPercent,
             notes: notes,
             updatedAt: updatedAt,
+            deletedAt: deletedAt,
             rowid: rowid,
           ),
           withReferenceMapper: (p0) => p0
@@ -6398,6 +6779,7 @@ typedef $$WorkoutSetsTableCreateCompanionBuilder = WorkoutSetsCompanion
   Value<bool> isWarmUp,
   Value<String?> groupId,
   Value<int> updatedAt,
+  Value<int?> deletedAt,
   Value<int> rowid,
 });
 typedef $$WorkoutSetsTableUpdateCompanionBuilder = WorkoutSetsCompanion
@@ -6413,6 +6795,7 @@ typedef $$WorkoutSetsTableUpdateCompanionBuilder = WorkoutSetsCompanion
   Value<bool> isWarmUp,
   Value<String?> groupId,
   Value<int> updatedAt,
+  Value<int?> deletedAt,
   Value<int> rowid,
 });
 
@@ -6503,6 +6886,9 @@ class $$WorkoutSetsTableFilterComposer
 
   ColumnFilters<int> get updatedAt => $composableBuilder(
       column: $table.updatedAt, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<int> get deletedAt => $composableBuilder(
+      column: $table.deletedAt, builder: (column) => ColumnFilters(column));
 
   $$WorkoutsTableFilterComposer get workoutId {
     final $$WorkoutsTableFilterComposer composer = $composerBuilder(
@@ -6602,6 +6988,9 @@ class $$WorkoutSetsTableOrderingComposer
   ColumnOrderings<int> get updatedAt => $composableBuilder(
       column: $table.updatedAt, builder: (column) => ColumnOrderings(column));
 
+  ColumnOrderings<int> get deletedAt => $composableBuilder(
+      column: $table.deletedAt, builder: (column) => ColumnOrderings(column));
+
   $$WorkoutsTableOrderingComposer get workoutId {
     final $$WorkoutsTableOrderingComposer composer = $composerBuilder(
         composer: this,
@@ -6678,6 +7067,9 @@ class $$WorkoutSetsTableAnnotationComposer
 
   GeneratedColumn<int> get updatedAt =>
       $composableBuilder(column: $table.updatedAt, builder: (column) => column);
+
+  GeneratedColumn<int> get deletedAt =>
+      $composableBuilder(column: $table.deletedAt, builder: (column) => column);
 
   $$WorkoutsTableAnnotationComposer get workoutId {
     final $$WorkoutsTableAnnotationComposer composer = $composerBuilder(
@@ -6776,6 +7168,7 @@ class $$WorkoutSetsTableTableManager extends RootTableManager<
             Value<bool> isWarmUp = const Value.absent(),
             Value<String?> groupId = const Value.absent(),
             Value<int> updatedAt = const Value.absent(),
+            Value<int?> deletedAt = const Value.absent(),
             Value<int> rowid = const Value.absent(),
           }) =>
               WorkoutSetsCompanion(
@@ -6790,6 +7183,7 @@ class $$WorkoutSetsTableTableManager extends RootTableManager<
             isWarmUp: isWarmUp,
             groupId: groupId,
             updatedAt: updatedAt,
+            deletedAt: deletedAt,
             rowid: rowid,
           ),
           createCompanionCallback: ({
@@ -6804,6 +7198,7 @@ class $$WorkoutSetsTableTableManager extends RootTableManager<
             Value<bool> isWarmUp = const Value.absent(),
             Value<String?> groupId = const Value.absent(),
             Value<int> updatedAt = const Value.absent(),
+            Value<int?> deletedAt = const Value.absent(),
             Value<int> rowid = const Value.absent(),
           }) =>
               WorkoutSetsCompanion.insert(
@@ -6818,6 +7213,7 @@ class $$WorkoutSetsTableTableManager extends RootTableManager<
             isWarmUp: isWarmUp,
             groupId: groupId,
             updatedAt: updatedAt,
+            deletedAt: deletedAt,
             rowid: rowid,
           ),
           withReferenceMapper: (p0) => p0
@@ -6916,6 +7312,7 @@ typedef $$CardioSessionsTableCreateCompanionBuilder = CardioSessionsCompanion
   Value<double?> incline,
   Value<int?> avgHeartRate,
   Value<int> updatedAt,
+  Value<int?> deletedAt,
   Value<int> rowid,
 });
 typedef $$CardioSessionsTableUpdateCompanionBuilder = CardioSessionsCompanion
@@ -6928,6 +7325,7 @@ typedef $$CardioSessionsTableUpdateCompanionBuilder = CardioSessionsCompanion
   Value<double?> incline,
   Value<int?> avgHeartRate,
   Value<int> updatedAt,
+  Value<int?> deletedAt,
   Value<int> rowid,
 });
 
@@ -6995,6 +7393,9 @@ class $$CardioSessionsTableFilterComposer
 
   ColumnFilters<int> get updatedAt => $composableBuilder(
       column: $table.updatedAt, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<int> get deletedAt => $composableBuilder(
+      column: $table.deletedAt, builder: (column) => ColumnFilters(column));
 
   $$WorkoutsTableFilterComposer get workoutId {
     final $$WorkoutsTableFilterComposer composer = $composerBuilder(
@@ -7067,6 +7468,9 @@ class $$CardioSessionsTableOrderingComposer
   ColumnOrderings<int> get updatedAt => $composableBuilder(
       column: $table.updatedAt, builder: (column) => ColumnOrderings(column));
 
+  ColumnOrderings<int> get deletedAt => $composableBuilder(
+      column: $table.deletedAt, builder: (column) => ColumnOrderings(column));
+
   $$WorkoutsTableOrderingComposer get workoutId {
     final $$WorkoutsTableOrderingComposer composer = $composerBuilder(
         composer: this,
@@ -7134,6 +7538,9 @@ class $$CardioSessionsTableAnnotationComposer
 
   GeneratedColumn<int> get updatedAt =>
       $composableBuilder(column: $table.updatedAt, builder: (column) => column);
+
+  GeneratedColumn<int> get deletedAt =>
+      $composableBuilder(column: $table.deletedAt, builder: (column) => column);
 
   $$WorkoutsTableAnnotationComposer get workoutId {
     final $$WorkoutsTableAnnotationComposer composer = $composerBuilder(
@@ -7208,6 +7615,7 @@ class $$CardioSessionsTableTableManager extends RootTableManager<
             Value<double?> incline = const Value.absent(),
             Value<int?> avgHeartRate = const Value.absent(),
             Value<int> updatedAt = const Value.absent(),
+            Value<int?> deletedAt = const Value.absent(),
             Value<int> rowid = const Value.absent(),
           }) =>
               CardioSessionsCompanion(
@@ -7219,6 +7627,7 @@ class $$CardioSessionsTableTableManager extends RootTableManager<
             incline: incline,
             avgHeartRate: avgHeartRate,
             updatedAt: updatedAt,
+            deletedAt: deletedAt,
             rowid: rowid,
           ),
           createCompanionCallback: ({
@@ -7230,6 +7639,7 @@ class $$CardioSessionsTableTableManager extends RootTableManager<
             Value<double?> incline = const Value.absent(),
             Value<int?> avgHeartRate = const Value.absent(),
             Value<int> updatedAt = const Value.absent(),
+            Value<int?> deletedAt = const Value.absent(),
             Value<int> rowid = const Value.absent(),
           }) =>
               CardioSessionsCompanion.insert(
@@ -7241,6 +7651,7 @@ class $$CardioSessionsTableTableManager extends RootTableManager<
             incline: incline,
             avgHeartRate: avgHeartRate,
             updatedAt: updatedAt,
+            deletedAt: deletedAt,
             rowid: rowid,
           ),
           withReferenceMapper: (p0) => p0
@@ -7318,6 +7729,7 @@ typedef $$PersonalRecordsTableCreateCompanionBuilder = PersonalRecordsCompanion
   required int achievedAt,
   Value<String?> workoutSetId,
   Value<int> updatedAt,
+  Value<int?> deletedAt,
   Value<int> rowid,
 });
 typedef $$PersonalRecordsTableUpdateCompanionBuilder = PersonalRecordsCompanion
@@ -7329,6 +7741,7 @@ typedef $$PersonalRecordsTableUpdateCompanionBuilder = PersonalRecordsCompanion
   Value<int> achievedAt,
   Value<String?> workoutSetId,
   Value<int> updatedAt,
+  Value<int?> deletedAt,
   Value<int> rowid,
 });
 
@@ -7391,6 +7804,9 @@ class $$PersonalRecordsTableFilterComposer
 
   ColumnFilters<int> get updatedAt => $composableBuilder(
       column: $table.updatedAt, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<int> get deletedAt => $composableBuilder(
+      column: $table.deletedAt, builder: (column) => ColumnFilters(column));
 
   $$ExercisesTableFilterComposer get exerciseId {
     final $$ExercisesTableFilterComposer composer = $composerBuilder(
@@ -7457,6 +7873,9 @@ class $$PersonalRecordsTableOrderingComposer
   ColumnOrderings<int> get updatedAt => $composableBuilder(
       column: $table.updatedAt, builder: (column) => ColumnOrderings(column));
 
+  ColumnOrderings<int> get deletedAt => $composableBuilder(
+      column: $table.deletedAt, builder: (column) => ColumnOrderings(column));
+
   $$ExercisesTableOrderingComposer get exerciseId {
     final $$ExercisesTableOrderingComposer composer = $composerBuilder(
         composer: this,
@@ -7521,6 +7940,9 @@ class $$PersonalRecordsTableAnnotationComposer
 
   GeneratedColumn<int> get updatedAt =>
       $composableBuilder(column: $table.updatedAt, builder: (column) => column);
+
+  GeneratedColumn<int> get deletedAt =>
+      $composableBuilder(column: $table.deletedAt, builder: (column) => column);
 
   $$ExercisesTableAnnotationComposer get exerciseId {
     final $$ExercisesTableAnnotationComposer composer = $composerBuilder(
@@ -7594,6 +8016,7 @@ class $$PersonalRecordsTableTableManager extends RootTableManager<
             Value<int> achievedAt = const Value.absent(),
             Value<String?> workoutSetId = const Value.absent(),
             Value<int> updatedAt = const Value.absent(),
+            Value<int?> deletedAt = const Value.absent(),
             Value<int> rowid = const Value.absent(),
           }) =>
               PersonalRecordsCompanion(
@@ -7604,6 +8027,7 @@ class $$PersonalRecordsTableTableManager extends RootTableManager<
             achievedAt: achievedAt,
             workoutSetId: workoutSetId,
             updatedAt: updatedAt,
+            deletedAt: deletedAt,
             rowid: rowid,
           ),
           createCompanionCallback: ({
@@ -7614,6 +8038,7 @@ class $$PersonalRecordsTableTableManager extends RootTableManager<
             required int achievedAt,
             Value<String?> workoutSetId = const Value.absent(),
             Value<int> updatedAt = const Value.absent(),
+            Value<int?> deletedAt = const Value.absent(),
             Value<int> rowid = const Value.absent(),
           }) =>
               PersonalRecordsCompanion.insert(
@@ -7624,6 +8049,7 @@ class $$PersonalRecordsTableTableManager extends RootTableManager<
             achievedAt: achievedAt,
             workoutSetId: workoutSetId,
             updatedAt: updatedAt,
+            deletedAt: deletedAt,
             rowid: rowid,
           ),
           withReferenceMapper: (p0) => p0
@@ -7700,6 +8126,7 @@ typedef $$WorkoutTemplatesTableCreateCompanionBuilder
   required String name,
   required int createdAt,
   required int updatedAt,
+  Value<int?> deletedAt,
   Value<int> rowid,
 });
 typedef $$WorkoutTemplatesTableUpdateCompanionBuilder
@@ -7708,6 +8135,7 @@ typedef $$WorkoutTemplatesTableUpdateCompanionBuilder
   Value<String> name,
   Value<int> createdAt,
   Value<int> updatedAt,
+  Value<int?> deletedAt,
   Value<int> rowid,
 });
 
@@ -7755,6 +8183,9 @@ class $$WorkoutTemplatesTableFilterComposer
   ColumnFilters<int> get updatedAt => $composableBuilder(
       column: $table.updatedAt, builder: (column) => ColumnFilters(column));
 
+  ColumnFilters<int> get deletedAt => $composableBuilder(
+      column: $table.deletedAt, builder: (column) => ColumnFilters(column));
+
   Expression<bool> templateExercisesRefs(
       Expression<bool> Function($$TemplateExercisesTableFilterComposer f) f) {
     final $$TemplateExercisesTableFilterComposer composer = $composerBuilder(
@@ -7797,6 +8228,9 @@ class $$WorkoutTemplatesTableOrderingComposer
 
   ColumnOrderings<int> get updatedAt => $composableBuilder(
       column: $table.updatedAt, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<int> get deletedAt => $composableBuilder(
+      column: $table.deletedAt, builder: (column) => ColumnOrderings(column));
 }
 
 class $$WorkoutTemplatesTableAnnotationComposer
@@ -7819,6 +8253,9 @@ class $$WorkoutTemplatesTableAnnotationComposer
 
   GeneratedColumn<int> get updatedAt =>
       $composableBuilder(column: $table.updatedAt, builder: (column) => column);
+
+  GeneratedColumn<int> get deletedAt =>
+      $composableBuilder(column: $table.deletedAt, builder: (column) => column);
 
   Expression<T> templateExercisesRefs<T extends Object>(
       Expression<T> Function($$TemplateExercisesTableAnnotationComposer a) f) {
@@ -7871,6 +8308,7 @@ class $$WorkoutTemplatesTableTableManager extends RootTableManager<
             Value<String> name = const Value.absent(),
             Value<int> createdAt = const Value.absent(),
             Value<int> updatedAt = const Value.absent(),
+            Value<int?> deletedAt = const Value.absent(),
             Value<int> rowid = const Value.absent(),
           }) =>
               WorkoutTemplatesCompanion(
@@ -7878,6 +8316,7 @@ class $$WorkoutTemplatesTableTableManager extends RootTableManager<
             name: name,
             createdAt: createdAt,
             updatedAt: updatedAt,
+            deletedAt: deletedAt,
             rowid: rowid,
           ),
           createCompanionCallback: ({
@@ -7885,6 +8324,7 @@ class $$WorkoutTemplatesTableTableManager extends RootTableManager<
             required String name,
             required int createdAt,
             required int updatedAt,
+            Value<int?> deletedAt = const Value.absent(),
             Value<int> rowid = const Value.absent(),
           }) =>
               WorkoutTemplatesCompanion.insert(
@@ -7892,6 +8332,7 @@ class $$WorkoutTemplatesTableTableManager extends RootTableManager<
             name: name,
             createdAt: createdAt,
             updatedAt: updatedAt,
+            deletedAt: deletedAt,
             rowid: rowid,
           ),
           withReferenceMapper: (p0) => p0
@@ -7951,6 +8392,7 @@ typedef $$TemplateExercisesTableCreateCompanionBuilder
   required int targetReps,
   required int orderIndex,
   Value<int> updatedAt,
+  Value<int?> deletedAt,
   Value<int> rowid,
 });
 typedef $$TemplateExercisesTableUpdateCompanionBuilder
@@ -7963,6 +8405,7 @@ typedef $$TemplateExercisesTableUpdateCompanionBuilder
   Value<int> targetReps,
   Value<int> orderIndex,
   Value<int> updatedAt,
+  Value<int?> deletedAt,
   Value<int> rowid,
 });
 
@@ -8029,6 +8472,9 @@ class $$TemplateExercisesTableFilterComposer
 
   ColumnFilters<int> get updatedAt => $composableBuilder(
       column: $table.updatedAt, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<int> get deletedAt => $composableBuilder(
+      column: $table.deletedAt, builder: (column) => ColumnFilters(column));
 
   $$WorkoutTemplatesTableFilterComposer get templateId {
     final $$WorkoutTemplatesTableFilterComposer composer = $composerBuilder(
@@ -8099,6 +8545,9 @@ class $$TemplateExercisesTableOrderingComposer
   ColumnOrderings<int> get updatedAt => $composableBuilder(
       column: $table.updatedAt, builder: (column) => ColumnOrderings(column));
 
+  ColumnOrderings<int> get deletedAt => $composableBuilder(
+      column: $table.deletedAt, builder: (column) => ColumnOrderings(column));
+
   $$WorkoutTemplatesTableOrderingComposer get templateId {
     final $$WorkoutTemplatesTableOrderingComposer composer = $composerBuilder(
         composer: this,
@@ -8166,6 +8615,9 @@ class $$TemplateExercisesTableAnnotationComposer
 
   GeneratedColumn<int> get updatedAt =>
       $composableBuilder(column: $table.updatedAt, builder: (column) => column);
+
+  GeneratedColumn<int> get deletedAt =>
+      $composableBuilder(column: $table.deletedAt, builder: (column) => column);
 
   $$WorkoutTemplatesTableAnnotationComposer get templateId {
     final $$WorkoutTemplatesTableAnnotationComposer composer = $composerBuilder(
@@ -8241,6 +8693,7 @@ class $$TemplateExercisesTableTableManager extends RootTableManager<
             Value<int> targetReps = const Value.absent(),
             Value<int> orderIndex = const Value.absent(),
             Value<int> updatedAt = const Value.absent(),
+            Value<int?> deletedAt = const Value.absent(),
             Value<int> rowid = const Value.absent(),
           }) =>
               TemplateExercisesCompanion(
@@ -8252,6 +8705,7 @@ class $$TemplateExercisesTableTableManager extends RootTableManager<
             targetReps: targetReps,
             orderIndex: orderIndex,
             updatedAt: updatedAt,
+            deletedAt: deletedAt,
             rowid: rowid,
           ),
           createCompanionCallback: ({
@@ -8263,6 +8717,7 @@ class $$TemplateExercisesTableTableManager extends RootTableManager<
             required int targetReps,
             required int orderIndex,
             Value<int> updatedAt = const Value.absent(),
+            Value<int?> deletedAt = const Value.absent(),
             Value<int> rowid = const Value.absent(),
           }) =>
               TemplateExercisesCompanion.insert(
@@ -8274,6 +8729,7 @@ class $$TemplateExercisesTableTableManager extends RootTableManager<
             targetReps: targetReps,
             orderIndex: orderIndex,
             updatedAt: updatedAt,
+            deletedAt: deletedAt,
             rowid: rowid,
           ),
           withReferenceMapper: (p0) => p0
@@ -8351,6 +8807,7 @@ typedef $$ProgrammesTableCreateCompanionBuilder = ProgrammesCompanion Function({
   required int createdAt,
   required int updatedAt,
   Value<int?> startedAt,
+  Value<int?> deletedAt,
   Value<int> rowid,
 });
 typedef $$ProgrammesTableUpdateCompanionBuilder = ProgrammesCompanion Function({
@@ -8360,6 +8817,7 @@ typedef $$ProgrammesTableUpdateCompanionBuilder = ProgrammesCompanion Function({
   Value<int> createdAt,
   Value<int> updatedAt,
   Value<int?> startedAt,
+  Value<int?> deletedAt,
   Value<int> rowid,
 });
 
@@ -8389,6 +8847,9 @@ class $$ProgrammesTableFilterComposer
 
   ColumnFilters<int> get startedAt => $composableBuilder(
       column: $table.startedAt, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<int> get deletedAt => $composableBuilder(
+      column: $table.deletedAt, builder: (column) => ColumnFilters(column));
 }
 
 class $$ProgrammesTableOrderingComposer
@@ -8418,6 +8879,9 @@ class $$ProgrammesTableOrderingComposer
 
   ColumnOrderings<int> get startedAt => $composableBuilder(
       column: $table.startedAt, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<int> get deletedAt => $composableBuilder(
+      column: $table.deletedAt, builder: (column) => ColumnOrderings(column));
 }
 
 class $$ProgrammesTableAnnotationComposer
@@ -8446,6 +8910,9 @@ class $$ProgrammesTableAnnotationComposer
 
   GeneratedColumn<int> get startedAt =>
       $composableBuilder(column: $table.startedAt, builder: (column) => column);
+
+  GeneratedColumn<int> get deletedAt =>
+      $composableBuilder(column: $table.deletedAt, builder: (column) => column);
 }
 
 class $$ProgrammesTableTableManager extends RootTableManager<
@@ -8477,6 +8944,7 @@ class $$ProgrammesTableTableManager extends RootTableManager<
             Value<int> createdAt = const Value.absent(),
             Value<int> updatedAt = const Value.absent(),
             Value<int?> startedAt = const Value.absent(),
+            Value<int?> deletedAt = const Value.absent(),
             Value<int> rowid = const Value.absent(),
           }) =>
               ProgrammesCompanion(
@@ -8486,6 +8954,7 @@ class $$ProgrammesTableTableManager extends RootTableManager<
             createdAt: createdAt,
             updatedAt: updatedAt,
             startedAt: startedAt,
+            deletedAt: deletedAt,
             rowid: rowid,
           ),
           createCompanionCallback: ({
@@ -8495,6 +8964,7 @@ class $$ProgrammesTableTableManager extends RootTableManager<
             required int createdAt,
             required int updatedAt,
             Value<int?> startedAt = const Value.absent(),
+            Value<int?> deletedAt = const Value.absent(),
             Value<int> rowid = const Value.absent(),
           }) =>
               ProgrammesCompanion.insert(
@@ -8504,6 +8974,7 @@ class $$ProgrammesTableTableManager extends RootTableManager<
             createdAt: createdAt,
             updatedAt: updatedAt,
             startedAt: startedAt,
+            deletedAt: deletedAt,
             rowid: rowid,
           ),
           withReferenceMapper: (p0) => p0
@@ -8534,6 +9005,7 @@ typedef $$ProgrammeDaysTableCreateCompanionBuilder = ProgrammeDaysCompanion
   required String templateId,
   required String templateName,
   Value<int> updatedAt,
+  Value<int?> deletedAt,
   Value<int> rowid,
 });
 typedef $$ProgrammeDaysTableUpdateCompanionBuilder = ProgrammeDaysCompanion
@@ -8545,6 +9017,7 @@ typedef $$ProgrammeDaysTableUpdateCompanionBuilder = ProgrammeDaysCompanion
   Value<String> templateId,
   Value<String> templateName,
   Value<int> updatedAt,
+  Value<int?> deletedAt,
   Value<int> rowid,
 });
 
@@ -8577,6 +9050,9 @@ class $$ProgrammeDaysTableFilterComposer
 
   ColumnFilters<int> get updatedAt => $composableBuilder(
       column: $table.updatedAt, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<int> get deletedAt => $composableBuilder(
+      column: $table.deletedAt, builder: (column) => ColumnFilters(column));
 }
 
 class $$ProgrammeDaysTableOrderingComposer
@@ -8609,6 +9085,9 @@ class $$ProgrammeDaysTableOrderingComposer
 
   ColumnOrderings<int> get updatedAt => $composableBuilder(
       column: $table.updatedAt, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<int> get deletedAt => $composableBuilder(
+      column: $table.deletedAt, builder: (column) => ColumnOrderings(column));
 }
 
 class $$ProgrammeDaysTableAnnotationComposer
@@ -8640,6 +9119,9 @@ class $$ProgrammeDaysTableAnnotationComposer
 
   GeneratedColumn<int> get updatedAt =>
       $composableBuilder(column: $table.updatedAt, builder: (column) => column);
+
+  GeneratedColumn<int> get deletedAt =>
+      $composableBuilder(column: $table.deletedAt, builder: (column) => column);
 }
 
 class $$ProgrammeDaysTableTableManager extends RootTableManager<
@@ -8675,6 +9157,7 @@ class $$ProgrammeDaysTableTableManager extends RootTableManager<
             Value<String> templateId = const Value.absent(),
             Value<String> templateName = const Value.absent(),
             Value<int> updatedAt = const Value.absent(),
+            Value<int?> deletedAt = const Value.absent(),
             Value<int> rowid = const Value.absent(),
           }) =>
               ProgrammeDaysCompanion(
@@ -8685,6 +9168,7 @@ class $$ProgrammeDaysTableTableManager extends RootTableManager<
             templateId: templateId,
             templateName: templateName,
             updatedAt: updatedAt,
+            deletedAt: deletedAt,
             rowid: rowid,
           ),
           createCompanionCallback: ({
@@ -8695,6 +9179,7 @@ class $$ProgrammeDaysTableTableManager extends RootTableManager<
             required String templateId,
             required String templateName,
             Value<int> updatedAt = const Value.absent(),
+            Value<int?> deletedAt = const Value.absent(),
             Value<int> rowid = const Value.absent(),
           }) =>
               ProgrammeDaysCompanion.insert(
@@ -8705,6 +9190,7 @@ class $$ProgrammeDaysTableTableManager extends RootTableManager<
             templateId: templateId,
             templateName: templateName,
             updatedAt: updatedAt,
+            deletedAt: deletedAt,
             rowid: rowid,
           ),
           withReferenceMapper: (p0) => p0
@@ -8738,6 +9224,7 @@ typedef $$ProgressionRulesTableCreateCompanionBuilder
   required double value,
   Value<int> frequencyWeeks,
   Value<int> updatedAt,
+  Value<int?> deletedAt,
   Value<int> rowid,
 });
 typedef $$ProgressionRulesTableUpdateCompanionBuilder
@@ -8749,6 +9236,7 @@ typedef $$ProgressionRulesTableUpdateCompanionBuilder
   Value<double> value,
   Value<int> frequencyWeeks,
   Value<int> updatedAt,
+  Value<int?> deletedAt,
   Value<int> rowid,
 });
 
@@ -8782,6 +9270,9 @@ class $$ProgressionRulesTableFilterComposer
 
   ColumnFilters<int> get updatedAt => $composableBuilder(
       column: $table.updatedAt, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<int> get deletedAt => $composableBuilder(
+      column: $table.deletedAt, builder: (column) => ColumnFilters(column));
 }
 
 class $$ProgressionRulesTableOrderingComposer
@@ -8814,6 +9305,9 @@ class $$ProgressionRulesTableOrderingComposer
 
   ColumnOrderings<int> get updatedAt => $composableBuilder(
       column: $table.updatedAt, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<int> get deletedAt => $composableBuilder(
+      column: $table.deletedAt, builder: (column) => ColumnOrderings(column));
 }
 
 class $$ProgressionRulesTableAnnotationComposer
@@ -8845,6 +9339,9 @@ class $$ProgressionRulesTableAnnotationComposer
 
   GeneratedColumn<int> get updatedAt =>
       $composableBuilder(column: $table.updatedAt, builder: (column) => column);
+
+  GeneratedColumn<int> get deletedAt =>
+      $composableBuilder(column: $table.deletedAt, builder: (column) => column);
 }
 
 class $$ProgressionRulesTableTableManager extends RootTableManager<
@@ -8881,6 +9378,7 @@ class $$ProgressionRulesTableTableManager extends RootTableManager<
             Value<double> value = const Value.absent(),
             Value<int> frequencyWeeks = const Value.absent(),
             Value<int> updatedAt = const Value.absent(),
+            Value<int?> deletedAt = const Value.absent(),
             Value<int> rowid = const Value.absent(),
           }) =>
               ProgressionRulesCompanion(
@@ -8891,6 +9389,7 @@ class $$ProgressionRulesTableTableManager extends RootTableManager<
             value: value,
             frequencyWeeks: frequencyWeeks,
             updatedAt: updatedAt,
+            deletedAt: deletedAt,
             rowid: rowid,
           ),
           createCompanionCallback: ({
@@ -8901,6 +9400,7 @@ class $$ProgressionRulesTableTableManager extends RootTableManager<
             required double value,
             Value<int> frequencyWeeks = const Value.absent(),
             Value<int> updatedAt = const Value.absent(),
+            Value<int?> deletedAt = const Value.absent(),
             Value<int> rowid = const Value.absent(),
           }) =>
               ProgressionRulesCompanion.insert(
@@ -8911,6 +9411,7 @@ class $$ProgressionRulesTableTableManager extends RootTableManager<
             value: value,
             frequencyWeeks: frequencyWeeks,
             updatedAt: updatedAt,
+            deletedAt: deletedAt,
             rowid: rowid,
           ),
           withReferenceMapper: (p0) => p0

--- a/lib/core/database/tables/body_metrics_table.dart
+++ b/lib/core/database/tables/body_metrics_table.dart
@@ -7,6 +7,7 @@ class BodyMetrics extends Table {
   RealColumn get bodyFatPercent => real().nullable()();
   TextColumn get notes => text().nullable()();
   IntColumn get updatedAt => integer().withDefault(const Constant(0))();
+  IntColumn get deletedAt => integer().nullable()();
 
   @override
   Set<Column> get primaryKey => {id};

--- a/lib/core/database/tables/cardio_sessions_table.dart
+++ b/lib/core/database/tables/cardio_sessions_table.dart
@@ -11,6 +11,7 @@ class CardioSessions extends Table {
   RealColumn get incline => real().nullable()();
   IntColumn get avgHeartRate => integer().nullable()();
   IntColumn get updatedAt => integer().withDefault(const Constant(0))();
+  IntColumn get deletedAt => integer().nullable()();
 
   @override
   Set<Column> get primaryKey => {id};

--- a/lib/core/database/tables/personal_records_table.dart
+++ b/lib/core/database/tables/personal_records_table.dart
@@ -11,6 +11,7 @@ class PersonalRecords extends Table {
   TextColumn get workoutSetId =>
       text().nullable().references(WorkoutSets, #id)();
   IntColumn get updatedAt => integer().withDefault(const Constant(0))();
+  IntColumn get deletedAt => integer().nullable()();
 
   @override
   Set<Column> get primaryKey => {id};

--- a/lib/core/database/tables/programme_days_table.dart
+++ b/lib/core/database/tables/programme_days_table.dart
@@ -8,6 +8,7 @@ class ProgrammeDays extends Table {
   TextColumn get templateId => text()();
   TextColumn get templateName => text()();
   IntColumn get updatedAt => integer().withDefault(const Constant(0))();
+  IntColumn get deletedAt => integer().nullable()();
 
   @override
   Set<Column> get primaryKey => {id};

--- a/lib/core/database/tables/programmes_table.dart
+++ b/lib/core/database/tables/programmes_table.dart
@@ -10,6 +10,7 @@ class Programmes extends Table {
   /// Epoch ms when the user activated the programme. Null = not yet started.
   /// Used to compute the current week for [Programme.currentWeek].
   IntColumn get startedAt => integer().nullable()();
+  IntColumn get deletedAt => integer().nullable()();
 
   @override
   Set<Column> get primaryKey => {id};

--- a/lib/core/database/tables/progression_rules_table.dart
+++ b/lib/core/database/tables/progression_rules_table.dart
@@ -8,6 +8,7 @@ class ProgressionRules extends Table {
   RealColumn get value => real()();
   IntColumn get frequencyWeeks => integer().withDefault(const Constant(1))();
   IntColumn get updatedAt => integer().withDefault(const Constant(0))();
+  IntColumn get deletedAt => integer().nullable()();
 
   @override
   Set<Column> get primaryKey => {id};

--- a/lib/core/database/tables/template_exercises_table.dart
+++ b/lib/core/database/tables/template_exercises_table.dart
@@ -11,6 +11,7 @@ class TemplateExercises extends Table {
   IntColumn get targetReps => integer()();
   IntColumn get orderIndex => integer()();
   IntColumn get updatedAt => integer().withDefault(const Constant(0))();
+  IntColumn get deletedAt => integer().nullable()();
 
   @override
   Set<Column> get primaryKey => {id};

--- a/lib/core/database/tables/workout_sets_table.dart
+++ b/lib/core/database/tables/workout_sets_table.dart
@@ -19,6 +19,7 @@ class WorkoutSets extends Table {
   BoolColumn get isWarmUp => boolean().withDefault(const Constant(false))();
   TextColumn get groupId => text().nullable()();
   IntColumn get updatedAt => integer().withDefault(const Constant(0))();
+  IntColumn get deletedAt => integer().nullable()();
 
   @override
   Set<Column> get primaryKey => {id};

--- a/lib/core/database/tables/workout_templates_table.dart
+++ b/lib/core/database/tables/workout_templates_table.dart
@@ -5,6 +5,7 @@ class WorkoutTemplates extends Table {
   TextColumn get name => text().withLength(min: 1, max: 200)();
   IntColumn get createdAt => integer()();
   IntColumn get updatedAt => integer()();
+  IntColumn get deletedAt => integer().nullable()();
 
   @override
   Set<Column> get primaryKey => {id};

--- a/lib/features/body_metrics/data/drift_body_metric_repository.dart
+++ b/lib/features/body_metrics/data/drift_body_metric_repository.dart
@@ -35,6 +35,7 @@ class DriftBodyMetricRepository implements BodyMetricRepository {
         bodyFatPercent: Value(metric.bodyFatPercent),
         notes: Value(metric.notes),
         updatedAt: Value(dateTimeToEpochMs(metric.updatedAt)),
+        deletedAt: Value(nullableDateTimeToEpochMs(metric.deletedAt)),
       ),
     );
     return metric;
@@ -42,12 +43,19 @@ class DriftBodyMetricRepository implements BodyMetricRepository {
 
   @override
   Future<void> delete(String id) async {
-    await (_db.delete(_db.bodyMetrics)..where((t) => t.id.equals(id))).go();
+    final now = dateTimeToEpochMs(DateTime.now().toUtc());
+    await (_db.update(_db.bodyMetrics)..where((t) => t.id.equals(id))).write(
+      db.BodyMetricsCompanion(
+        deletedAt: Value(now),
+        updatedAt: Value(now),
+      ),
+    );
   }
 
   @override
   Future<List<BodyMetric>> getAll({int limit = 100}) async {
     final q = _db.select(_db.bodyMetrics)
+      ..where((t) => t.deletedAt.isNull())
       ..orderBy([(t) => OrderingTerm.desc(t.date)])
       ..limit(limit);
     final rows = await q.get();
@@ -57,6 +65,7 @@ class DriftBodyMetricRepository implements BodyMetricRepository {
   @override
   Future<BodyMetric?> getLatest() async {
     final q = _db.select(_db.bodyMetrics)
+      ..where((t) => t.deletedAt.isNull())
       ..orderBy([(t) => OrderingTerm.desc(t.date)])
       ..limit(1);
     final row = await q.getSingleOrNull();
@@ -66,6 +75,7 @@ class DriftBodyMetricRepository implements BodyMetricRepository {
   @override
   Stream<List<BodyMetric>> watchAll() {
     final q = _db.select(_db.bodyMetrics)
+      ..where((t) => t.deletedAt.isNull())
       ..orderBy([(t) => OrderingTerm.desc(t.date)]);
     return q.watch().map((rows) => rows.map(_toDomain).toList());
   }
@@ -78,6 +88,7 @@ class DriftBodyMetricRepository implements BodyMetricRepository {
       bodyFatPercent: row.bodyFatPercent,
       notes: row.notes,
       updatedAt: dateTimeFromEpochMs(row.updatedAt),
+      deletedAt: nullableDateTimeFromEpochMs(row.deletedAt),
     );
   }
 }

--- a/lib/features/body_metrics/domain/models/body_metric.dart
+++ b/lib/features/body_metrics/domain/models/body_metric.dart
@@ -7,6 +7,7 @@ class BodyMetric {
   final double? bodyFatPercent;
   final String? notes;
   final DateTime updatedAt;
+  final DateTime? deletedAt;
 
   const BodyMetric({
     required this.id,
@@ -15,7 +16,10 @@ class BodyMetric {
     this.bodyFatPercent,
     this.notes,
     required this.updatedAt,
+    this.deletedAt,
   });
+
+  bool get isDeleted => deletedAt != null;
 
   BodyMetric copyWith({
     String? id,
@@ -26,6 +30,7 @@ class BodyMetric {
     bool clearBodyFat = false,
     bool clearNotes = false,
     DateTime? updatedAt,
+    DateTime? deletedAt,
   }) {
     return BodyMetric(
       id: id ?? this.id,
@@ -35,6 +40,7 @@ class BodyMetric {
           clearBodyFat ? null : (bodyFatPercent ?? this.bodyFatPercent),
       notes: clearNotes ? null : (notes ?? this.notes),
       updatedAt: updatedAt ?? this.updatedAt,
+      deletedAt: deletedAt ?? this.deletedAt,
     );
   }
 

--- a/lib/features/cardio/data/drift_cardio_session_repository.dart
+++ b/lib/features/cardio/data/drift_cardio_session_repository.dart
@@ -29,7 +29,8 @@ class DriftCardioSessionRepository implements CardioSessionRepository {
 
   @override
   Future<CardioSession?> getSession(String id) async {
-    final q = _db.select(_db.cardioSessions)..where((t) => t.id.equals(id));
+    final q = _db.select(_db.cardioSessions)
+      ..where((t) => t.id.equals(id) & t.deletedAt.isNull());
     final row = await q.getSingleOrNull();
     return row == null ? null : _toDomain(row);
   }
@@ -37,7 +38,7 @@ class DriftCardioSessionRepository implements CardioSessionRepository {
   @override
   Future<List<CardioSession>> getSessionsForWorkout(String workoutId) async {
     final q = _db.select(_db.cardioSessions)
-      ..where((t) => t.workoutId.equals(workoutId));
+      ..where((t) => t.workoutId.equals(workoutId) & t.deletedAt.isNull());
     final rows = await q.get();
     return rows.map(_toDomain).toList();
   }
@@ -48,7 +49,7 @@ class DriftCardioSessionRepository implements CardioSessionRepository {
     int limit = 50,
   }) async {
     final q = _db.select(_db.cardioSessions)
-      ..where((t) => t.exerciseId.equals(exerciseId))
+      ..where((t) => t.exerciseId.equals(exerciseId) & t.deletedAt.isNull())
       ..limit(limit);
     final rows = await q.get();
     return rows.map(_toDomain).toList();
@@ -56,7 +57,9 @@ class DriftCardioSessionRepository implements CardioSessionRepository {
 
   @override
   Future<List<CardioSession>> getAllSessions() async {
-    final rows = await _db.select(_db.cardioSessions).get();
+    final q = _db.select(_db.cardioSessions)
+      ..where((t) => t.deletedAt.isNull());
+    final rows = await q.get();
     return rows.map(_toDomain).toList();
   }
 
@@ -68,7 +71,8 @@ class DriftCardioSessionRepository implements CardioSessionRepository {
         _db.workouts.id.equalsExp(_db.cardioSessions.workoutId),
       ),
     ])
-      ..where(_db.cardioSessions.exerciseId.equals(exerciseId))
+      ..where(_db.cardioSessions.exerciseId.equals(exerciseId) &
+          _db.cardioSessions.deletedAt.isNull())
       ..orderBy([OrderingTerm.desc(_db.workouts.startedAt)])
       ..limit(1);
     final rows = await q.get();
@@ -78,13 +82,18 @@ class DriftCardioSessionRepository implements CardioSessionRepository {
 
   @override
   Future<void> deleteSession(String id) async {
-    await (_db.delete(_db.cardioSessions)..where((t) => t.id.equals(id))).go();
+    final now = dateTimeToEpochMs(DateTime.now().toUtc());
+    await (_db.update(_db.cardioSessions)..where((t) => t.id.equals(id)))
+        .write(db.CardioSessionsCompanion(
+      deletedAt: Value(now),
+      updatedAt: Value(now),
+    ));
   }
 
   @override
   Stream<List<CardioSession>> watchSessionsForWorkout(String workoutId) {
     final q = _db.select(_db.cardioSessions)
-      ..where((t) => t.workoutId.equals(workoutId));
+      ..where((t) => t.workoutId.equals(workoutId) & t.deletedAt.isNull());
     return q.watch().map((rows) => rows.map(_toDomain).toList());
   }
 
@@ -98,6 +107,7 @@ class DriftCardioSessionRepository implements CardioSessionRepository {
       incline: row.incline,
       avgHeartRate: row.avgHeartRate,
       updatedAt: dateTimeFromEpochMs(row.updatedAt),
+      deletedAt: nullableDateTimeFromEpochMs(row.deletedAt),
     );
   }
 }

--- a/lib/features/cardio/domain/models/cardio_session.dart
+++ b/lib/features/cardio/domain/models/cardio_session.dart
@@ -9,6 +9,7 @@ class CardioSession {
   final double? incline;
   final int? avgHeartRate;
   final DateTime updatedAt;
+  final DateTime? deletedAt;
 
   const CardioSession({
     required this.id,
@@ -19,7 +20,10 @@ class CardioSession {
     this.incline,
     this.avgHeartRate,
     required this.updatedAt,
+    this.deletedAt,
   });
+
+  bool get isDeleted => deletedAt != null;
 
   Duration get duration => Duration(seconds: durationSeconds);
 

--- a/lib/features/history/data/drift_personal_record_repository.dart
+++ b/lib/features/history/data/drift_personal_record_repository.dart
@@ -33,7 +33,7 @@ class DriftPersonalRecordRepository implements PersonalRecordRepository {
   }) async {
     final q = _db.select(_db.personalRecords)
       ..where((t) {
-        var cond = t.exerciseId.equals(exerciseId);
+        var cond = t.exerciseId.equals(exerciseId) & t.deletedAt.isNull();
         if (recordType != null) {
           cond = cond & t.recordType.equals(recordType.name);
         }
@@ -53,7 +53,8 @@ class DriftPersonalRecordRepository implements PersonalRecordRepository {
       ..where(
         (t) =>
             t.exerciseId.equals(exerciseId) &
-            t.recordType.equals(recordType.name),
+            t.recordType.equals(recordType.name) &
+            t.deletedAt.isNull(),
       )
       ..orderBy([(t) => OrderingTerm.desc(t.value)])
       ..limit(1);
@@ -64,6 +65,7 @@ class DriftPersonalRecordRepository implements PersonalRecordRepository {
   @override
   Future<List<PersonalRecord>> getAllRecords({int limit = 50}) async {
     final q = _db.select(_db.personalRecords)
+      ..where((t) => t.deletedAt.isNull())
       ..orderBy([(t) => OrderingTerm.desc(t.achievedAt)])
       ..limit(limit);
     final rows = await q.get();
@@ -73,7 +75,7 @@ class DriftPersonalRecordRepository implements PersonalRecordRepository {
   @override
   Stream<List<PersonalRecord>> watchRecordsForExercise(String exerciseId) {
     final q = _db.select(_db.personalRecords)
-      ..where((t) => t.exerciseId.equals(exerciseId))
+      ..where((t) => t.exerciseId.equals(exerciseId) & t.deletedAt.isNull())
       ..orderBy([(t) => OrderingTerm.desc(t.achievedAt)]);
     return q.watch().map((rows) => rows.map(_toDomain).toList());
   }
@@ -87,6 +89,7 @@ class DriftPersonalRecordRepository implements PersonalRecordRepository {
       achievedAt: dateTimeFromEpochMs(row.achievedAt),
       workoutSetId: row.workoutSetId,
       updatedAt: dateTimeFromEpochMs(row.updatedAt),
+      deletedAt: nullableDateTimeFromEpochMs(row.deletedAt),
     );
   }
 }

--- a/lib/features/history/domain/models/personal_record.dart
+++ b/lib/features/history/domain/models/personal_record.dart
@@ -15,6 +15,7 @@ class PersonalRecord {
   final DateTime achievedAt;
   final String? workoutSetId;
   final DateTime updatedAt;
+  final DateTime? deletedAt;
 
   const PersonalRecord({
     required this.id,
@@ -24,7 +25,10 @@ class PersonalRecord {
     required this.achievedAt,
     this.workoutSetId,
     required this.updatedAt,
+    this.deletedAt,
   });
+
+  bool get isDeleted => deletedAt != null;
 
   static PersonalRecord create({
     required String exerciseId,

--- a/lib/features/history/presentation/screens/workout_detail_screen.dart
+++ b/lib/features/history/presentation/screens/workout_detail_screen.dart
@@ -183,8 +183,8 @@ class _StretchingCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final s = S.of(context)!;
-    final timedSessions = sessions
-        .where((sn) => sn.entryMethod != StretchingEntryMethod.untimed);
+    final timedSessions =
+        sessions.where((sn) => sn.entryMethod != StretchingEntryMethod.untimed);
     final totalSeconds =
         timedSessions.fold<int>(0, (sum, sn) => sum + sn.durationSeconds);
     final totalMinutes = (totalSeconds / 60).round();
@@ -246,10 +246,10 @@ class _StretchingCard extends StatelessWidget {
                         fontFeatures: const [
                           FontFeature.tabularFigures(),
                         ],
-                        color: session.entryMethod ==
-                                StretchingEntryMethod.untimed
-                            ? Theme.of(context).colorScheme.onSurfaceVariant
-                            : null,
+                        color:
+                            session.entryMethod == StretchingEntryMethod.untimed
+                                ? Theme.of(context).colorScheme.onSurfaceVariant
+                                : null,
                       ),
                     ),
                   ],

--- a/lib/features/programmes/data/drift_programme_repository.dart
+++ b/lib/features/programmes/data/drift_programme_repository.dart
@@ -29,7 +29,8 @@ class DriftProgrammeRepository implements ProgrammeRepository {
 
   @override
   Future<Programme?> getProgramme(String id) async {
-    final q = _db.select(_db.programmes)..where((t) => t.id.equals(id));
+    final q = _db.select(_db.programmes)
+      ..where((t) => t.id.equals(id) & t.deletedAt.isNull());
     final row = await q.getSingleOrNull();
     if (row == null) return null;
 
@@ -41,6 +42,7 @@ class DriftProgrammeRepository implements ProgrammeRepository {
   @override
   Future<List<Programme>> getAllProgrammes() async {
     final q = _db.select(_db.programmes)
+      ..where((t) => t.deletedAt.isNull())
       ..orderBy([(t) => OrderingTerm.desc(t.createdAt)]);
     final rows = await q.get();
     return Future.wait(rows.map((row) async {
@@ -83,20 +85,37 @@ class DriftProgrammeRepository implements ProgrammeRepository {
 
   @override
   Future<void> deleteProgramme(String id) async {
+    final nowMs = dateTimeToEpochMs(DateTime.now().toUtc());
     await _db.transaction(() async {
-      await (_db.delete(_db.programmeDays)
-            ..where((t) => t.programmeId.equals(id)))
-          .go();
-      await (_db.delete(_db.progressionRules)
-            ..where((t) => t.programmeId.equals(id)))
-          .go();
-      await (_db.delete(_db.programmes)..where((t) => t.id.equals(id))).go();
+      await (_db.update(_db.programmeDays)
+            ..where(
+              (t) => t.programmeId.equals(id) & t.deletedAt.isNull(),
+            ))
+          .write(db.ProgrammeDaysCompanion(
+        deletedAt: Value(nowMs),
+        updatedAt: Value(nowMs),
+      ));
+      await (_db.update(_db.progressionRules)
+            ..where(
+              (t) => t.programmeId.equals(id) & t.deletedAt.isNull(),
+            ))
+          .write(db.ProgressionRulesCompanion(
+        deletedAt: Value(nowMs),
+        updatedAt: Value(nowMs),
+      ));
+      await (_db.update(_db.programmes)..where((t) => t.id.equals(id))).write(
+        db.ProgrammesCompanion(
+          deletedAt: Value(nowMs),
+          updatedAt: Value(nowMs),
+        ),
+      );
     });
   }
 
   @override
   Stream<List<Programme>> watchAllProgrammes() {
     final q = _db.select(_db.programmes)
+      ..where((t) => t.deletedAt.isNull())
       ..orderBy([(t) => OrderingTerm.desc(t.createdAt)]);
     return q.watch().asyncMap((rows) async {
       return Future.wait(rows.map((row) async {
@@ -124,8 +143,12 @@ class DriftProgrammeRepository implements ProgrammeRepository {
 
   @override
   Future<void> removeDay(String dayId) async {
-    await (_db.delete(_db.programmeDays)..where((t) => t.id.equals(dayId)))
-        .go();
+    final now = dateTimeToEpochMs(DateTime.now().toUtc());
+    await (_db.update(_db.programmeDays)..where((t) => t.id.equals(dayId)))
+        .write(db.ProgrammeDaysCompanion(
+      deletedAt: Value(now),
+      updatedAt: Value(now),
+    ));
   }
 
   @override
@@ -150,8 +173,12 @@ class DriftProgrammeRepository implements ProgrammeRepository {
 
   @override
   Future<void> removeRule(String ruleId) async {
-    await (_db.delete(_db.progressionRules)..where((t) => t.id.equals(ruleId)))
-        .go();
+    final now = dateTimeToEpochMs(DateTime.now().toUtc());
+    await (_db.update(_db.progressionRules)..where((t) => t.id.equals(ruleId)))
+        .write(db.ProgressionRulesCompanion(
+      deletedAt: Value(now),
+      updatedAt: Value(now),
+    ));
   }
 
   @override
@@ -169,7 +196,9 @@ class DriftProgrammeRepository implements ProgrammeRepository {
     String programmeId,
   ) async {
     final q = _db.select(_db.programmeDays)
-      ..where((t) => t.programmeId.equals(programmeId))
+      ..where(
+        (t) => t.programmeId.equals(programmeId) & t.deletedAt.isNull(),
+      )
       ..orderBy([
         (t) => OrderingTerm.asc(t.weekNumber),
         (t) => OrderingTerm.asc(t.dayOfWeek),
@@ -182,7 +211,9 @@ class DriftProgrammeRepository implements ProgrammeRepository {
     String programmeId,
   ) async {
     final q = _db.select(_db.progressionRules)
-      ..where((t) => t.programmeId.equals(programmeId));
+      ..where(
+        (t) => t.programmeId.equals(programmeId) & t.deletedAt.isNull(),
+      );
     final rows = await q.get();
     return rows.map(_ruleToDomain).toList();
   }
@@ -200,6 +231,7 @@ class DriftProgrammeRepository implements ProgrammeRepository {
       updatedAt: dateTimeFromEpochMs(row.updatedAt),
       startedAt:
           row.startedAt == null ? null : dateTimeFromEpochMs(row.startedAt!),
+      deletedAt: nullableDateTimeFromEpochMs(row.deletedAt),
       days: days,
       rules: rules,
     );
@@ -214,6 +246,7 @@ class DriftProgrammeRepository implements ProgrammeRepository {
       templateId: row.templateId,
       templateName: row.templateName,
       updatedAt: dateTimeFromEpochMs(row.updatedAt),
+      deletedAt: nullableDateTimeFromEpochMs(row.deletedAt),
     );
   }
 
@@ -226,6 +259,7 @@ class DriftProgrammeRepository implements ProgrammeRepository {
       value: row.value,
       frequencyWeeks: row.frequencyWeeks,
       updatedAt: dateTimeFromEpochMs(row.updatedAt),
+      deletedAt: nullableDateTimeFromEpochMs(row.deletedAt),
     );
   }
 }

--- a/lib/features/programmes/domain/models/programme.dart
+++ b/lib/features/programmes/domain/models/programme.dart
@@ -16,6 +16,7 @@ class Programme {
   /// When the user pressed "Start programme". Null until they start.
   /// Used to compute [currentWeek] so multi-week programmes advance.
   final DateTime? startedAt;
+  final DateTime? deletedAt;
   final List<ProgrammeDay> days;
   final List<ProgressionRule> rules;
 
@@ -26,9 +27,12 @@ class Programme {
     required this.createdAt,
     required this.updatedAt,
     this.startedAt,
+    this.deletedAt,
     this.days = const [],
     this.rules = const [],
   });
+
+  bool get isDeleted => deletedAt != null;
 
   /// 1-based current week of the programme, clamped to [1, durationWeeks].
   /// Returns 1 if the programme has not been started yet.
@@ -61,6 +65,7 @@ class Programme {
     DateTime? updatedAt,
     DateTime? startedAt,
     bool clearStartedAt = false,
+    DateTime? deletedAt,
     List<ProgrammeDay>? days,
     List<ProgressionRule>? rules,
   }) {
@@ -71,6 +76,7 @@ class Programme {
       createdAt: createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
       startedAt: clearStartedAt ? null : (startedAt ?? this.startedAt),
+      deletedAt: deletedAt ?? this.deletedAt,
       days: days ?? this.days,
       rules: rules ?? this.rules,
     );
@@ -93,6 +99,7 @@ class ProgrammeDay {
   final String templateId;
   final String templateName;
   final DateTime updatedAt;
+  final DateTime? deletedAt;
 
   const ProgrammeDay({
     required this.id,
@@ -102,7 +109,10 @@ class ProgrammeDay {
     required this.templateId,
     required this.templateName,
     required this.updatedAt,
+    this.deletedAt,
   });
+
+  bool get isDeleted => deletedAt != null;
 
   static ProgrammeDay create({
     required String programmeId,
@@ -128,6 +138,7 @@ class ProgrammeDay {
     String? templateId,
     String? templateName,
     DateTime? updatedAt,
+    DateTime? deletedAt,
   }) {
     return ProgrammeDay(
       id: id,
@@ -137,6 +148,7 @@ class ProgrammeDay {
       templateId: templateId ?? this.templateId,
       templateName: templateName ?? this.templateName,
       updatedAt: updatedAt ?? this.updatedAt,
+      deletedAt: deletedAt ?? this.deletedAt,
     );
   }
 
@@ -159,6 +171,7 @@ class ProgressionRule {
   final double value;
   final int frequencyWeeks;
   final DateTime updatedAt;
+  final DateTime? deletedAt;
 
   const ProgressionRule({
     required this.id,
@@ -168,7 +181,10 @@ class ProgressionRule {
     required this.value,
     this.frequencyWeeks = 1,
     required this.updatedAt,
+    this.deletedAt,
   });
+
+  bool get isDeleted => deletedAt != null;
 
   static ProgressionRule create({
     required String programmeId,

--- a/lib/features/stretching/presentation/widgets/stretching_section.dart
+++ b/lib/features/stretching/presentation/widgets/stretching_section.dart
@@ -29,8 +29,8 @@ class StretchingSection extends ConsumerWidget {
 
     // Untimed entries are excluded from the minute total — by definition
     // they have no recorded duration.
-    final timedSessions = sessions
-        .where((sn) => sn.entryMethod != StretchingEntryMethod.untimed);
+    final timedSessions =
+        sessions.where((sn) => sn.entryMethod != StretchingEntryMethod.untimed);
     final totalSeconds =
         timedSessions.fold<int>(0, (sum, sn) => sum + sn.durationSeconds);
     final totalMinutes = (totalSeconds / 60).round();

--- a/lib/features/sync/application/sync_orchestrator.dart
+++ b/lib/features/sync/application/sync_orchestrator.dart
@@ -5,7 +5,9 @@ import 'package:connectivity_plus/connectivity_plus.dart';
 import '../../../core/database/app_database.dart';
 import '../data/sync_snapshot_serialiser.dart';
 import '../domain/models/sync_result.dart';
+import '../domain/models/sync_snapshot.dart';
 import '../domain/sync_merge_engine.dart';
+import '../domain/sync_schema_version_exception.dart';
 import '../domain/sync_service.dart';
 
 class SyncOrchestrator {
@@ -56,20 +58,35 @@ class SyncOrchestrator {
       // 3. Download remote snapshot (null on first sync)
       final remoteJson = await _cloudService.downloadSnapshot();
 
-      // 4. Merge local + remote
-      final merged = remoteJson != null
-          ? _mergeEngine.merge(
-              local: localSnapshot,
-              remote: _serialiser.fromJson(remoteJson),
-            )
-          : localSnapshot;
+      // 4. Merge local + remote.
+      //
+      // fromJson can throw SyncSchemaVersionException when the remote
+      // snapshot was created by a newer client; surface that as a typed
+      // failure so the UI can display upgrade copy.
+      final SyncSnapshot merged;
+      try {
+        merged = remoteJson != null
+            ? _mergeEngine.merge(
+                local: localSnapshot,
+                remote: _serialiser.fromJson(remoteJson),
+              )
+            : localSnapshot;
+      } on SyncSchemaVersionException catch (e) {
+        return SyncResult.error(e.message);
+      }
 
-      // 5. Apply merged result to local DB
-      await _serialiser.applyToDatabase(_database, merged);
-
-      // 6. Upload merged snapshot to cloud
+      // 5. Upload merged snapshot to cloud FIRST.
+      //
+      // Upload-first makes cloud the source of truth: if the upload
+      // throws (network blip), the local DB stays untouched and a retry
+      // can compose a fresh merge. The previous order — apply-then-upload
+      // — left local ahead of cloud after a failed upload, which let the
+      // next syncing device overwrite the unrelayed work.
       final mergedJson = _serialiser.toJson(merged);
       await _cloudService.uploadSnapshot(mergedJson);
+
+      // 6. Apply merged result to local DB (only after upload succeeds).
+      await _serialiser.applyToDatabase(_database, merged);
 
       final totalEntities = merged.exercises.length +
           merged.workouts.length +
@@ -81,7 +98,8 @@ class SyncOrchestrator {
           merged.bodyMetrics.length +
           merged.programmes.length +
           merged.programmeDays.length +
-          merged.progressionRules.length;
+          merged.progressionRules.length +
+          merged.stretchingSessions.length;
 
       return SyncResult.success(entitiesMerged: totalEntities);
     } on Exception catch (e) {

--- a/lib/features/sync/data/sync_snapshot_serialiser.dart
+++ b/lib/features/sync/data/sync_snapshot_serialiser.dart
@@ -9,10 +9,12 @@ import '../../cardio/domain/models/cardio_session.dart';
 import '../../exercises/domain/models/exercise.dart';
 import '../../history/domain/models/personal_record.dart';
 import '../../programmes/domain/models/programme.dart';
+import '../../stretching/domain/models/stretching_session.dart';
 import '../../templates/domain/models/workout_template.dart';
 import '../../workout/domain/models/workout.dart';
 import '../../workout/domain/models/workout_set.dart';
 import '../domain/models/sync_snapshot.dart';
+import '../domain/sync_schema_version_exception.dart';
 
 class SyncSnapshotSerialiser {
   /// Read all data from the database, including soft-deleted rows.
@@ -48,6 +50,7 @@ class SyncSnapshotSerialiser {
               name: row.name,
               createdAt: dateTimeFromEpochMs(row.createdAt),
               updatedAt: dateTimeFromEpochMs(row.updatedAt),
+              deletedAt: nullableDateTimeFromEpochMs(row.deletedAt),
             ))
         .toList();
 
@@ -71,6 +74,7 @@ class SyncSnapshotSerialiser {
               startedAt: row.startedAt == null
                   ? null
                   : dateTimeFromEpochMs(row.startedAt!),
+              deletedAt: nullableDateTimeFromEpochMs(row.deletedAt),
             ))
         .toList();
 
@@ -82,10 +86,15 @@ class SyncSnapshotSerialiser {
     final ruleRows = await database.select(database.progressionRules).get();
     final progressionRules = ruleRows.map(_progressionRuleToDomain).toList();
 
+    // Stretching sessions — include soft-deleted (no WHERE filter)
+    final stretchingRows =
+        await database.select(database.stretchingSessions).get();
+    final stretchingSessions = stretchingRows.map(_stretchingToDomain).toList();
+
     return SyncSnapshot(
       snapshotAt: DateTime.now().toUtc(),
       deviceId: deviceId,
-      schemaVersion: 7,
+      schemaVersion: db.AppDatabase.schemaVersionConst,
       exercises: exercises,
       workouts: workouts,
       workoutSets: workoutSets,
@@ -97,6 +106,7 @@ class SyncSnapshotSerialiser {
       programmes: programmes,
       programmeDays: programmeDays,
       progressionRules: progressionRules,
+      stretchingSessions: stretchingSessions,
     );
   }
 
@@ -121,16 +131,29 @@ class SyncSnapshotSerialiser {
       'programmeDays': snapshot.programmeDays.map(_programmeDayToMap).toList(),
       'progressionRules':
           snapshot.progressionRules.map(_progressionRuleToMap).toList(),
+      'stretchingSessions':
+          snapshot.stretchingSessions.map(_stretchingToMap).toList(),
     };
     return jsonEncode(data);
   }
 
   SyncSnapshot fromJson(String jsonString) {
     final data = jsonDecode(jsonString) as Map<String, dynamic>;
+    final remoteSchema = data['schemaVersion'] as int? ?? 0;
+    if (remoteSchema > db.AppDatabase.schemaVersionConst) {
+      // Refuse to merge: an older client would silently drop fields it
+      // doesn't recognise and re-upload a degraded blob.
+      throw SyncSchemaVersionException.tooNew(
+        remoteSchema,
+        db.AppDatabase.schemaVersionConst,
+      );
+    }
+    // remoteSchema < local is accepted: per-field readers are null-safe and
+    // missing keys produce empty lists via _mapList.
     return SyncSnapshot(
       snapshotAt: DateTime.parse(data['snapshotAt'] as String),
       deviceId: data['deviceId'] as String,
-      schemaVersion: data['schemaVersion'] as int,
+      schemaVersion: remoteSchema,
       exercises: _mapList(data['exercises'], _exerciseFromMap),
       workouts: _mapList(data['workouts'], _workoutFromMap),
       workoutSets: _mapList(data['workoutSets'], _setFromMap),
@@ -146,6 +169,8 @@ class SyncSnapshotSerialiser {
       programmeDays: _mapList(data['programmeDays'], _programmeDayFromMap),
       progressionRules:
           _mapList(data['progressionRules'], _progressionRuleFromMap),
+      stretchingSessions:
+          _mapList(data['stretchingSessions'], _stretchingFromMap),
     );
   }
 
@@ -199,6 +224,7 @@ class SyncSnapshotSerialiser {
                 isWarmUp: Value(s.isWarmUp),
                 groupId: Value(s.groupId),
                 updatedAt: Value(dateTimeToEpochMs(s.updatedAt)),
+                deletedAt: Value(nullableDateTimeToEpochMs(s.deletedAt)),
               ),
             );
       }
@@ -214,6 +240,7 @@ class SyncSnapshotSerialiser {
                 incline: Value(c.incline),
                 avgHeartRate: Value(c.avgHeartRate),
                 updatedAt: Value(dateTimeToEpochMs(c.updatedAt)),
+                deletedAt: Value(nullableDateTimeToEpochMs(c.deletedAt)),
               ),
             );
       }
@@ -228,6 +255,7 @@ class SyncSnapshotSerialiser {
                 achievedAt: dateTimeToEpochMs(pr.achievedAt),
                 workoutSetId: Value(pr.workoutSetId),
                 updatedAt: Value(dateTimeToEpochMs(pr.updatedAt)),
+                deletedAt: Value(nullableDateTimeToEpochMs(pr.deletedAt)),
               ),
             );
       }
@@ -239,6 +267,7 @@ class SyncSnapshotSerialiser {
                 name: t.name,
                 createdAt: dateTimeToEpochMs(t.createdAt),
                 updatedAt: dateTimeToEpochMs(t.updatedAt),
+                deletedAt: Value(nullableDateTimeToEpochMs(t.deletedAt)),
               ),
             );
       }
@@ -254,6 +283,7 @@ class SyncSnapshotSerialiser {
                 targetReps: te.targetReps,
                 orderIndex: te.orderIndex,
                 updatedAt: Value(dateTimeToEpochMs(te.updatedAt)),
+                deletedAt: Value(nullableDateTimeToEpochMs(te.deletedAt)),
               ),
             );
       }
@@ -267,6 +297,7 @@ class SyncSnapshotSerialiser {
                 bodyFatPercent: Value(bm.bodyFatPercent),
                 notes: Value(bm.notes),
                 updatedAt: Value(dateTimeToEpochMs(bm.updatedAt)),
+                deletedAt: Value(nullableDateTimeToEpochMs(bm.deletedAt)),
               ),
             );
       }
@@ -282,6 +313,7 @@ class SyncSnapshotSerialiser {
                 startedAt: Value(p.startedAt == null
                     ? null
                     : dateTimeToEpochMs(p.startedAt!)),
+                deletedAt: Value(nullableDateTimeToEpochMs(p.deletedAt)),
               ),
             );
       }
@@ -296,6 +328,7 @@ class SyncSnapshotSerialiser {
                 templateId: d.templateId,
                 templateName: d.templateName,
                 updatedAt: Value(dateTimeToEpochMs(d.updatedAt)),
+                deletedAt: Value(nullableDateTimeToEpochMs(d.deletedAt)),
               ),
             );
       }
@@ -310,6 +343,27 @@ class SyncSnapshotSerialiser {
                 value: r.value,
                 frequencyWeeks: Value(r.frequencyWeeks),
                 updatedAt: Value(dateTimeToEpochMs(r.updatedAt)),
+                deletedAt: Value(nullableDateTimeToEpochMs(r.deletedAt)),
+              ),
+            );
+      }
+
+      for (final s in snapshot.stretchingSessions) {
+        await database.into(database.stretchingSessions).insertOnConflictUpdate(
+              db.StretchingSessionsCompanion.insert(
+                id: s.id,
+                workoutId: s.workoutId,
+                type: s.type,
+                customName: Value(s.customName),
+                bodyArea: Value(s.bodyArea?.name),
+                side: Value(s.side?.name),
+                durationSeconds: s.durationSeconds,
+                startedAt: Value(nullableDateTimeToEpochMs(s.startedAt)),
+                endedAt: Value(nullableDateTimeToEpochMs(s.endedAt)),
+                entryMethod: s.entryMethod.name,
+                notes: Value(s.notes),
+                updatedAt: Value(dateTimeToEpochMs(s.updatedAt)),
+                deletedAt: Value(nullableDateTimeToEpochMs(s.deletedAt)),
               ),
             );
       }
@@ -364,6 +418,7 @@ class SyncSnapshotSerialiser {
         isWarmUp: row.isWarmUp,
         groupId: row.groupId,
         updatedAt: dateTimeFromEpochMs(row.updatedAt),
+        deletedAt: nullableDateTimeFromEpochMs(row.deletedAt),
       );
 
   CardioSession _cardioToDomain(db.CardioSession row) => CardioSession(
@@ -375,6 +430,7 @@ class SyncSnapshotSerialiser {
         incline: row.incline,
         avgHeartRate: row.avgHeartRate,
         updatedAt: dateTimeFromEpochMs(row.updatedAt),
+        deletedAt: nullableDateTimeFromEpochMs(row.deletedAt),
       );
 
   PersonalRecord _personalRecordToDomain(db.PersonalRecord row) =>
@@ -386,6 +442,7 @@ class SyncSnapshotSerialiser {
         achievedAt: dateTimeFromEpochMs(row.achievedAt),
         workoutSetId: row.workoutSetId,
         updatedAt: dateTimeFromEpochMs(row.updatedAt),
+        deletedAt: nullableDateTimeFromEpochMs(row.deletedAt),
       );
 
   TemplateExercise _templateExerciseToDomain(db.TemplateExercise row) =>
@@ -398,6 +455,7 @@ class SyncSnapshotSerialiser {
         targetReps: row.targetReps,
         orderIndex: row.orderIndex,
         updatedAt: dateTimeFromEpochMs(row.updatedAt),
+        deletedAt: nullableDateTimeFromEpochMs(row.deletedAt),
       );
 
   BodyMetric _bodyMetricToDomain(db.BodyMetric row) => BodyMetric(
@@ -407,6 +465,7 @@ class SyncSnapshotSerialiser {
         bodyFatPercent: row.bodyFatPercent,
         notes: row.notes,
         updatedAt: dateTimeFromEpochMs(row.updatedAt),
+        deletedAt: nullableDateTimeFromEpochMs(row.deletedAt),
       );
 
   ProgrammeDay _programmeDayToDomain(db.ProgrammeDay row) => ProgrammeDay(
@@ -417,6 +476,7 @@ class SyncSnapshotSerialiser {
         templateId: row.templateId,
         templateName: row.templateName,
         updatedAt: dateTimeFromEpochMs(row.updatedAt),
+        deletedAt: nullableDateTimeFromEpochMs(row.deletedAt),
       );
 
   ProgressionRule _progressionRuleToDomain(db.ProgressionRule row) =>
@@ -428,6 +488,26 @@ class SyncSnapshotSerialiser {
         value: row.value,
         frequencyWeeks: row.frequencyWeeks,
         updatedAt: dateTimeFromEpochMs(row.updatedAt),
+        deletedAt: nullableDateTimeFromEpochMs(row.deletedAt),
+      );
+
+  StretchingSession _stretchingToDomain(db.StretchingSession row) =>
+      StretchingSession(
+        id: row.id,
+        workoutId: row.workoutId,
+        type: row.type,
+        customName: row.customName,
+        bodyArea: row.bodyArea == null
+            ? null
+            : StretchingBodyArea.values.byName(row.bodyArea!),
+        side: row.side == null ? null : StretchingSide.values.byName(row.side!),
+        durationSeconds: row.durationSeconds,
+        startedAt: nullableDateTimeFromEpochMs(row.startedAt),
+        endedAt: nullableDateTimeFromEpochMs(row.endedAt),
+        entryMethod: StretchingEntryMethod.values.byName(row.entryMethod),
+        notes: row.notes,
+        updatedAt: dateTimeFromEpochMs(row.updatedAt),
+        deletedAt: nullableDateTimeFromEpochMs(row.deletedAt),
       );
 
   // ── Domain → JSON maps ─────────────────────────────────────────────
@@ -466,6 +546,7 @@ class SyncSnapshotSerialiser {
         'isWarmUp': s.isWarmUp,
         'groupId': s.groupId,
         'updatedAt': s.updatedAt.toIso8601String(),
+        'deletedAt': s.deletedAt?.toIso8601String(),
       };
 
   Map<String, dynamic> _cardioToMap(CardioSession c) => {
@@ -477,6 +558,7 @@ class SyncSnapshotSerialiser {
         'incline': c.incline,
         'avgHeartRate': c.avgHeartRate,
         'updatedAt': c.updatedAt.toIso8601String(),
+        'deletedAt': c.deletedAt?.toIso8601String(),
       };
 
   Map<String, dynamic> _personalRecordToMap(PersonalRecord pr) => {
@@ -487,6 +569,7 @@ class SyncSnapshotSerialiser {
         'achievedAt': pr.achievedAt.toIso8601String(),
         'workoutSetId': pr.workoutSetId,
         'updatedAt': pr.updatedAt.toIso8601String(),
+        'deletedAt': pr.deletedAt?.toIso8601String(),
       };
 
   Map<String, dynamic> _workoutTemplateToMap(WorkoutTemplate t) => {
@@ -494,6 +577,7 @@ class SyncSnapshotSerialiser {
         'name': t.name,
         'createdAt': t.createdAt.toIso8601String(),
         'updatedAt': t.updatedAt.toIso8601String(),
+        'deletedAt': t.deletedAt?.toIso8601String(),
       };
 
   Map<String, dynamic> _templateExerciseToMap(TemplateExercise te) => {
@@ -505,6 +589,7 @@ class SyncSnapshotSerialiser {
         'targetReps': te.targetReps,
         'orderIndex': te.orderIndex,
         'updatedAt': te.updatedAt.toIso8601String(),
+        'deletedAt': te.deletedAt?.toIso8601String(),
       };
 
   Map<String, dynamic> _bodyMetricToMap(BodyMetric bm) => {
@@ -514,6 +599,7 @@ class SyncSnapshotSerialiser {
         'bodyFatPercent': bm.bodyFatPercent,
         'notes': bm.notes,
         'updatedAt': bm.updatedAt.toIso8601String(),
+        'deletedAt': bm.deletedAt?.toIso8601String(),
       };
 
   Map<String, dynamic> _programmeToMap(Programme p) => {
@@ -523,6 +609,7 @@ class SyncSnapshotSerialiser {
         'createdAt': p.createdAt.toIso8601String(),
         'updatedAt': p.updatedAt.toIso8601String(),
         'startedAt': p.startedAt?.toIso8601String(),
+        'deletedAt': p.deletedAt?.toIso8601String(),
       };
 
   Map<String, dynamic> _programmeDayToMap(ProgrammeDay d) => {
@@ -533,6 +620,7 @@ class SyncSnapshotSerialiser {
         'templateId': d.templateId,
         'templateName': d.templateName,
         'updatedAt': d.updatedAt.toIso8601String(),
+        'deletedAt': d.deletedAt?.toIso8601String(),
       };
 
   Map<String, dynamic> _progressionRuleToMap(ProgressionRule r) => {
@@ -543,6 +631,23 @@ class SyncSnapshotSerialiser {
         'value': r.value,
         'frequencyWeeks': r.frequencyWeeks,
         'updatedAt': r.updatedAt.toIso8601String(),
+        'deletedAt': r.deletedAt?.toIso8601String(),
+      };
+
+  Map<String, dynamic> _stretchingToMap(StretchingSession s) => {
+        'id': s.id,
+        'workoutId': s.workoutId,
+        'type': s.type,
+        'customName': s.customName,
+        'bodyArea': s.bodyArea?.name,
+        'side': s.side?.name,
+        'durationSeconds': s.durationSeconds,
+        'startedAt': s.startedAt?.toIso8601String(),
+        'endedAt': s.endedAt?.toIso8601String(),
+        'entryMethod': s.entryMethod.name,
+        'notes': s.notes,
+        'updatedAt': s.updatedAt.toIso8601String(),
+        'deletedAt': s.deletedAt?.toIso8601String(),
       };
 
   // ── JSON → Domain maps ─────────────────────────────────────────────
@@ -588,6 +693,7 @@ class SyncSnapshotSerialiser {
         isWarmUp: m['isWarmUp'] as bool? ?? false,
         groupId: m['groupId'] as String?,
         updatedAt: DateTime.parse(m['updatedAt'] as String),
+        deletedAt: _parseNullableDate(m['deletedAt']),
       );
 
   CardioSession _cardioFromMap(Map<String, dynamic> m) => CardioSession(
@@ -599,6 +705,7 @@ class SyncSnapshotSerialiser {
         incline: (m['incline'] as num?)?.toDouble(),
         avgHeartRate: m['avgHeartRate'] as int?,
         updatedAt: DateTime.parse(m['updatedAt'] as String),
+        deletedAt: _parseNullableDate(m['deletedAt']),
       );
 
   PersonalRecord _personalRecordFromMap(Map<String, dynamic> m) =>
@@ -610,6 +717,7 @@ class SyncSnapshotSerialiser {
         achievedAt: DateTime.parse(m['achievedAt'] as String),
         workoutSetId: m['workoutSetId'] as String?,
         updatedAt: DateTime.parse(m['updatedAt'] as String),
+        deletedAt: _parseNullableDate(m['deletedAt']),
       );
 
   WorkoutTemplate _workoutTemplateFromMap(Map<String, dynamic> m) =>
@@ -618,6 +726,7 @@ class SyncSnapshotSerialiser {
         name: m['name'] as String,
         createdAt: DateTime.parse(m['createdAt'] as String),
         updatedAt: DateTime.parse(m['updatedAt'] as String),
+        deletedAt: _parseNullableDate(m['deletedAt']),
       );
 
   TemplateExercise _templateExerciseFromMap(Map<String, dynamic> m) =>
@@ -630,6 +739,7 @@ class SyncSnapshotSerialiser {
         targetReps: m['targetReps'] as int,
         orderIndex: m['orderIndex'] as int,
         updatedAt: DateTime.parse(m['updatedAt'] as String),
+        deletedAt: _parseNullableDate(m['deletedAt']),
       );
 
   BodyMetric _bodyMetricFromMap(Map<String, dynamic> m) => BodyMetric(
@@ -639,6 +749,7 @@ class SyncSnapshotSerialiser {
         bodyFatPercent: (m['bodyFatPercent'] as num?)?.toDouble(),
         notes: m['notes'] as String?,
         updatedAt: DateTime.parse(m['updatedAt'] as String),
+        deletedAt: _parseNullableDate(m['deletedAt']),
       );
 
   Programme _programmeFromMap(Map<String, dynamic> m) => Programme(
@@ -647,9 +758,8 @@ class SyncSnapshotSerialiser {
         durationWeeks: m['durationWeeks'] as int,
         createdAt: DateTime.parse(m['createdAt'] as String),
         updatedAt: DateTime.parse(m['updatedAt'] as String),
-        startedAt: m['startedAt'] == null
-            ? null
-            : DateTime.parse(m['startedAt'] as String),
+        startedAt: _parseNullableDate(m['startedAt']),
+        deletedAt: _parseNullableDate(m['deletedAt']),
       );
 
   ProgrammeDay _programmeDayFromMap(Map<String, dynamic> m) => ProgrammeDay(
@@ -660,6 +770,7 @@ class SyncSnapshotSerialiser {
         templateId: m['templateId'] as String,
         templateName: m['templateName'] as String,
         updatedAt: DateTime.parse(m['updatedAt'] as String),
+        deletedAt: _parseNullableDate(m['deletedAt']),
       );
 
   ProgressionRule _progressionRuleFromMap(Map<String, dynamic> m) =>
@@ -671,5 +782,33 @@ class SyncSnapshotSerialiser {
         value: (m['value'] as num).toDouble(),
         frequencyWeeks: m['frequencyWeeks'] as int? ?? 1,
         updatedAt: DateTime.parse(m['updatedAt'] as String),
+        deletedAt: _parseNullableDate(m['deletedAt']),
       );
+
+  StretchingSession _stretchingFromMap(Map<String, dynamic> m) =>
+      StretchingSession(
+        id: m['id'] as String,
+        workoutId: m['workoutId'] as String,
+        type: m['type'] as String,
+        customName: m['customName'] as String?,
+        bodyArea: m['bodyArea'] == null
+            ? null
+            : StretchingBodyArea.values.byName(m['bodyArea'] as String),
+        side: m['side'] == null
+            ? null
+            : StretchingSide.values.byName(m['side'] as String),
+        durationSeconds: m['durationSeconds'] as int,
+        startedAt: _parseNullableDate(m['startedAt']),
+        endedAt: _parseNullableDate(m['endedAt']),
+        entryMethod:
+            StretchingEntryMethod.values.byName(m['entryMethod'] as String),
+        notes: m['notes'] as String?,
+        updatedAt: DateTime.parse(m['updatedAt'] as String),
+        deletedAt: _parseNullableDate(m['deletedAt']),
+      );
+
+  static DateTime? _parseNullableDate(dynamic value) {
+    if (value == null) return null;
+    return DateTime.parse(value as String);
+  }
 }

--- a/lib/features/sync/domain/models/sync_snapshot.dart
+++ b/lib/features/sync/domain/models/sync_snapshot.dart
@@ -3,6 +3,7 @@ import '../../../cardio/domain/models/cardio_session.dart';
 import '../../../exercises/domain/models/exercise.dart';
 import '../../../history/domain/models/personal_record.dart';
 import '../../../programmes/domain/models/programme.dart';
+import '../../../stretching/domain/models/stretching_session.dart';
 import '../../../templates/domain/models/workout_template.dart';
 import '../../../workout/domain/models/workout.dart';
 import '../../../workout/domain/models/workout_set.dart';
@@ -22,6 +23,7 @@ class SyncSnapshot {
   final List<Programme> programmes;
   final List<ProgrammeDay> programmeDays;
   final List<ProgressionRule> progressionRules;
+  final List<StretchingSession> stretchingSessions;
 
   const SyncSnapshot({
     required this.snapshotAt,
@@ -38,5 +40,6 @@ class SyncSnapshot {
     this.programmes = const [],
     this.programmeDays = const [],
     this.progressionRules = const [],
+    this.stretchingSessions = const [],
   });
 }

--- a/lib/features/sync/domain/sync_merge_engine.dart
+++ b/lib/features/sync/domain/sync_merge_engine.dart
@@ -1,10 +1,16 @@
 import 'models/sync_snapshot.dart';
 
-/// Merges two [SyncSnapshot]s using last-write-wins per entity.
+/// Merges two [SyncSnapshot]s using last-write-wins per entity, with
+/// tombstone awareness so deletes do not resurrect across devices.
 ///
 /// For each entity type, entities are matched by UUID. When the same
-/// UUID exists in both snapshots, the entity with the newer [updatedAt]
-/// wins. Ties are broken in favour of the local snapshot.
+/// UUID exists in both snapshots, the comparator runs in this order:
+///
+/// 1. If both sides have a `deletedAt` set, the larger one wins.
+/// 2. If exactly one side has a `deletedAt` set, that side wins —
+///    a tombstone always beats a live row.
+/// 3. Otherwise, the side with the larger `updatedAt` wins.
+///    Ties are broken in favour of the local snapshot.
 class SyncMergeEngine {
   SyncSnapshot merge({
     required SyncSnapshot local,
@@ -19,78 +25,95 @@ class SyncMergeEngine {
         remote.exercises,
         getId: (e) => e.id,
         getUpdatedAt: (e) => e.updatedAt,
+        getDeletedAt: (e) => e.deletedAt,
       ),
       workouts: _mergeById(
         local.workouts,
         remote.workouts,
         getId: (w) => w.id,
         getUpdatedAt: (w) => w.updatedAt,
+        getDeletedAt: (w) => w.deletedAt,
       ),
       workoutSets: _mergeById(
         local.workoutSets,
         remote.workoutSets,
         getId: (s) => s.id,
         getUpdatedAt: (s) => s.updatedAt,
+        getDeletedAt: (s) => s.deletedAt,
       ),
       cardioSessions: _mergeById(
         local.cardioSessions,
         remote.cardioSessions,
         getId: (c) => c.id,
         getUpdatedAt: (c) => c.updatedAt,
+        getDeletedAt: (c) => c.deletedAt,
       ),
       personalRecords: _mergeById(
         local.personalRecords,
         remote.personalRecords,
         getId: (p) => p.id,
         getUpdatedAt: (p) => p.updatedAt,
+        getDeletedAt: (p) => p.deletedAt,
       ),
       workoutTemplates: _mergeById(
         local.workoutTemplates,
         remote.workoutTemplates,
         getId: (t) => t.id,
         getUpdatedAt: (t) => t.updatedAt,
+        getDeletedAt: (t) => t.deletedAt,
       ),
       templateExercises: _mergeById(
         local.templateExercises,
         remote.templateExercises,
         getId: (te) => te.id,
         getUpdatedAt: (te) => te.updatedAt,
+        getDeletedAt: (te) => te.deletedAt,
       ),
       bodyMetrics: _mergeById(
         local.bodyMetrics,
         remote.bodyMetrics,
         getId: (b) => b.id,
         getUpdatedAt: (b) => b.updatedAt,
+        getDeletedAt: (b) => b.deletedAt,
       ),
       programmes: _mergeById(
         local.programmes,
         remote.programmes,
         getId: (p) => p.id,
         getUpdatedAt: (p) => p.updatedAt,
+        getDeletedAt: (p) => p.deletedAt,
       ),
       programmeDays: _mergeById(
         local.programmeDays,
         remote.programmeDays,
         getId: (d) => d.id,
         getUpdatedAt: (d) => d.updatedAt,
+        getDeletedAt: (d) => d.deletedAt,
       ),
       progressionRules: _mergeById(
         local.progressionRules,
         remote.progressionRules,
         getId: (r) => r.id,
         getUpdatedAt: (r) => r.updatedAt,
+        getDeletedAt: (r) => r.deletedAt,
+      ),
+      stretchingSessions: _mergeById(
+        local.stretchingSessions,
+        remote.stretchingSessions,
+        getId: (s) => s.id,
+        getUpdatedAt: (s) => s.updatedAt,
+        getDeletedAt: (s) => s.deletedAt,
       ),
     );
   }
 
-  /// Generic last-write-wins merge by UUID.
-  ///
-  /// When timestamps are equal, local wins (deterministic tie-breaking).
+  /// Generic last-write-wins merge by UUID, with tombstone precedence.
   List<T> _mergeById<T>(
     List<T> localItems,
     List<T> remoteItems, {
     required String Function(T) getId,
     required DateTime Function(T) getUpdatedAt,
+    DateTime? Function(T)? getDeletedAt,
   }) {
     final merged = <String, T>{};
 
@@ -103,16 +126,37 @@ class SyncMergeEngine {
       final existing = merged[id];
       if (existing == null) {
         merged[id] = item;
-      } else {
-        final existingTime = getUpdatedAt(existing);
-        final remoteTime = getUpdatedAt(item);
-        if (remoteTime.isAfter(existingTime)) {
-          merged[id] = item;
-        }
-        // Equal timestamps: local wins (already in map).
+        continue;
       }
+      if (_remoteWins(existing, item, getUpdatedAt, getDeletedAt)) {
+        merged[id] = item;
+      }
+      // Otherwise the local entry stays (already in map).
     }
 
     return merged.values.toList();
+  }
+
+  bool _remoteWins<T>(
+    T local,
+    T remote,
+    DateTime Function(T) getUpdatedAt,
+    DateTime? Function(T)? getDeletedAt,
+  ) {
+    final localDeleted = getDeletedAt?.call(local);
+    final remoteDeleted = getDeletedAt?.call(remote);
+
+    if (localDeleted != null && remoteDeleted != null) {
+      // Both tombstones: larger wins. Ties favour local.
+      return remoteDeleted.isAfter(localDeleted);
+    }
+    if (remoteDeleted != null && localDeleted == null) {
+      return true;
+    }
+    if (localDeleted != null && remoteDeleted == null) {
+      return false;
+    }
+    // Neither tombstoned: compare updatedAt. Ties favour local.
+    return getUpdatedAt(remote).isAfter(getUpdatedAt(local));
   }
 }

--- a/lib/features/sync/domain/sync_schema_version_exception.dart
+++ b/lib/features/sync/domain/sync_schema_version_exception.dart
@@ -1,0 +1,37 @@
+/// Thrown when a remote sync snapshot's `schemaVersion` is incompatible with
+/// the local app's schema.
+///
+/// The merge engine refuses to apply a snapshot built by a newer client; doing
+/// so would cause the older client to silently strip unknown fields and
+/// re-upload a degraded blob, overwriting the newer device's contributions.
+class SyncSchemaVersionException implements Exception {
+  /// Schema version reported by the remote snapshot.
+  final int remoteVersion;
+
+  /// Schema version of the local app.
+  final int localVersion;
+
+  /// User-facing message describing the failure.
+  final String message;
+
+  const SyncSchemaVersionException._(
+    this.remoteVersion,
+    this.localVersion,
+    this.message,
+  );
+
+  /// The remote snapshot was created by a newer version of the app than the
+  /// local client supports.
+  factory SyncSchemaVersionException.tooNew(int remote, int local) {
+    return SyncSchemaVersionException._(
+      remote,
+      local,
+      'Cloud backup was created by a newer version of RepFoundry '
+      '(schema v$remote, this app supports v$local). '
+      'Please update RepFoundry and try again.',
+    );
+  }
+
+  @override
+  String toString() => message;
+}

--- a/lib/features/templates/data/drift_workout_template_repository.dart
+++ b/lib/features/templates/data/drift_workout_template_repository.dart
@@ -41,7 +41,8 @@ class DriftWorkoutTemplateRepository implements WorkoutTemplateRepository {
 
   @override
   Future<WorkoutTemplate?> getTemplate(String id) async {
-    final q = _db.select(_db.workoutTemplates)..where((t) => t.id.equals(id));
+    final q = _db.select(_db.workoutTemplates)
+      ..where((t) => t.id.equals(id) & t.deletedAt.isNull());
     final row = await q.getSingleOrNull();
     if (row == null) return null;
 
@@ -52,6 +53,7 @@ class DriftWorkoutTemplateRepository implements WorkoutTemplateRepository {
   @override
   Future<List<WorkoutTemplate>> getAllTemplates() async {
     final q = _db.select(_db.workoutTemplates)
+      ..where((t) => t.deletedAt.isNull())
       ..orderBy([(t) => OrderingTerm.desc(t.createdAt)]);
     final rows = await q.get();
     return Future.wait(rows.map((row) async {
@@ -62,6 +64,7 @@ class DriftWorkoutTemplateRepository implements WorkoutTemplateRepository {
 
   @override
   Future<WorkoutTemplate> updateTemplate(WorkoutTemplate template) async {
+    final nowMs = dateTimeToEpochMs(DateTime.now().toUtc());
     await _db.transaction(() async {
       await (_db.update(_db.workoutTemplates)
             ..where((t) => t.id.equals(template.id)))
@@ -71,12 +74,21 @@ class DriftWorkoutTemplateRepository implements WorkoutTemplateRepository {
           updatedAt: Value(dateTimeToEpochMs(template.updatedAt)),
         ),
       );
-      // Delete-and-reinsert children.
-      await (_db.delete(_db.templateExercises)
-            ..where((t) => t.templateId.equals(template.id)))
-          .go();
+      // Soft-delete previous children (preserves tombstones for sync) and
+      // insert the new set. New rows with the same id will upsert via
+      // primary-key conflict; new ids appear as new rows.
+      await (_db.update(_db.templateExercises)
+            ..where(
+              (t) => t.templateId.equals(template.id) & t.deletedAt.isNull(),
+            ))
+          .write(
+        db.TemplateExercisesCompanion(
+          deletedAt: Value(nowMs),
+          updatedAt: Value(nowMs),
+        ),
+      );
       for (final ex in template.exercises) {
-        await _db.into(_db.templateExercises).insert(
+        await _db.into(_db.templateExercises).insertOnConflictUpdate(
               db.TemplateExercisesCompanion.insert(
                 id: ex.id,
                 templateId: template.id,
@@ -86,6 +98,8 @@ class DriftWorkoutTemplateRepository implements WorkoutTemplateRepository {
                 targetReps: ex.targetReps,
                 orderIndex: ex.orderIndex,
                 updatedAt: Value(dateTimeToEpochMs(ex.updatedAt)),
+                // Resurrect: explicit null clears any prior tombstone.
+                deletedAt: const Value(null),
               ),
             );
       }
@@ -95,18 +109,30 @@ class DriftWorkoutTemplateRepository implements WorkoutTemplateRepository {
 
   @override
   Future<void> deleteTemplate(String id) async {
+    final nowMs = dateTimeToEpochMs(DateTime.now().toUtc());
     await _db.transaction(() async {
-      await (_db.delete(_db.templateExercises)
-            ..where((t) => t.templateId.equals(id)))
-          .go();
-      await (_db.delete(_db.workoutTemplates)..where((t) => t.id.equals(id)))
-          .go();
+      await (_db.update(_db.templateExercises)
+            ..where((t) => t.templateId.equals(id) & t.deletedAt.isNull()))
+          .write(
+        db.TemplateExercisesCompanion(
+          deletedAt: Value(nowMs),
+          updatedAt: Value(nowMs),
+        ),
+      );
+      await (_db.update(_db.workoutTemplates)..where((t) => t.id.equals(id)))
+          .write(
+        db.WorkoutTemplatesCompanion(
+          deletedAt: Value(nowMs),
+          updatedAt: Value(nowMs),
+        ),
+      );
     });
   }
 
   @override
   Stream<List<WorkoutTemplate>> watchAllTemplates() {
     final q = _db.select(_db.workoutTemplates)
+      ..where((t) => t.deletedAt.isNull())
       ..orderBy([(t) => OrderingTerm.desc(t.createdAt)]);
     return q.watch().asyncMap((rows) async {
       return Future.wait(rows.map((row) async {
@@ -120,7 +146,7 @@ class DriftWorkoutTemplateRepository implements WorkoutTemplateRepository {
     String templateId,
   ) async {
     final q = _db.select(_db.templateExercises)
-      ..where((t) => t.templateId.equals(templateId))
+      ..where((t) => t.templateId.equals(templateId) & t.deletedAt.isNull())
       ..orderBy([(t) => OrderingTerm.asc(t.orderIndex)]);
     final rows = await q.get();
     return rows.map(_exerciseToDomain).toList();
@@ -135,6 +161,7 @@ class DriftWorkoutTemplateRepository implements WorkoutTemplateRepository {
       name: row.name,
       createdAt: dateTimeFromEpochMs(row.createdAt),
       updatedAt: dateTimeFromEpochMs(row.updatedAt),
+      deletedAt: nullableDateTimeFromEpochMs(row.deletedAt),
       exercises: exercises,
     );
   }
@@ -149,6 +176,7 @@ class DriftWorkoutTemplateRepository implements WorkoutTemplateRepository {
       targetReps: row.targetReps,
       orderIndex: row.orderIndex,
       updatedAt: dateTimeFromEpochMs(row.updatedAt),
+      deletedAt: nullableDateTimeFromEpochMs(row.deletedAt),
     );
   }
 }

--- a/lib/features/templates/domain/models/workout_template.dart
+++ b/lib/features/templates/domain/models/workout_template.dart
@@ -9,6 +9,7 @@ class TemplateExercise {
   final int targetReps;
   final int orderIndex;
   final DateTime updatedAt;
+  final DateTime? deletedAt;
 
   const TemplateExercise({
     required this.id,
@@ -19,7 +20,10 @@ class TemplateExercise {
     required this.targetReps,
     required this.orderIndex,
     required this.updatedAt,
+    this.deletedAt,
   });
+
+  bool get isDeleted => deletedAt != null;
 }
 
 class WorkoutTemplate {
@@ -27,6 +31,7 @@ class WorkoutTemplate {
   final String name;
   final DateTime createdAt;
   final DateTime updatedAt;
+  final DateTime? deletedAt;
   final List<TemplateExercise> exercises;
 
   const WorkoutTemplate({
@@ -34,8 +39,11 @@ class WorkoutTemplate {
     required this.name,
     required this.createdAt,
     required this.updatedAt,
+    this.deletedAt,
     this.exercises = const [],
   });
+
+  bool get isDeleted => deletedAt != null;
 
   static WorkoutTemplate create({
     required String name,
@@ -56,6 +64,7 @@ class WorkoutTemplate {
     String? name,
     DateTime? createdAt,
     DateTime? updatedAt,
+    DateTime? deletedAt,
     List<TemplateExercise>? exercises,
   }) {
     return WorkoutTemplate(
@@ -63,6 +72,7 @@ class WorkoutTemplate {
       name: name ?? this.name,
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
+      deletedAt: deletedAt ?? this.deletedAt,
       exercises: exercises ?? this.exercises,
     );
   }

--- a/lib/features/workout/data/drift_workout_repository.dart
+++ b/lib/features/workout/data/drift_workout_repository.dart
@@ -117,7 +117,7 @@ class DriftWorkoutRepository implements WorkoutRepository {
   @override
   Future<List<WorkoutSet>> getSetsForWorkout(String workoutId) async {
     final q = _db.select(_db.workoutSets)
-      ..where((t) => t.workoutId.equals(workoutId))
+      ..where((t) => t.workoutId.equals(workoutId) & t.deletedAt.isNull())
       ..orderBy([(t) => OrderingTerm.asc(t.setOrder)]);
     final rows = await q.get();
     return rows.map(_setToDomain).toList();
@@ -129,7 +129,7 @@ class DriftWorkoutRepository implements WorkoutRepository {
     int limit = 50,
   }) async {
     final q = _db.select(_db.workoutSets)
-      ..where((t) => t.exerciseId.equals(exerciseId))
+      ..where((t) => t.exerciseId.equals(exerciseId) & t.deletedAt.isNull())
       ..orderBy([(t) => OrderingTerm.desc(t.timestamp)])
       ..limit(limit);
     final rows = await q.get();
@@ -139,7 +139,7 @@ class DriftWorkoutRepository implements WorkoutRepository {
   @override
   Future<WorkoutSet?> getLastSetForExercise(String exerciseId) async {
     final q = _db.select(_db.workoutSets)
-      ..where((t) => t.exerciseId.equals(exerciseId))
+      ..where((t) => t.exerciseId.equals(exerciseId) & t.deletedAt.isNull())
       ..orderBy([(t) => OrderingTerm.desc(t.timestamp)])
       ..limit(1);
     final row = await q.getSingleOrNull();
@@ -161,6 +161,7 @@ class DriftWorkoutRepository implements WorkoutRepository {
         isWarmUp: Value(set.isWarmUp),
         groupId: Value(set.groupId),
         updatedAt: Value(dateTimeToEpochMs(set.updatedAt)),
+        deletedAt: Value(nullableDateTimeToEpochMs(set.deletedAt)),
       ),
     );
     return set;
@@ -168,7 +169,12 @@ class DriftWorkoutRepository implements WorkoutRepository {
 
   @override
   Future<void> deleteSet(String setId) async {
-    await (_db.delete(_db.workoutSets)..where((t) => t.id.equals(setId))).go();
+    final now = dateTimeToEpochMs(DateTime.now().toUtc());
+    await (_db.update(_db.workoutSets)..where((t) => t.id.equals(setId)))
+        .write(db.WorkoutSetsCompanion(
+      deletedAt: Value(now),
+      updatedAt: Value(now),
+    ));
   }
 
   @override
@@ -192,7 +198,10 @@ class DriftWorkoutRepository implements WorkoutRepository {
     // Fetch all sets for that exercise in that workout, ordered by setOrder.
     final q = _db.select(_db.workoutSets)
       ..where(
-        (t) => t.workoutId.equals(workoutId) & t.exerciseId.equals(exerciseId),
+        (t) =>
+            t.workoutId.equals(workoutId) &
+            t.exerciseId.equals(exerciseId) &
+            t.deletedAt.isNull(),
       )
       ..orderBy([(t) => OrderingTerm.asc(t.setOrder)]);
     final rows = await q.get();
@@ -214,7 +223,7 @@ class DriftWorkoutRepository implements WorkoutRepository {
   @override
   Stream<List<WorkoutSet>> watchSetsForWorkout(String workoutId) {
     final q = _db.select(_db.workoutSets)
-      ..where((t) => t.workoutId.equals(workoutId))
+      ..where((t) => t.workoutId.equals(workoutId) & t.deletedAt.isNull())
       ..orderBy([(t) => OrderingTerm.asc(t.setOrder)]);
     return q.watch().map((rows) => rows.map(_setToDomain).toList());
   }
@@ -246,6 +255,7 @@ class DriftWorkoutRepository implements WorkoutRepository {
       isWarmUp: row.isWarmUp,
       groupId: row.groupId,
       updatedAt: dateTimeFromEpochMs(row.updatedAt),
+      deletedAt: nullableDateTimeFromEpochMs(row.deletedAt),
     );
   }
 }

--- a/lib/features/workout/domain/models/workout_set.dart
+++ b/lib/features/workout/domain/models/workout_set.dart
@@ -12,6 +12,7 @@ class WorkoutSet {
   final bool isWarmUp;
   final String? groupId;
   final DateTime updatedAt;
+  final DateTime? deletedAt;
 
   const WorkoutSet({
     required this.id,
@@ -25,7 +26,10 @@ class WorkoutSet {
     this.isWarmUp = false,
     this.groupId,
     required this.updatedAt,
+    this.deletedAt,
   });
+
+  bool get isDeleted => deletedAt != null;
 
   double get volume => weight * reps;
 
@@ -48,6 +52,7 @@ class WorkoutSet {
     String? groupId,
     bool clearGroupId = false,
     DateTime? updatedAt,
+    DateTime? deletedAt,
   }) {
     return WorkoutSet(
       id: id ?? this.id,
@@ -61,6 +66,7 @@ class WorkoutSet {
       isWarmUp: isWarmUp ?? this.isWarmUp,
       groupId: clearGroupId ? null : (groupId ?? this.groupId),
       updatedAt: updatedAt ?? this.updatedAt,
+      deletedAt: deletedAt ?? this.deletedAt,
     );
   }
 

--- a/test/features/body_metrics/data/drift_body_metric_repository_test.dart
+++ b/test/features/body_metrics/data/drift_body_metric_repository_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:rep_foundry/core/database/app_database.dart' as db;
 import 'package:rep_foundry/features/body_metrics/data/drift_body_metric_repository.dart';
 import 'package:rep_foundry/features/body_metrics/domain/models/body_metric.dart';
+import 'package:drift/drift.dart' show Value;
 
 void main() {
   late db.AppDatabase database;
@@ -80,7 +81,7 @@ void main() {
     });
 
     group('delete', () {
-      test('removes the metric', () async {
+      test('removes the metric from public reads', () async {
         final metric = newMetric();
         await repo.create(metric);
 
@@ -88,6 +89,50 @@ void main() {
 
         final results = await repo.getAll();
         expect(results, isEmpty);
+      });
+
+      test('soft-deletes: row remains in DB with deletedAt set', () async {
+        // The soft-delete must keep the tombstone around so a subsequent
+        // sync can propagate the delete. A hard-delete here would silently
+        // resurrect the row on the next sync from another device.
+        final metric = newMetric();
+        await repo.create(metric);
+
+        await repo.delete(metric.id);
+
+        // Query the table directly, bypassing the repo's deletedAt filter.
+        final raw = await database.select(database.bodyMetrics).get();
+        expect(raw, hasLength(1));
+        expect(raw.single.id, metric.id);
+        expect(raw.single.deletedAt, isNotNull);
+      });
+
+      test('subsequent reads filter the tombstoned row', () async {
+        final metric = newMetric();
+        await repo.create(metric);
+        await repo.delete(metric.id);
+
+        expect(await repo.getAll(), isEmpty);
+        expect(await repo.getLatest(), isNull);
+      });
+
+      test('manually-tombstoned row (sync-applied) is filtered from reads',
+          () async {
+        // Simulate a tombstone arriving via cloud sync rather than via
+        // repo.delete(): apply a deletedAt directly. Public reads must
+        // still hide it.
+        final metric = newMetric();
+        await repo.create(metric);
+
+        await (database.update(database.bodyMetrics)
+              ..where((t) => t.id.equals(metric.id)))
+            .write(
+          db.BodyMetricsCompanion(
+            deletedAt: Value(DateTime.now().millisecondsSinceEpoch),
+          ),
+        );
+
+        expect(await repo.getAll(), isEmpty);
       });
     });
 

--- a/test/features/cardio/data/drift_cardio_session_repository_test.dart
+++ b/test/features/cardio/data/drift_cardio_session_repository_test.dart
@@ -142,7 +142,7 @@ void main() {
     });
 
     group('deleteSession', () {
-      test('hard-deletes a session', () async {
+      test('soft-deletes: getSession returns null after delete', () async {
         final workout = await createParentWorkout();
         final session = newSession(workoutId: workout.id);
         await repo.createSession(session);
@@ -150,6 +150,39 @@ void main() {
 
         final fetched = await repo.getSession(session.id);
         expect(fetched, isNull);
+      });
+
+      test('row is preserved in DB with deletedAt non-null', () async {
+        final workout = await createParentWorkout();
+        final session = newSession(workoutId: workout.id);
+        await repo.createSession(session);
+        await repo.deleteSession(session.id);
+
+        // Bypass the repo filter and inspect the table directly.
+        final raw = await database.select(database.cardioSessions).get();
+        expect(raw, hasLength(1));
+        expect(raw.single.id, session.id);
+        expect(raw.single.deletedAt, isNotNull);
+      });
+
+      test('tombstone is hidden from list reads', () async {
+        final workout = await createParentWorkout();
+        final live = newSession(workoutId: workout.id);
+        final deleted = newSession(workoutId: workout.id);
+        await repo.createSession(live);
+        await repo.createSession(deleted);
+        await repo.deleteSession(deleted.id);
+
+        final forWorkout = await repo.getSessionsForWorkout(workout.id);
+        expect(forWorkout, hasLength(1));
+        expect(forWorkout.single.id, live.id);
+
+        final all = await repo.getAllSessions();
+        expect(all, hasLength(1));
+
+        final lastForExercise = await repo.getLastSessionForExercise('16');
+        expect(lastForExercise, isNotNull);
+        expect(lastForExercise!.id, live.id);
       });
     });
 

--- a/test/features/history/data/drift_personal_record_repository_test.dart
+++ b/test/features/history/data/drift_personal_record_repository_test.dart
@@ -1,3 +1,4 @@
+import 'package:drift/drift.dart' show Value;
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:rep_foundry/core/database/app_database.dart' as db;
@@ -96,6 +97,75 @@ void main() {
 
         final all = await repo.getAllRecords(limit: 3);
         expect(all, hasLength(3));
+      });
+    });
+
+    group('soft-delete (tombstone-from-sync)', () {
+      // Personal records have no public delete method on the repository
+      // (the model is append-only from the user's point of view), but
+      // tombstones can still arrive via cloud sync. The read paths must
+      // skip them so a deleted-on-another-device record does not show up
+      // as a current PR locally.
+
+      test('tombstoned record is excluded from getRecordsForExercise',
+          () async {
+        final live = newRecord(value: 100);
+        final tombstoned = newRecord(value: 150);
+        await repo.createRecord(live);
+        await repo.createRecord(tombstoned);
+
+        // Apply a tombstone directly, simulating a sync-applied delete.
+        await (database.update(database.personalRecords)
+              ..where((t) => t.id.equals(tombstoned.id)))
+            .write(
+          db.PersonalRecordsCompanion(
+            deletedAt: Value(DateTime.now().millisecondsSinceEpoch),
+          ),
+        );
+
+        final results = await repo.getRecordsForExercise('1');
+        expect(results, hasLength(1));
+        expect(results.single.id, live.id);
+      });
+
+      test('tombstoned record is excluded from getBestRecord', () async {
+        await repo.createRecord(newRecord(value: 100));
+        final highButTombstoned = newRecord(value: 250);
+        await repo.createRecord(highButTombstoned);
+
+        await (database.update(database.personalRecords)
+              ..where((t) => t.id.equals(highButTombstoned.id)))
+            .write(
+          db.PersonalRecordsCompanion(
+            deletedAt: Value(DateTime.now().millisecondsSinceEpoch),
+          ),
+        );
+
+        final best = await repo.getBestRecord(
+          '1',
+          RecordType.estimatedOneRepMax,
+        );
+        expect(best, isNotNull);
+        expect(best!.value, 100.0);
+      });
+
+      test('tombstoned record is excluded from getAllRecords', () async {
+        final live = newRecord(value: 100);
+        final dead = newRecord(value: 200);
+        await repo.createRecord(live);
+        await repo.createRecord(dead);
+
+        await (database.update(database.personalRecords)
+              ..where((t) => t.id.equals(dead.id)))
+            .write(
+          db.PersonalRecordsCompanion(
+            deletedAt: Value(DateTime.now().millisecondsSinceEpoch),
+          ),
+        );
+
+        final all = await repo.getAllRecords();
+        expect(all, hasLength(1));
+        expect(all.single.id, live.id);
       });
     });
 

--- a/test/features/programmes/data/drift_programme_repository_test.dart
+++ b/test/features/programmes/data/drift_programme_repository_test.dart
@@ -39,7 +39,8 @@ void main() {
       expect(all, hasLength(2));
     });
 
-    test('deleteProgramme removes programme and children', () async {
+    test('deleteProgramme removes programme and children from public reads',
+        () async {
       final p = Programme.create(name: 'PPL', durationWeeks: 4);
       await repo.createProgramme(p);
       await repo.addDay(ProgrammeDay.create(
@@ -65,6 +66,81 @@ void main() {
 
       final rules = await repo.getRulesForProgramme(p.id);
       expect(rules, isEmpty);
+    });
+
+    test('deleteProgramme soft-deletes and cascades to days + rules', () async {
+      final p = Programme.create(name: 'PPL', durationWeeks: 4);
+      await repo.createProgramme(p);
+      await repo.addDay(ProgrammeDay.create(
+        programmeId: p.id,
+        weekNumber: 1,
+        dayOfWeek: 1,
+        templateId: 't1',
+        templateName: 'Push',
+      ));
+      await repo.addRule(ProgressionRule.create(
+        programmeId: p.id,
+        exerciseId: 'e1',
+        type: ProgressionType.fixedIncrement,
+        value: 2.5,
+      ));
+
+      await repo.deleteProgramme(p.id);
+
+      // Bypass repo filters and confirm parent + children rows are
+      // preserved with deletedAt set, so a sync can propagate them.
+      final rawProgrammes = await db.select(db.programmes).get();
+      expect(rawProgrammes, hasLength(1));
+      expect(rawProgrammes.single.deletedAt, isNotNull);
+
+      final rawDays = await db.select(db.programmeDays).get();
+      expect(rawDays, hasLength(1));
+      expect(rawDays.single.deletedAt, isNotNull);
+
+      final rawRules = await db.select(db.progressionRules).get();
+      expect(rawRules, hasLength(1));
+      expect(rawRules.single.deletedAt, isNotNull);
+    });
+
+    test('removeDay soft-deletes the day', () async {
+      final p = Programme.create(name: 'PPL', durationWeeks: 4);
+      await repo.createProgramme(p);
+      final day = ProgrammeDay.create(
+        programmeId: p.id,
+        weekNumber: 1,
+        dayOfWeek: 1,
+        templateId: 't1',
+        templateName: 'Push',
+      );
+      await repo.addDay(day);
+
+      await repo.removeDay(day.id);
+
+      // Public read returns empty.
+      expect(await repo.getDaysForProgramme(p.id), isEmpty);
+      // Underlying row preserved with deletedAt set.
+      final raw = await db.select(db.programmeDays).get();
+      expect(raw, hasLength(1));
+      expect(raw.single.deletedAt, isNotNull);
+    });
+
+    test('removeRule soft-deletes the rule', () async {
+      final p = Programme.create(name: 'PPL', durationWeeks: 4);
+      await repo.createProgramme(p);
+      final rule = ProgressionRule.create(
+        programmeId: p.id,
+        exerciseId: 'e1',
+        type: ProgressionType.fixedIncrement,
+        value: 2.5,
+      );
+      await repo.addRule(rule);
+
+      await repo.removeRule(rule.id);
+
+      expect(await repo.getRulesForProgramme(p.id), isEmpty);
+      final raw = await db.select(db.progressionRules).get();
+      expect(raw, hasLength(1));
+      expect(raw.single.deletedAt, isNotNull);
     });
 
     test('addDay and getDaysForProgramme', () async {

--- a/test/features/sync/application/sync_orchestrator_test.dart
+++ b/test/features/sync/application/sync_orchestrator_test.dart
@@ -17,6 +17,11 @@ class FakeCloudSyncService implements CloudSyncService {
   bool throwOnUpload = false;
   String uploadError = 'Cloud upload failed';
 
+  /// Records the order in which orchestrator steps fire on the fakes.
+  /// Used to assert "upload-first" ordering: the entry "upload" must
+  /// appear before "apply" for any sync that succeeds.
+  final List<String> callLog = [];
+
   /// Completer to delay downloadSnapshot until we release it.
   Completer<String?>? downloadCompleter;
 
@@ -25,6 +30,7 @@ class FakeCloudSyncService implements CloudSyncService {
 
   @override
   Future<void> uploadSnapshot(String jsonData) async {
+    callLog.add('upload');
     if (throwOnUpload) {
       throw Exception(uploadError);
     }
@@ -62,6 +68,7 @@ class FakeConnectivity implements Connectivity {
 class FakeSyncSnapshotSerialiser extends SyncSnapshotSerialiser {
   late SyncSnapshot snapshotToReturn;
   SyncSnapshot? appliedSnapshot;
+  List<String>? callLog;
 
   @override
   Future<SyncSnapshot> createFromDatabase(
@@ -76,6 +83,7 @@ class FakeSyncSnapshotSerialiser extends SyncSnapshotSerialiser {
     AppDatabase database,
     SyncSnapshot snapshot,
   ) async {
+    callLog?.add('apply');
     appliedSnapshot = snapshot;
   }
 }
@@ -190,10 +198,44 @@ void main() {
       // isSyncing should be reset so another sync is possible.
       expect(orchestrator.isSyncing, isFalse);
 
+      // Upload-first guarantee: applyToDatabase must NOT have been called
+      // when the upload failed; local state stays consistent with cloud.
+      expect(serialiser.appliedSnapshot, isNull);
+
       // Verify a subsequent sync is not blocked.
       cloudService.throwOnUpload = false;
       final result2 = await orchestrator.sync();
       expect(result2.success, isTrue);
+    });
+
+    test('upload happens before applyToDatabase (upload-first ordering)',
+        () async {
+      // Wire shared call log.
+      serialiser.callLog = cloudService.callLog;
+
+      final result = await orchestrator.sync();
+
+      expect(result.success, isTrue);
+      expect(cloudService.callLog, equals(['upload', 'apply']));
+    });
+
+    test('schema-version-too-new from remote propagates as error', () async {
+      // Construct a JSON snapshot claiming schema 999 (newer than this app).
+      cloudService.storedJson = '{"snapshotAt":"2026-04-30T00:00:00.000Z",'
+          '"deviceId":"future-device","schemaVersion":999}';
+
+      // Use the real serialiser so fromJson actually parses + validates.
+      final realOrchestrator = SyncOrchestrator(
+        database: db,
+        cloudService: cloudService,
+        deviceId: 'test-device',
+        connectivity: connectivity,
+      );
+
+      final result = await realOrchestrator.sync();
+
+      expect(result.success, isFalse);
+      expect(result.errorMessage, contains('newer version'));
     });
 
     test('deleteCloudData delegates to cloud service', () async {

--- a/test/features/sync/data/sync_snapshot_serialiser_db_test.dart
+++ b/test/features/sync/data/sync_snapshot_serialiser_db_test.dart
@@ -1,0 +1,210 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_foundry/core/database/app_database.dart' as db;
+import 'package:rep_foundry/features/stretching/data/drift_stretching_session_repository.dart';
+import 'package:rep_foundry/features/stretching/domain/models/stretching_session.dart';
+import 'package:rep_foundry/features/sync/data/sync_snapshot_serialiser.dart';
+import 'package:rep_foundry/features/sync/domain/models/sync_snapshot.dart';
+import 'package:rep_foundry/features/workout/data/drift_workout_repository.dart';
+import 'package:rep_foundry/features/workout/domain/models/workout.dart';
+
+/// Integration test: exercise [SyncSnapshotSerialiser.applyToDatabase] for
+/// stretching sessions against an in-memory [db.AppDatabase]. The
+/// stretching upsert path was added in the cloud-sync correctness sprint
+/// and otherwise has no test coverage that touches a real DB.
+void main() {
+  late db.AppDatabase database;
+  late SyncSnapshotSerialiser serialiser;
+  late DriftWorkoutRepository workoutRepo;
+  late DriftStretchingSessionRepository stretchingRepo;
+
+  setUp(() {
+    database = db.AppDatabase.forTesting(NativeDatabase.memory());
+    serialiser = SyncSnapshotSerialiser();
+    workoutRepo = DriftWorkoutRepository(database);
+    stretchingRepo = DriftStretchingSessionRepository(database);
+  });
+
+  tearDown(() => database.close());
+
+  Future<Workout> seedParentWorkout() async {
+    final workout = Workout.create();
+    await workoutRepo.createWorkout(workout);
+    return workout;
+  }
+
+  StretchingSession buildSession({
+    required String workoutId,
+    String id = 'st-1',
+    String type = 'pigeon',
+    int durationSeconds = 60,
+    StretchingEntryMethod entryMethod = StretchingEntryMethod.timer,
+    StretchingBodyArea? bodyArea = StretchingBodyArea.hips,
+    StretchingSide? side = StretchingSide.left,
+    DateTime? deletedAt,
+    String? customName,
+    String? notes,
+  }) {
+    final start = DateTime.utc(2026, 4, 30, 10, 0);
+    return StretchingSession(
+      id: id,
+      workoutId: workoutId,
+      type: type,
+      customName: customName,
+      bodyArea: bodyArea,
+      side: side,
+      durationSeconds: durationSeconds,
+      startedAt: start,
+      endedAt: start.add(Duration(seconds: durationSeconds)),
+      entryMethod: entryMethod,
+      notes: notes,
+      updatedAt: start,
+      deletedAt: deletedAt,
+    );
+  }
+
+  SyncSnapshot snapshotWith(List<StretchingSession> sessions) {
+    return SyncSnapshot(
+      snapshotAt: DateTime.utc(2026, 4, 30, 12, 0),
+      deviceId: 'remote-device',
+      schemaVersion: db.AppDatabase.schemaVersionConst,
+      stretchingSessions: sessions,
+    );
+  }
+
+  group('SyncSnapshotSerialiser.applyToDatabase – stretching', () {
+    test('inserts a stretching session that did not exist locally', () async {
+      final workout = await seedParentWorkout();
+      final incoming = buildSession(workoutId: workout.id);
+
+      await serialiser.applyToDatabase(database, snapshotWith([incoming]));
+
+      final raw = await database.select(database.stretchingSessions).get();
+      expect(raw, hasLength(1));
+      final row = raw.single;
+      expect(row.id, 'st-1');
+      expect(row.workoutId, workout.id);
+      expect(row.type, 'pigeon');
+      expect(row.bodyArea, 'hips');
+      expect(row.side, 'left');
+      expect(row.entryMethod, 'timer');
+      expect(row.durationSeconds, 60);
+      expect(row.startedAt, isNotNull);
+      expect(row.endedAt, isNotNull);
+      expect(row.deletedAt, isNull);
+    });
+
+    test('persists nullable enum + custom-name fields correctly', () async {
+      final workout = await seedParentWorkout();
+      final incoming = buildSession(
+        workoutId: workout.id,
+        id: 'st-custom',
+        type: 'custom',
+        customName: 'Wrist circles',
+        bodyArea: null,
+        side: null,
+        entryMethod: StretchingEntryMethod.untimed,
+        durationSeconds: 0,
+      );
+
+      await serialiser.applyToDatabase(database, snapshotWith([incoming]));
+
+      final fetched = await stretchingRepo.getSession('st-custom');
+      expect(fetched, isNotNull);
+      expect(fetched!.type, 'custom');
+      expect(fetched.customName, 'Wrist circles');
+      expect(fetched.bodyArea, isNull);
+      expect(fetched.side, isNull);
+      expect(fetched.entryMethod, StretchingEntryMethod.untimed);
+    });
+
+    test('upserts on conflict: existing local row gets updated fields',
+        () async {
+      final workout = await seedParentWorkout();
+
+      // Seed local row.
+      final original = buildSession(
+        workoutId: workout.id,
+        notes: 'before',
+      );
+      await stretchingRepo.createSession(original);
+
+      // Apply a snapshot that carries the same id with new field values.
+      final updated = buildSession(
+        workoutId: workout.id,
+        notes: 'after',
+        durationSeconds: 90,
+      );
+      await serialiser.applyToDatabase(database, snapshotWith([updated]));
+
+      // The local repo must observe the merged values.
+      final fetched = await stretchingRepo.getSession('st-1');
+      expect(fetched, isNotNull);
+      expect(fetched!.notes, 'after');
+      expect(fetched.durationSeconds, 90);
+
+      // Only one row in the table (upsert, not insert).
+      final raw = await database.select(database.stretchingSessions).get();
+      expect(raw, hasLength(1));
+    });
+
+    test('round-trips deletedAt when applying a tombstoned session', () async {
+      final workout = await seedParentWorkout();
+      final tombstoned = buildSession(
+        workoutId: workout.id,
+        deletedAt: DateTime.utc(2026, 4, 30, 11, 0),
+      );
+
+      await serialiser.applyToDatabase(database, snapshotWith([tombstoned]));
+
+      // Row exists in the DB with deletedAt set.
+      final raw = await database.select(database.stretchingSessions).get();
+      expect(raw, hasLength(1));
+      expect(raw.single.deletedAt, isNotNull);
+
+      // Public reads (which filter deletedAt IS NULL) hide the tombstone.
+      final visible = await stretchingRepo.getSessionsForWorkout(workout.id);
+      expect(visible, isEmpty);
+    });
+
+    test('createFromDatabase round-trips a real stretching session', () async {
+      // End-to-end: seed via the repo, snapshot via the serialiser, then
+      // apply that snapshot to a fresh DB and confirm the row arrives.
+      final workout = await seedParentWorkout();
+      final session = StretchingSession.create(
+        workoutId: workout.id,
+        type: 'frontSplits',
+        durationSeconds: 120,
+        entryMethod: StretchingEntryMethod.manual,
+        bodyArea: StretchingBodyArea.hamstrings,
+        notes: 'tight',
+      );
+      await stretchingRepo.createSession(session);
+
+      // Snapshot the source DB.
+      final snapshot = await serialiser.createFromDatabase(
+        database,
+        deviceId: 'source-device',
+      );
+      expect(snapshot.stretchingSessions, hasLength(1));
+
+      // Apply to a fresh DB.
+      final destination = db.AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(destination.close);
+      // Seed the parent workout in the destination too (FK requirement).
+      await DriftWorkoutRepository(destination).createWorkout(workout);
+      await serialiser.applyToDatabase(destination, snapshot);
+
+      final landed =
+          await DriftStretchingSessionRepository(destination).getSession(
+        session.id,
+      );
+      expect(landed, isNotNull);
+      expect(landed!.type, 'frontSplits');
+      expect(landed.durationSeconds, 120);
+      expect(landed.entryMethod, StretchingEntryMethod.manual);
+      expect(landed.bodyArea, StretchingBodyArea.hamstrings);
+      expect(landed.notes, 'tight');
+    });
+  });
+}

--- a/test/features/sync/data/sync_snapshot_serialiser_test.dart
+++ b/test/features/sync/data/sync_snapshot_serialiser_test.dart
@@ -1,0 +1,267 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_foundry/core/database/app_database.dart' show AppDatabase;
+import 'package:rep_foundry/features/body_metrics/domain/models/body_metric.dart';
+import 'package:rep_foundry/features/cardio/domain/models/cardio_session.dart';
+import 'package:rep_foundry/features/exercises/domain/models/exercise.dart';
+import 'package:rep_foundry/features/history/domain/models/personal_record.dart';
+import 'package:rep_foundry/features/programmes/domain/models/programme.dart';
+import 'package:rep_foundry/features/stretching/domain/models/stretching_session.dart';
+import 'package:rep_foundry/features/sync/data/sync_snapshot_serialiser.dart';
+import 'package:rep_foundry/features/sync/domain/models/sync_snapshot.dart';
+import 'package:rep_foundry/features/sync/domain/sync_schema_version_exception.dart';
+import 'package:rep_foundry/features/templates/domain/models/workout_template.dart';
+import 'package:rep_foundry/features/workout/domain/models/workout.dart';
+import 'package:rep_foundry/features/workout/domain/models/workout_set.dart';
+
+void main() {
+  final ts = DateTime.utc(2026, 4, 1, 12, 0);
+  final tombstone = DateTime.utc(2026, 4, 2, 9, 30);
+
+  late SyncSnapshotSerialiser serialiser;
+
+  setUp(() {
+    serialiser = SyncSnapshotSerialiser();
+  });
+
+  SyncSnapshot makeFullSnapshot() {
+    return SyncSnapshot(
+      snapshotAt: ts,
+      deviceId: 'device-a',
+      schemaVersion: AppDatabase.schemaVersionConst,
+      exercises: [
+        Exercise(
+          id: 'ex-1',
+          name: 'Bench',
+          category: ExerciseCategory.strength,
+          muscleGroup: MuscleGroup.chest,
+          equipmentType: EquipmentType.barbell,
+          updatedAt: ts,
+          deletedAt: tombstone,
+        ),
+      ],
+      workouts: [
+        Workout(
+          id: 'wo-1',
+          startedAt: ts,
+          updatedAt: ts,
+          deletedAt: tombstone,
+        ),
+      ],
+      workoutSets: [
+        WorkoutSet(
+          id: 'set-1',
+          workoutId: 'wo-1',
+          exerciseId: 'ex-1',
+          setOrder: 1,
+          weight: 100,
+          reps: 5,
+          timestamp: ts,
+          updatedAt: ts,
+          deletedAt: tombstone,
+        ),
+      ],
+      cardioSessions: [
+        CardioSession(
+          id: 'card-1',
+          workoutId: 'wo-1',
+          exerciseId: 'ex-1',
+          durationSeconds: 600,
+          updatedAt: ts,
+          deletedAt: tombstone,
+        ),
+      ],
+      personalRecords: [
+        PersonalRecord(
+          id: 'pr-1',
+          exerciseId: 'ex-1',
+          recordType: RecordType.maxWeight,
+          value: 100,
+          achievedAt: ts,
+          updatedAt: ts,
+          deletedAt: tombstone,
+        ),
+      ],
+      workoutTemplates: [
+        WorkoutTemplate(
+          id: 'tpl-1',
+          name: 'Push',
+          createdAt: ts,
+          updatedAt: ts,
+          deletedAt: tombstone,
+        ),
+      ],
+      templateExercises: [
+        TemplateExercise(
+          id: 'te-1',
+          templateId: 'tpl-1',
+          exerciseId: 'ex-1',
+          exerciseName: 'Bench',
+          targetSets: 3,
+          targetReps: 5,
+          orderIndex: 0,
+          updatedAt: ts,
+          deletedAt: tombstone,
+        ),
+      ],
+      bodyMetrics: [
+        BodyMetric(
+          id: 'bm-1',
+          date: ts,
+          weight: 80,
+          updatedAt: ts,
+          deletedAt: tombstone,
+        ),
+      ],
+      programmes: [
+        Programme(
+          id: 'prg-1',
+          name: 'Strength',
+          durationWeeks: 12,
+          createdAt: ts,
+          updatedAt: ts,
+          deletedAt: tombstone,
+        ),
+      ],
+      programmeDays: [
+        ProgrammeDay(
+          id: 'pd-1',
+          programmeId: 'prg-1',
+          weekNumber: 1,
+          dayOfWeek: 1,
+          templateId: 'tpl-1',
+          templateName: 'Push',
+          updatedAt: ts,
+          deletedAt: tombstone,
+        ),
+      ],
+      progressionRules: [
+        ProgressionRule(
+          id: 'pr-rule-1',
+          programmeId: 'prg-1',
+          exerciseId: 'ex-1',
+          type: ProgressionType.fixedIncrement,
+          value: 2.5,
+          updatedAt: ts,
+          deletedAt: tombstone,
+        ),
+      ],
+      stretchingSessions: [
+        StretchingSession(
+          id: 'st-1',
+          workoutId: 'wo-1',
+          type: 'pigeon',
+          durationSeconds: 60,
+          entryMethod: StretchingEntryMethod.timer,
+          startedAt: ts,
+          endedAt: ts.add(const Duration(seconds: 60)),
+          bodyArea: StretchingBodyArea.hips,
+          side: StretchingSide.left,
+          updatedAt: ts,
+          deletedAt: tombstone,
+        ),
+      ],
+    );
+  }
+
+  group('SyncSnapshotSerialiser JSON round-trip', () {
+    test('preserves deletedAt for every entity type', () {
+      final original = makeFullSnapshot();
+
+      final json = serialiser.toJson(original);
+      final round = serialiser.fromJson(json);
+
+      // Every list should round-trip its single tombstoned entity.
+      expect(round.exercises.single.deletedAt, equals(tombstone));
+      expect(round.workouts.single.deletedAt, equals(tombstone));
+      expect(round.workoutSets.single.deletedAt, equals(tombstone));
+      expect(round.cardioSessions.single.deletedAt, equals(tombstone));
+      expect(round.personalRecords.single.deletedAt, equals(tombstone));
+      expect(round.workoutTemplates.single.deletedAt, equals(tombstone));
+      expect(round.templateExercises.single.deletedAt, equals(tombstone));
+      expect(round.bodyMetrics.single.deletedAt, equals(tombstone));
+      expect(round.programmes.single.deletedAt, equals(tombstone));
+      expect(round.programmeDays.single.deletedAt, equals(tombstone));
+      expect(round.progressionRules.single.deletedAt, equals(tombstone));
+      expect(round.stretchingSessions.single.deletedAt, equals(tombstone));
+    });
+
+    test('stretching sessions survive a full JSON round-trip', () {
+      final original = makeFullSnapshot();
+
+      final json = serialiser.toJson(original);
+      final round = serialiser.fromJson(json);
+
+      final s = round.stretchingSessions.single;
+      expect(s.id, 'st-1');
+      expect(s.type, 'pigeon');
+      expect(s.bodyArea, StretchingBodyArea.hips);
+      expect(s.side, StretchingSide.left);
+      expect(s.entryMethod, StretchingEntryMethod.timer);
+      expect(s.durationSeconds, 60);
+    });
+
+    test('schemaVersion in JSON matches AppDatabase.schemaVersionConst', () {
+      final original = makeFullSnapshot();
+      final json = serialiser.toJson(original);
+      final decoded = jsonDecode(json) as Map<String, dynamic>;
+      expect(decoded['schemaVersion'], equals(AppDatabase.schemaVersionConst));
+    });
+
+    test('older snapshot without stretchingSessions key still parses', () {
+      // Simulate a snapshot from an older client that did not write the
+      // stretchingSessions key. The serialiser must accept it and produce
+      // an empty list rather than throwing.
+      final json = jsonEncode({
+        'version': 1,
+        'schemaVersion': AppDatabase.schemaVersionConst - 1,
+        'snapshotAt': ts.toIso8601String(),
+        'deviceId': 'old-device',
+      });
+
+      final round = serialiser.fromJson(json);
+      expect(round.stretchingSessions, isEmpty);
+      expect(round.exercises, isEmpty);
+    });
+  });
+
+  group('SyncSnapshotSerialiser schema-version validation', () {
+    test('fromJson rejects snapshot with schemaVersion > local', () {
+      final json = jsonEncode({
+        'version': 1,
+        'schemaVersion': AppDatabase.schemaVersionConst + 1,
+        'snapshotAt': ts.toIso8601String(),
+        'deviceId': 'newer-device',
+      });
+
+      expect(
+        () => serialiser.fromJson(json),
+        throwsA(isA<SyncSchemaVersionException>()),
+      );
+    });
+
+    test('fromJson accepts snapshot with schemaVersion < local', () {
+      final json = jsonEncode({
+        'version': 1,
+        'schemaVersion': 1,
+        'snapshotAt': ts.toIso8601String(),
+        'deviceId': 'older-device',
+      });
+
+      final round = serialiser.fromJson(json);
+      expect(round.deviceId, 'older-device');
+      expect(round.schemaVersion, 1);
+    });
+
+    test('SyncSchemaVersionException carries user-facing message', () {
+      final exception = SyncSchemaVersionException.tooNew(
+        AppDatabase.schemaVersionConst + 1,
+        AppDatabase.schemaVersionConst,
+      );
+
+      expect(exception.message, contains('newer version'));
+      expect(exception.message, contains('Please update'));
+    });
+  });
+}

--- a/test/features/sync/domain/sync_merge_engine_test.dart
+++ b/test/features/sync/domain/sync_merge_engine_test.dart
@@ -28,6 +28,7 @@ void main() {
     required String id,
     required String name,
     required DateTime updatedAt,
+    DateTime? deletedAt,
   }) =>
       Exercise(
         id: id,
@@ -36,18 +37,21 @@ void main() {
         muscleGroup: MuscleGroup.chest,
         equipmentType: EquipmentType.barbell,
         updatedAt: updatedAt,
+        deletedAt: deletedAt,
       );
 
   Workout makeWorkout({
     required String id,
     required DateTime updatedAt,
     String? notes,
+    DateTime? deletedAt,
   }) =>
       Workout(
         id: id,
         startedAt: baseTime,
         updatedAt: updatedAt,
         notes: notes,
+        deletedAt: deletedAt,
       );
 
   setUp(() {
@@ -261,6 +265,143 @@ void main() {
       // Workout wo-2: remote only → kept
       final mergedWo2 = result.workouts.firstWhere((w) => w.id == 'wo-2');
       expect(mergedWo2.notes, equals('Only Remote'));
+    });
+
+    group('tombstones', () {
+      test('tombstone beats live, regardless of updatedAt order', () {
+        // Local has live row updated *after* the remote tombstone — but
+        // the tombstone must still win, otherwise deletes resurrect.
+        final liveLocal = makeExercise(
+          id: 'ex-1',
+          name: 'Resurrected',
+          updatedAt: later,
+        );
+        final tombstonedRemote = makeExercise(
+          id: 'ex-1',
+          name: 'Deleted',
+          updatedAt: earlier,
+          deletedAt: earlier,
+        );
+
+        final local = makeSnapshot(exercises: [liveLocal]);
+        final remote = makeSnapshot(
+          deviceId: 'device-remote',
+          exercises: [tombstonedRemote],
+        );
+
+        final result = engine.merge(local: local, remote: remote);
+
+        expect(result.exercises, hasLength(1));
+        expect(result.exercises.first.deletedAt, isNotNull);
+        expect(result.exercises.first.name, equals('Deleted'));
+      });
+
+      test('live remote vs tombstoned local — local tombstone wins', () {
+        final tombstonedLocal = makeExercise(
+          id: 'ex-1',
+          name: 'Deleted Locally',
+          updatedAt: earlier,
+          deletedAt: earlier,
+        );
+        final liveRemote = makeExercise(
+          id: 'ex-1',
+          name: 'Live Remote',
+          updatedAt: later,
+        );
+
+        final local = makeSnapshot(exercises: [tombstonedLocal]);
+        final remote = makeSnapshot(
+          deviceId: 'device-remote',
+          exercises: [liveRemote],
+        );
+
+        final result = engine.merge(local: local, remote: remote);
+
+        expect(result.exercises, hasLength(1));
+        expect(result.exercises.first.deletedAt, isNotNull);
+      });
+
+      test('both tombstoned — larger deletedAt wins', () {
+        final earlyTombstoneLocal = makeExercise(
+          id: 'ex-1',
+          name: 'Early',
+          updatedAt: baseTime,
+          deletedAt: earlier,
+        );
+        final lateTombstoneRemote = makeExercise(
+          id: 'ex-1',
+          name: 'Late',
+          updatedAt: baseTime,
+          deletedAt: later,
+        );
+
+        final local = makeSnapshot(exercises: [earlyTombstoneLocal]);
+        final remote = makeSnapshot(
+          deviceId: 'device-remote',
+          exercises: [lateTombstoneRemote],
+        );
+
+        final result = engine.merge(local: local, remote: remote);
+
+        expect(result.exercises, hasLength(1));
+        expect(result.exercises.first.name, equals('Late'));
+        expect(result.exercises.first.deletedAt, equals(later));
+      });
+
+      test('both live — falls through to updatedAt comparison', () {
+        // Sanity: deletedAt awareness must not regress the existing
+        // live/live behaviour.
+        final localLive = makeExercise(
+          id: 'ex-1',
+          name: 'Old',
+          updatedAt: earlier,
+        );
+        final remoteLive = makeExercise(
+          id: 'ex-1',
+          name: 'New',
+          updatedAt: later,
+        );
+
+        final local = makeSnapshot(exercises: [localLive]);
+        final remote = makeSnapshot(
+          deviceId: 'device-remote',
+          exercises: [remoteLive],
+        );
+
+        final result = engine.merge(local: local, remote: remote);
+
+        expect(result.exercises.first.name, equals('New'));
+        expect(result.exercises.first.deletedAt, isNull);
+      });
+
+      test('delete-then-edit-on-other-device — tombstone propagates', () {
+        // Device A deletes a workout (tombstone). Device B edits the
+        // same workout before syncing. After merge: tombstone wins,
+        // edits are discarded.
+        final tombstonedFromA = makeWorkout(
+          id: 'wo-1',
+          updatedAt: earlier,
+          deletedAt: earlier,
+          notes: 'before delete',
+        );
+        final editedOnB = makeWorkout(
+          id: 'wo-1',
+          updatedAt: later,
+          notes: 'edits made on B',
+        );
+
+        // Local is B (edited), remote is A (deleted).
+        final local = makeSnapshot(workouts: [editedOnB]);
+        final remote = makeSnapshot(
+          deviceId: 'device-a',
+          workouts: [tombstonedFromA],
+        );
+
+        final result = engine.merge(local: local, remote: remote);
+
+        expect(result.workouts, hasLength(1));
+        expect(result.workouts.first.deletedAt, isNotNull);
+      });
     });
   });
 }

--- a/test/features/templates/data/drift_workout_template_repository_test.dart
+++ b/test/features/templates/data/drift_workout_template_repository_test.dart
@@ -151,7 +151,7 @@ void main() {
     });
 
     group('deleteTemplate', () {
-      test('hard-deletes template and its exercises', () async {
+      test('soft-deletes template and cascades to exercises', () async {
         final template = newTemplate();
         final withExercise = template.copyWith(
           exercises: [
@@ -165,8 +165,33 @@ void main() {
         await repo.createTemplate(withExercise);
         await repo.deleteTemplate(template.id);
 
+        // Public reads filter the tombstoned template.
         final fetched = await repo.getTemplate(template.id);
         expect(fetched, isNull);
+
+        // Bypass the filter and confirm both rows are preserved with
+        // deletedAt set, so a sync can propagate the cascading delete.
+        final rawTemplates =
+            await database.select(database.workoutTemplates).get();
+        expect(rawTemplates, hasLength(1));
+        expect(rawTemplates.single.deletedAt, isNotNull);
+
+        final rawExercises =
+            await database.select(database.templateExercises).get();
+        expect(rawExercises, hasLength(1));
+        expect(rawExercises.single.deletedAt, isNotNull);
+      });
+
+      test('tombstoned templates are excluded from getAllTemplates', () async {
+        final live = newTemplate(name: 'Push');
+        final dead = newTemplate(name: 'Legs');
+        await repo.createTemplate(live);
+        await repo.createTemplate(dead);
+        await repo.deleteTemplate(dead.id);
+
+        final all = await repo.getAllTemplates();
+        expect(all, hasLength(1));
+        expect(all.single.name, 'Push');
       });
     });
 

--- a/test/features/workout/data/drift_workout_repository_test.dart
+++ b/test/features/workout/data/drift_workout_repository_test.dart
@@ -281,7 +281,7 @@ void main() {
     });
 
     group('deleteSet', () {
-      test('hard-deletes a set', () async {
+      test('soft-deletes: getSetsForWorkout excludes the set', () async {
         final workout = newWorkout();
         await repo.createWorkout(workout);
 
@@ -291,6 +291,41 @@ void main() {
 
         final sets = await repo.getSetsForWorkout(workout.id);
         expect(sets, isEmpty);
+      });
+
+      test('row is preserved in DB with deletedAt non-null', () async {
+        final workout = newWorkout();
+        await repo.createWorkout(workout);
+
+        final set = newSet(workoutId: workout.id);
+        await repo.addSet(set);
+        await repo.deleteSet(set.id);
+
+        // Bypass the repo filter and inspect the table directly. The
+        // tombstone must persist so a subsequent sync can propagate the
+        // delete; a hard-delete would let the next sync resurrect the row.
+        final raw = await database.select(database.workoutSets).get();
+        expect(raw, hasLength(1));
+        expect(raw.single.id, set.id);
+        expect(raw.single.deletedAt, isNotNull);
+      });
+
+      test('tombstone is hidden from getLastSetForExercise', () async {
+        final workout = newWorkout();
+        await repo.createWorkout(workout);
+
+        final live = newSet(workoutId: workout.id);
+        final deleted = newSet(workoutId: workout.id);
+        await repo.addSet(live);
+        await repo.addSet(deleted);
+        await repo.deleteSet(deleted.id);
+
+        final last = await repo.getLastSetForExercise(live.exerciseId);
+        expect(last, isNotNull);
+        expect(last!.id, anyOf(live.id, deleted.id));
+        // Whichever of the two was returned, it must not be the tombstoned
+        // one — getLastSetForExercise filters deletedAt IS NULL.
+        expect(last.deletedAt, isNull);
       });
     });
 


### PR DESCRIPTION
## Summary

Closes the five ship-blocking sync defects tracked in #25. Each was identified by the 2026-04-30 code review; the current sync feature silently loses user data and these together gate any sync-enabled release.

- **#20** — stretching sessions added to the sync snapshot, serialiser, and merge engine.
- **#21** — `deletedAt` added to 9 domain models, 9 Drift tables, and 6 repositories (with cascading soft-delete for templates → exercises and programme → days + rules). Merge engine now tombstone-aware: a tombstone always beats a live row; larger `deletedAt` wins ties.
- **#22** — `SyncSnapshot.schemaVersion` now sourced from `AppDatabase.schemaVersionConst` (bumped 9 → 10); `fromJson` refuses newer-than-local snapshots with user-facing copy via the new `SyncSchemaVersionException`; older-than-local accepted.
- **#23** — orchestrator reordered to **upload-first**; on upload failure the local DB stays untouched.
- **#24** — v10 migration retrofits `updated_at = 0` rows to `MAX(updated_at, <best timestamp>)` per table (`timestamp` / `achieved_at` / `date` / `started_at` / `created_at`); tables without a meaningful own timestamp get migration-time stamping so post-v6 rows do not always win on first sync after upgrade.

Schema bumps to **v10**. Single migration covers tombstones + `updatedAt` backfill so users see one upgrade, not two.

## Test plan

- [x] Tombstone semantics — 6 new cases in `sync_merge_engine_test.dart` (both directions, tie, regression, multi-device propagation).
- [x] `deletedAt` JSON round-trip for all 12 entity types — new `sync_snapshot_serialiser_test.dart`.
- [x] Schema-version validation — too-new rejected, too-old accepted, older-snapshot-without-stretching-key tolerated.
- [x] Orchestrator atomicity — upload happens before `applyToDatabase`; upload failure leaves DB untouched; `SyncSchemaVersionException` propagates as `SyncResult.error`.
- [x] Repository soft-delete — 14 new cases across body_metric, cardio, personal_record, template, programme, workout-set repos confirming row preserved with `deletedAt` set, public reads filter tombstones, cascading soft-delete for templates and programmes.
- [x] Stretching ↔ DB integration — new `sync_snapshot_serialiser_db_test.dart` covering insert, custom-name + null-enum path, upsert on conflict, tombstone round-trip, end-to-end source-DB → snapshot → fresh-DB.
- [x] `flutter test` — **all 803 tests pass** (+19 new).
- [x] `dart analyze` — no issues.
- [x] `dart format --set-exit-if-changed` — clean.
- [ ] Manual: install previous build (v9), populate stretching + workout-set + body-metric data, upgrade to this build, sign in to cloud sync, confirm a stretching session syncs to a second device.
- [ ] Manual: delete a workout-set on Device A, sync; confirm the set is removed on Device B after sync (tombstone propagates).
- [ ] Manual: simulate upload failure (airplane-mode after the snapshot is built) → confirm local DB rolls back to pre-merge state and a retry succeeds.

## Deferred

- A dedicated v9 → v10 schema-migration test using Drift's `schema_test_utils` requires generating fixtures via `dart run drift_dev schema dump`; left as follow-up since the dumps are not yet checked in.
- Tombstone retention / GC policy — tombstones grow forever; raise as separate issue.