### PR TITLE
feat: responsive desktop power-layouts with adaptive navigation

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../core/responsive/layout_mode.dart';
+import '../features/settings/presentation/providers/layout_mode_provider.dart';
 import '../features/settings/presentation/providers/theme_mode_provider.dart';
 import '../l10n/generated/app_localizations.dart';
 import 'router.dart';
@@ -12,6 +14,7 @@ class RepFoundryApp extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final router = ref.watch(routerProvider);
     final themeMode = ref.watch(themeModeProvider);
+    final layoutMode = ref.watch(layoutModeProvider);
     return MaterialApp.router(
       title: 'RepFoundry',
       theme: AppTheme.light,
@@ -21,6 +24,12 @@ class RepFoundryApp extends ConsumerWidget {
       debugShowCheckedModeBanner: false,
       localizationsDelegates: S.localizationsDelegates,
       supportedLocales: S.supportedLocales,
+      // Make the user's layout override available to the width-based breakpoint
+      // helpers throughout the routed tree.
+      builder: (context, child) => LayoutModeScope(
+        mode: layoutMode,
+        child: child ?? const SizedBox.shrink(),
+      ),
     );
   }
 }

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -23,6 +23,10 @@ final routerProvider = Provider<GoRouter>((ref) {
   return GoRouter(
     initialLocation: '/workout',
     routes: [
+      // Primary destinations live inside the adaptive nav shell so the desktop
+      // side-rail stays visible across all of them. On mobile only the five
+      // core tabs surface the bottom nav (see [ScaffoldWithNavBar]); the others
+      // keep their original full-screen presentation.
       ShellRoute(
         builder: (context, state, child) => ScaffoldWithNavBar(child: child),
         routes: [
@@ -51,6 +55,34 @@ final routerProvider = Provider<GoRouter>((ref) {
             builder: (context, state) => const HeartRatePanelScreen(),
           ),
           GoRoute(
+            path: '/analytics',
+            builder: (context, state) => const AnalyticsScreen(),
+          ),
+          GoRoute(
+            path: '/templates',
+            builder: (context, state) => const TemplateListScreen(),
+            routes: [
+              GoRoute(
+                path: ':id',
+                builder: (context, state) => TemplateEditScreen(
+                  templateId: state.pathParameters['id']!,
+                ),
+              ),
+            ],
+          ),
+          GoRoute(
+            path: '/programmes',
+            builder: (context, state) => const ProgrammeListScreen(),
+            routes: [
+              GoRoute(
+                path: ':id',
+                builder: (context, state) => ProgrammeEditScreen(
+                  programmeId: state.pathParameters['id']!,
+                ),
+              ),
+            ],
+          ),
+          GoRoute(
             path: '/settings',
             builder: (context, state) => const SettingsScreen(),
             routes: [
@@ -66,18 +98,7 @@ final routerProvider = Provider<GoRouter>((ref) {
           ),
         ],
       ),
-      GoRoute(
-        path: '/templates',
-        builder: (context, state) => const TemplateListScreen(),
-        routes: [
-          GoRoute(
-            path: ':id',
-            builder: (context, state) => TemplateEditScreen(
-              templateId: state.pathParameters['id']!,
-            ),
-          ),
-        ],
-      ),
+      // Deep / contextual routes that sit outside the nav shell.
       GoRoute(
         path: '/exercises',
         builder: (context, state) => const ExercisePickerScreen(),
@@ -95,22 +116,6 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/body-metrics',
         builder: (context, state) => const BodyMetricsScreen(),
-      ),
-      GoRoute(
-        path: '/analytics',
-        builder: (context, state) => const AnalyticsScreen(),
-      ),
-      GoRoute(
-        path: '/programmes',
-        builder: (context, state) => const ProgrammeListScreen(),
-        routes: [
-          GoRoute(
-            path: ':id',
-            builder: (context, state) => ProgrammeEditScreen(
-              programmeId: state.pathParameters['id']!,
-            ),
-          ),
-        ],
       ),
     ],
   );

--- a/lib/core/providers.dart
+++ b/lib/core/providers.dart
@@ -4,6 +4,7 @@ import '../features/body_metrics/data/drift_body_metric_repository.dart';
 import '../features/body_metrics/domain/models/body_metric.dart';
 import '../features/body_metrics/domain/repositories/body_metric_repository.dart';
 import '../features/exercises/data/drift_exercise_repository.dart';
+import '../features/exercises/domain/models/exercise.dart';
 import '../features/exercises/domain/repositories/exercise_repository.dart';
 import '../features/workout/data/drift_workout_repository.dart';
 import '../features/workout/domain/repositories/workout_repository.dart';
@@ -48,6 +49,16 @@ final bodyMetricsStreamProvider =
 
 final exerciseRepositoryProvider = Provider<ExerciseRepository>((ref) {
   return DriftExerciseRepository(ref.watch(databaseProvider));
+});
+
+/// Maps exercise id → [Exercise] for resolving names and muscle groups in
+/// presentation (e.g. the desktop history detail and template panes), where
+/// only ids are stored on sets.
+final exerciseLookupProvider =
+    FutureProvider.autoDispose<Map<String, Exercise>>((ref) async {
+  final exercises =
+      await ref.watch(exerciseRepositoryProvider).getAllExercises();
+  return {for (final e in exercises) e.id: e};
 });
 
 final workoutRepositoryProvider = Provider<WorkoutRepository>((ref) {

--- a/lib/core/responsive/breakpoints.dart
+++ b/lib/core/responsive/breakpoints.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/widgets.dart';
+
+import 'layout_mode.dart';
+
+/// Responsive breakpoints for the "desktop power-layout" pattern.
+///
+/// The app is mobile-first: below [tablet] it keeps the bottom-nav phone
+/// layouts unchanged. From [tablet] up the navigation becomes a side-rail and
+/// screens may reflow into two-pane "power layouts" (master-detail, dashboard
+/// grid, library + canvas). See the docs site for the full pattern.
+class Breakpoints {
+  Breakpoints._();
+
+  /// Width at or above which the side-rail appears (tablet and up).
+  static const double tablet = 600;
+
+  /// Width at or above which full desktop two-pane power-layouts are used.
+  static const double desktop = 1024;
+
+  /// Width of the labeled desktop navigation rail (`.dnav` in the design).
+  static const double navRailWidth = 252;
+}
+
+/// Convenience width queries on [BuildContext].
+///
+/// [hasNavRail] and [isWide] honour the user's [LayoutMode] override, but only
+/// from [Breakpoints.tablet] up — phone widths always use the mobile layout so
+/// the desktop chrome can never be forced onto a too-small screen.
+extension ResponsiveContext on BuildContext {
+  double get screenWidth => MediaQuery.sizeOf(this).width;
+
+  LayoutMode get layoutMode => LayoutModeScope.of(this);
+
+  /// Raw width buckets (ignore the override) — handy for fine-grained tuning.
+  bool get isMobile => screenWidth < Breakpoints.tablet;
+  bool get isTablet =>
+      screenWidth >= Breakpoints.tablet && screenWidth < Breakpoints.desktop;
+  bool get isDesktop => screenWidth >= Breakpoints.desktop;
+
+  /// True when the side-rail replaces the bottom nav. Honours the override on
+  /// tablet+ widths; phones always return false.
+  bool get hasNavRail {
+    if (screenWidth < Breakpoints.tablet) return false;
+    switch (layoutMode) {
+      case LayoutMode.mobile:
+        return false;
+      case LayoutMode.desktop:
+      case LayoutMode.auto:
+        return true;
+    }
+  }
+
+  /// True when bespoke two-pane power layouts apply. Honours the override on
+  /// tablet+ widths; phones always return false.
+  bool get isWide {
+    if (screenWidth < Breakpoints.tablet) return false;
+    switch (layoutMode) {
+      case LayoutMode.mobile:
+        return false;
+      case LayoutMode.desktop:
+        return true;
+      case LayoutMode.auto:
+        return screenWidth >= Breakpoints.desktop;
+    }
+  }
+}

--- a/lib/core/responsive/layout_mode.dart
+++ b/lib/core/responsive/layout_mode.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/widgets.dart';
+
+/// User preference for which responsive layout to present.
+///
+/// The override is **tablet-and-up only** — on phone widths (`< 600`) the app
+/// always uses the mobile layout regardless of this value. See
+/// `ResponsiveContext` in `breakpoints.dart` for how it is applied.
+enum LayoutMode {
+  /// Pick the layout from the window width (the default behaviour).
+  auto,
+
+  /// Force the mobile experience (bottom nav, single-pane) on tablet+ widths.
+  mobile,
+
+  /// Force the desktop experience (side-rail, two-pane power layouts) on
+  /// tablet+ widths.
+  desktop,
+}
+
+/// Propagates the active [LayoutMode] down the tree so the width-based
+/// breakpoint helpers can consult it. Installed near the app root (see
+/// `RepFoundryApp`); absent in isolated widget tests, where it defaults to
+/// [LayoutMode.auto].
+class LayoutModeScope extends InheritedWidget {
+  const LayoutModeScope({
+    super.key,
+    required this.mode,
+    required super.child,
+  });
+
+  final LayoutMode mode;
+
+  static LayoutMode? maybeOf(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<LayoutModeScope>()?.mode;
+  }
+
+  static LayoutMode of(BuildContext context) {
+    return maybeOf(context) ?? LayoutMode.auto;
+  }
+
+  @override
+  bool updateShouldNotify(LayoutModeScope oldWidget) => mode != oldWidget.mode;
+}

--- a/lib/core/widgets/desktop_nav_rail.dart
+++ b/lib/core/widgets/desktop_nav_rail.dart
@@ -1,0 +1,309 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:rep_foundry/l10n/generated/app_localizations.dart';
+
+import 'kinetic.dart';
+
+/// A single destination in the desktop navigation rail.
+class RailDestination {
+  const RailDestination({
+    required this.label,
+    required this.icon,
+    required this.activeIcon,
+  });
+
+  final String label;
+  final IconData icon;
+  final IconData activeIcon;
+}
+
+/// A named group of destinations in the rail (e.g. "Train", "Review").
+class RailGroup {
+  const RailGroup({required this.heading, required this.destinations});
+
+  final String heading;
+  final List<RailDestination> destinations;
+}
+
+/// Persistent labeled side navigation for desktop/tablet widths — the
+/// "desktop power-layout" shell. Mirrors the design's `.dnav` (252px): a logo
+/// header, intent-grouped destinations (Train / Review / Plan), and Settings
+/// pinned to the bottom. The active item uses an accent-soft background with
+/// accent text and a filled icon.
+///
+/// Destinations are addressed by a flat index spanning all groups plus the
+/// trailing Settings entry, so it composes with a simple `int selectedIndex`.
+class DesktopNavRail extends StatelessWidget {
+  const DesktopNavRail({
+    super.key,
+    required this.selectedIndex,
+    required this.onDestinationSelected,
+  });
+
+  /// Flat index across all grouped destinations followed by Settings (last).
+  final int selectedIndex;
+  final ValueChanged<int> onDestinationSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final s = S.of(context)!;
+    final cs = Theme.of(context).colorScheme;
+
+    final groups = [
+      RailGroup(
+        heading: s.navGroupTrain,
+        destinations: [
+          RailDestination(
+            label: s.navWorkout,
+            icon: Icons.fitness_center,
+            activeIcon: Icons.fitness_center,
+          ),
+          RailDestination(
+            label: s.navCardio,
+            icon: Icons.directions_run,
+            activeIcon: Icons.directions_run,
+          ),
+        ],
+      ),
+      RailGroup(
+        heading: s.navGroupReview,
+        destinations: [
+          RailDestination(
+            label: s.navHistory,
+            icon: Icons.bar_chart_outlined,
+            activeIcon: Icons.bar_chart,
+          ),
+          RailDestination(
+            label: s.analyticsTitle,
+            icon: Icons.insights_outlined,
+            activeIcon: Icons.insights,
+          ),
+          RailDestination(
+            label: s.navHeartRate,
+            icon: Icons.favorite_border,
+            activeIcon: Icons.favorite,
+          ),
+        ],
+      ),
+      RailGroup(
+        heading: s.navGroupPlan,
+        destinations: [
+          RailDestination(
+            label: s.templatesTitle,
+            icon: Icons.dashboard_outlined,
+            activeIcon: Icons.dashboard,
+          ),
+          RailDestination(
+            label: s.programmesTitle,
+            icon: Icons.calendar_month_outlined,
+            activeIcon: Icons.calendar_month,
+          ),
+        ],
+      ),
+    ];
+
+    // Index of the trailing Settings entry = total grouped destinations.
+    final settingsIndex =
+        groups.fold<int>(0, (sum, g) => sum + g.destinations.length);
+
+    // Build the grouped items, tracking the running flat index.
+    final children = <Widget>[];
+    var flatIndex = 0;
+    for (final group in groups) {
+      children.add(_GroupHeading(group.heading));
+      for (final dest in group.destinations) {
+        final i = flatIndex;
+        children.add(_RailItem(
+          destination: dest,
+          selected: i == selectedIndex,
+          onTap: () => onDestinationSelected(i),
+        ));
+        flatIndex++;
+      }
+      children.add(const SizedBox(height: 18));
+    }
+
+    return Container(
+      width: 252,
+      decoration: BoxDecoration(
+        color: cs.surface,
+        border: Border(
+          right: BorderSide(color: cs.outlineVariant, width: 1),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const _RailHeader(),
+          Expanded(
+            child: ListView(
+              padding: const EdgeInsets.fromLTRB(14, 4, 14, 8),
+              children: children,
+            ),
+          ),
+          Divider(height: 1, thickness: 1, color: cs.outlineVariant),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(14, 10, 14, 6),
+            child: _RailItem(
+              destination: RailDestination(
+                label: s.navSettings,
+                icon: Icons.settings_outlined,
+                activeIcon: Icons.settings,
+              ),
+              selected: selectedIndex == settingsIndex,
+              onTap: () => onDestinationSelected(settingsIndex),
+            ),
+          ),
+          const _RailFooter(),
+        ],
+      ),
+    );
+  }
+}
+
+/// Logo + wordmark header at the top of the rail.
+class _RailHeader extends StatelessWidget {
+  const _RailHeader();
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 22, 20, 16),
+      child: Row(
+        children: [
+          Container(
+            width: 34,
+            height: 34,
+            decoration: BoxDecoration(
+              color: cs.primary,
+              borderRadius: BorderRadius.circular(11),
+            ),
+            child: Icon(Icons.bolt, size: 20, color: cs.onPrimary),
+          ),
+          const SizedBox(width: 10),
+          Flexible(
+            child: Text.rich(
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              TextSpan(
+                style: KineticText.display(
+                  size: 18,
+                  letterSpacing: -0.2,
+                  color: cs.onSurface,
+                ),
+                children: [
+                  const TextSpan(text: 'Rep'),
+                  TextSpan(
+                      text: 'Foundry', style: TextStyle(color: cs.primary)),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Uppercase mono group heading (e.g. "TRAIN").
+class _GroupHeading extends StatelessWidget {
+  const _GroupHeading(this.text);
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(10, 10, 0, 8),
+      child: Text(
+        text.toUpperCase(),
+        style: KineticText.mono(
+          size: 10,
+          weight: FontWeight.w700,
+          letterSpacing: 1.8,
+          color: cs.outline,
+        ),
+      ),
+    );
+  }
+}
+
+/// A single tappable rail destination row.
+class _RailItem extends StatelessWidget {
+  const _RailItem({
+    required this.destination,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final RailDestination destination;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final fg = selected ? cs.primary : cs.onSurfaceVariant;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2),
+      child: Material(
+        color:
+            selected ? cs.primary.withValues(alpha: 0.14) : Colors.transparent,
+        borderRadius: BorderRadius.circular(12),
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(12),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 11),
+            child: Row(
+              children: [
+                Icon(
+                  selected ? destination.activeIcon : destination.icon,
+                  size: 20,
+                  color: fg,
+                ),
+                const SizedBox(width: 13),
+                Expanded(
+                  child: Text(
+                    destination.label,
+                    overflow: TextOverflow.ellipsis,
+                    style: GoogleFonts.manrope(
+                      fontSize: 13.5,
+                      fontWeight: selected ? FontWeight.w700 : FontWeight.w600,
+                      color: selected ? cs.onSurface : cs.onSurfaceVariant,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Decorative footer beneath the rail — offline-first reassurance line.
+class _RailFooter extends StatelessWidget {
+  const _RailFooter();
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(24, 4, 24, 18),
+      child: Text(
+        'KINETIC-GREEN · OFFLINE-FIRST',
+        style: KineticText.mono(
+          size: 8.5,
+          weight: FontWeight.w600,
+          letterSpacing: 1.0,
+          color: cs.outline,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/core/widgets/desktop_top_bar.dart
+++ b/lib/core/widgets/desktop_top_bar.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import 'kinetic.dart';
+
+/// The page bar at the top of a desktop power-layout (`.dtop` in the design):
+/// an eyebrow + title/subtitle on the left and contextual actions on the right.
+///
+/// Sits above the two-pane body inside the content pane (the nav rail is the
+/// shell). Use it instead of a Material [AppBar] on desktop screens.
+class DesktopTopBar extends StatelessWidget {
+  const DesktopTopBar({
+    super.key,
+    required this.title,
+    this.eyebrow,
+    this.subtitle,
+    this.actions = const [],
+  });
+
+  final String title;
+  final String? eyebrow;
+  final String? subtitle;
+  final List<Widget> actions;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+
+    return Container(
+      padding: const EdgeInsets.fromLTRB(30, 24, 30, 20),
+      decoration: BoxDecoration(
+        border: Border(
+          bottom: BorderSide(color: cs.outlineVariant, width: 1),
+        ),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (eyebrow != null) ...[
+                  KineticEyebrow(eyebrow!),
+                  const SizedBox(height: 8),
+                ],
+                Text(
+                  title,
+                  style: KineticText.display(
+                    size: 28,
+                    weight: FontWeight.w700,
+                    letterSpacing: -0.7,
+                    color: cs.onSurface,
+                  ),
+                ),
+                if (subtitle != null) ...[
+                  const SizedBox(height: 4),
+                  Text(
+                    subtitle!,
+                    style: GoogleFonts.manrope(
+                      fontSize: 13.5,
+                      color: cs.onSurfaceVariant,
+                      height: 1.45,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+          if (actions.isNotEmpty) ...[
+            const SizedBox(width: 16),
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                for (var i = 0; i < actions.length; i++) ...[
+                  if (i > 0) const SizedBox(width: 10),
+                  actions[i],
+                ],
+              ],
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/lib/core/widgets/kpi_strip.dart
+++ b/lib/core/widgets/kpi_strip.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/widgets.dart';
+
+/// Lays out a row of stat/KPI tiles that reflows to fewer columns as width
+/// shrinks, so dense desktop strips stay readable (and never overflow) when a
+/// two-pane power layout is forced onto a narrow tablet.
+///
+/// Columns: 4 when wide, 2 when medium, 1 when very narrow.
+class KpiStrip extends StatelessWidget {
+  const KpiStrip({super.key, required this.tiles, this.gap = 12});
+
+  final List<Widget> tiles;
+  final double gap;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final width = constraints.maxWidth;
+        final columns = width >= 560
+            ? 4
+            : width >= 320
+                ? 2
+                : 1;
+        final effectiveColumns = columns.clamp(1, tiles.length);
+        final itemWidth =
+            (width - gap * (effectiveColumns - 1)) / effectiveColumns;
+        return Wrap(
+          spacing: gap,
+          runSpacing: gap,
+          children: [
+            for (final tile in tiles) SizedBox(width: itemWidth, child: tile),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/core/widgets/scaffold_with_nav_bar.dart
+++ b/lib/core/widgets/scaffold_with_nav_bar.dart
@@ -4,6 +4,19 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:rep_foundry/l10n/generated/app_localizations.dart';
 
+import '../responsive/breakpoints.dart';
+import 'desktop_nav_rail.dart';
+
+/// Adaptive navigation shell.
+///
+/// - **Mobile** (`< 600`): the existing glass bottom navigation bar, shown only
+///   for the five core tabs (Workout, History, Cardio, Heart Rate, Settings).
+///   Deeper routes that the shell also wraps (Analytics, Templates, Programmes)
+///   keep their original full-screen presentation with no bottom nav.
+/// - **Tablet / Desktop** (`>= 600`): a persistent labeled [DesktopNavRail] on
+///   the left with the page content beside it. Screens that provide a bespoke
+///   two-pane "power layout" fill the pane; the rest are centred at a readable
+///   maximum width rather than stretched.
 class ScaffoldWithNavBar extends StatelessWidget {
   const ScaffoldWithNavBar({super.key, required this.child});
 
@@ -11,35 +24,119 @@ class ScaffoldWithNavBar extends StatelessWidget {
 
   static const _navBarHeight = 72.0;
 
+  /// Maximum content width for screens without a bespoke desktop layout, so a
+  /// phone-shaped screen reads as a centred column rather than stretched.
+  static const _centredMaxWidth = 980.0;
+
+  /// Route prefixes that show the bottom nav on mobile (the five core tabs).
+  static const _coreTabPrefixes = [
+    '/workout',
+    '/history',
+    '/cardio',
+    '/heart-rate',
+    '/settings',
+  ];
+
+  /// Route prefixes with a bespoke full-width desktop two-pane layout.
+  static const _fullWidthDesktopPrefixes = [
+    '/history',
+    '/analytics',
+    '/templates',
+  ];
+
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: Stack(
-        children: [
-          // Page content with bottom padding for the nav bar.
-          Positioned.fill(
-            child: Padding(
-              padding: const EdgeInsets.only(bottom: _navBarHeight),
+    final location = GoRouterState.of(context).uri.toString();
+
+    if (context.hasNavRail) {
+      return _buildWithRail(context, location);
+    }
+    return _buildWithBottomNav(context, location);
+  }
+
+  // ── Desktop / tablet: side-rail + content pane ──────────────────────────
+
+  Widget _buildWithRail(BuildContext context, String location) {
+    final fullWidth =
+        _fullWidthDesktopPrefixes.any((p) => location.startsWith(p));
+
+    final content = fullWidth
+        ? child
+        : Align(
+            alignment: Alignment.topCenter,
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: _centredMaxWidth),
               child: child,
             ),
-          ),
-          // Glassmorphism navigation bar.
-          Positioned(
-            left: 0,
-            right: 0,
-            bottom: 0,
-            child: _GlassNavBar(
-              selectedIndex: _calculateSelectedIndex(context),
-              onTap: (index) => _onDestinationSelected(index, context),
+          );
+
+    return Scaffold(
+      body: SafeArea(
+        child: Row(
+          children: [
+            DesktopNavRail(
+              selectedIndex: _railIndexForLocation(location),
+              onDestinationSelected: (index) =>
+                  _onRailDestinationSelected(index, context),
             ),
-          ),
-        ],
+            Expanded(child: content),
+          ],
+        ),
       ),
     );
   }
 
-  int _calculateSelectedIndex(BuildContext context) {
-    final location = GoRouterState.of(context).uri.toString();
+  // ── Mobile: glass bottom navigation ─────────────────────────────────────
+
+  Widget _buildWithBottomNav(BuildContext context, String location) {
+    final showBottomNav = _coreTabPrefixes.any((p) => location.startsWith(p));
+
+    final Widget inner;
+    if (!showBottomNav) {
+      // Deeper routes wrapped by the shell (templates/programmes/analytics)
+      // keep their original full-screen presentation on mobile.
+      inner = child;
+    } else {
+      inner = Scaffold(
+        body: Stack(
+          children: [
+            Positioned.fill(
+              child: Padding(
+                padding: const EdgeInsets.only(bottom: _navBarHeight),
+                child: child,
+              ),
+            ),
+            Positioned(
+              left: 0,
+              right: 0,
+              bottom: 0,
+              child: _GlassNavBar(
+                selectedIndex: _bottomNavIndex(location),
+                onTap: (index) => _onBottomNavSelected(index, context),
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    // When the mobile layout is forced onto a wide screen (LayoutMode.mobile),
+    // present it as a centred phone-width column rather than stretching it.
+    if (context.screenWidth >= Breakpoints.tablet) {
+      return ColoredBox(
+        color: Theme.of(context).colorScheme.surface,
+        child: Center(
+          child: SizedBox(width: Breakpoints.tablet, child: inner),
+        ),
+      );
+    }
+    return inner;
+  }
+
+  // ── Index helpers ───────────────────────────────────────────────────────
+
+  /// Bottom-nav (mobile) index across the five core tabs.
+  int _bottomNavIndex(String location) {
     if (location.startsWith('/workout')) return 0;
     if (location.startsWith('/history')) return 1;
     if (location.startsWith('/cardio')) return 2;
@@ -47,7 +144,7 @@ class ScaffoldWithNavBar extends StatelessWidget {
     return 4;
   }
 
-  void _onDestinationSelected(int index, BuildContext context) {
+  void _onBottomNavSelected(int index, BuildContext context) {
     switch (index) {
       case 0:
         context.go('/workout');
@@ -58,6 +155,41 @@ class ScaffoldWithNavBar extends StatelessWidget {
       case 3:
         context.go('/heart-rate');
       case 4:
+        context.go('/settings');
+    }
+  }
+
+  /// Rail (desktop) flat index across all eight destinations.
+  /// Order: Workout, Cardio, History, Analytics, Heart Rate, Templates,
+  /// Programmes, Settings.
+  int _railIndexForLocation(String location) {
+    if (location.startsWith('/workout')) return 0;
+    if (location.startsWith('/cardio')) return 1;
+    if (location.startsWith('/history')) return 2;
+    if (location.startsWith('/analytics')) return 3;
+    if (location.startsWith('/heart-rate')) return 4;
+    if (location.startsWith('/templates')) return 5;
+    if (location.startsWith('/programmes')) return 6;
+    return 7; // settings
+  }
+
+  void _onRailDestinationSelected(int index, BuildContext context) {
+    switch (index) {
+      case 0:
+        context.go('/workout');
+      case 1:
+        context.go('/cardio');
+      case 2:
+        context.go('/history');
+      case 3:
+        context.go('/analytics');
+      case 4:
+        context.go('/heart-rate');
+      case 5:
+        context.go('/templates');
+      case 6:
+        context.go('/programmes');
+      case 7:
         context.go('/settings');
     }
   }
@@ -96,16 +228,17 @@ class _GlassNavBar extends StatelessWidget {
           child: SizedBox(
             height: ScaffoldWithNavBar._navBarHeight,
             child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceAround,
               children: [
                 for (var i = 0; i < items.length; i++)
-                  _NavItem(
-                    icon: items[i].$1,
-                    label: items[i].$2,
-                    isSelected: i == selectedIndex,
-                    onTap: () => onTap(i),
-                    colorScheme: cs,
-                    textTheme: tt,
+                  Expanded(
+                    child: _NavItem(
+                      icon: items[i].$1,
+                      label: items[i].$2,
+                      isSelected: i == selectedIndex,
+                      onTap: () => onTap(i),
+                      colorScheme: cs,
+                      textTheme: tt,
+                    ),
                   ),
               ],
             ),
@@ -141,35 +274,39 @@ class _NavItem extends StatelessWidget {
     return GestureDetector(
       onTap: onTap,
       behavior: HitTestBehavior.opaque,
-      child: AnimatedContainer(
-        duration: const Duration(milliseconds: 200),
-        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 6),
-        decoration: isSelected
-            ? BoxDecoration(
-                color:
-                    colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
-                borderRadius: BorderRadius.circular(16),
-              )
-            : null,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(
-              icon,
-              size: 24,
-              color: isSelected ? activeColor : inactiveColor,
-            ),
-            const SizedBox(height: 4),
-            Text(
-              label.toUpperCase(),
-              style: textTheme.labelSmall?.copyWith(
-                fontSize: 9,
-                fontWeight: FontWeight.w600,
-                letterSpacing: 0.8,
+      child: Center(
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 200),
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+          decoration: isSelected
+              ? BoxDecoration(
+                  color: colorScheme.surfaceContainerHighest
+                      .withValues(alpha: 0.3),
+                  borderRadius: BorderRadius.circular(16),
+                )
+              : null,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                icon,
+                size: 24,
                 color: isSelected ? activeColor : inactiveColor,
               ),
-            ),
-          ],
+              const SizedBox(height: 4),
+              Text(
+                label.toUpperCase(),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: textTheme.labelSmall?.copyWith(
+                  fontSize: 9,
+                  fontWeight: FontWeight.w600,
+                  letterSpacing: 0.8,
+                  color: isSelected ? activeColor : inactiveColor,
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/analytics/presentation/screens/analytics_screen.dart
+++ b/lib/features/analytics/presentation/screens/analytics_screen.dart
@@ -8,6 +8,8 @@ import '../providers/weekly_volume_provider.dart';
 import '../providers/muscle_balance_provider.dart';
 import '../providers/pr_timeline_provider.dart';
 import '../providers/training_load_provider.dart';
+import '../widgets/analytics_desktop_view.dart';
+import '../../../../core/responsive/breakpoints.dart';
 
 class AnalyticsScreen extends ConsumerWidget {
   const AnalyticsScreen({super.key});
@@ -16,6 +18,11 @@ class AnalyticsScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final s = S.of(context)!;
     final theme = Theme.of(context);
+
+    // Wide screens use the desktop dashboard grid (all charts at once).
+    if (context.isWide) {
+      return const AnalyticsDesktopView();
+    }
 
     final volumeAsync = ref.watch(weeklyVolumeProvider);
     final balanceAsync = ref.watch(muscleBalanceProvider);
@@ -63,9 +70,9 @@ class AnalyticsScreen extends ConsumerWidget {
             child: volumeAsync.when(
               data: (data) => data.isEmpty
                   ? const SizedBox.shrink()
-                  : _WeeklyVolumeChart(data: data),
-              loading: () => const _ChartLoading(),
-              error: (e, _) => _ChartError(message: e.toString()),
+                  : WeeklyVolumeChart(data: data),
+              loading: () => const ChartLoading(),
+              error: (e, _) => ChartError(message: e.toString()),
             ),
           ),
           const SizedBox(height: 16),
@@ -77,9 +84,9 @@ class AnalyticsScreen extends ConsumerWidget {
             child: balanceAsync.when(
               data: (data) => data.isEmpty
                   ? const SizedBox.shrink()
-                  : _MuscleBalanceChart(data: data),
-              loading: () => const _ChartLoading(),
-              error: (e, _) => _ChartError(message: e.toString()),
+                  : MuscleBalanceChart(data: data),
+              loading: () => const ChartLoading(),
+              error: (e, _) => ChartError(message: e.toString()),
             ),
           ),
           const SizedBox(height: 16),
@@ -91,9 +98,9 @@ class AnalyticsScreen extends ConsumerWidget {
             child: prAsync.when(
               data: (data) => data.isEmpty
                   ? const SizedBox.shrink()
-                  : _PrTimeline(entries: data),
-              loading: () => const _ChartLoading(),
-              error: (e, _) => _ChartError(message: e.toString()),
+                  : PrTimeline(entries: data),
+              loading: () => const ChartLoading(),
+              error: (e, _) => ChartError(message: e.toString()),
             ),
           ),
           const SizedBox(height: 16),
@@ -106,9 +113,9 @@ class AnalyticsScreen extends ConsumerWidget {
             child: loadAsync.when(
               data: (data) => data.isEmpty
                   ? const SizedBox.shrink()
-                  : _TrainingLoadChart(data: data),
-              loading: () => const _ChartLoading(),
-              error: (e, _) => _ChartError(message: e.toString()),
+                  : TrainingLoadChart(data: data),
+              loading: () => const ChartLoading(),
+              error: (e, _) => ChartError(message: e.toString()),
             ),
           ),
         ],
@@ -155,8 +162,8 @@ class AnalyticsScreen extends ConsumerWidget {
 
 // --- Weekly Volume Line Chart ---
 
-class _WeeklyVolumeChart extends StatelessWidget {
-  const _WeeklyVolumeChart({required this.data});
+class WeeklyVolumeChart extends StatelessWidget {
+  const WeeklyVolumeChart({super.key, required this.data});
 
   final List<WeeklyVolume> data;
 
@@ -275,8 +282,8 @@ class _WeeklyVolumeChart extends StatelessWidget {
 
 // --- Muscle Balance Radar Chart ---
 
-class _MuscleBalanceChart extends StatelessWidget {
-  const _MuscleBalanceChart({required this.data});
+class MuscleBalanceChart extends StatelessWidget {
+  const MuscleBalanceChart({super.key, required this.data});
 
   final List<MuscleBalance> data;
 
@@ -332,8 +339,8 @@ class _MuscleBalanceChart extends StatelessWidget {
 
 // --- PR Timeline ---
 
-class _PrTimeline extends StatelessWidget {
-  const _PrTimeline({required this.entries});
+class PrTimeline extends StatelessWidget {
+  const PrTimeline({super.key, required this.entries});
 
   final List<PrTimelineEntry> entries;
 
@@ -414,8 +421,8 @@ class _PrTimeline extends StatelessWidget {
 
 // --- Training Load Bar Chart ---
 
-class _TrainingLoadChart extends StatelessWidget {
-  const _TrainingLoadChart({required this.data});
+class TrainingLoadChart extends StatelessWidget {
+  const TrainingLoadChart({super.key, required this.data});
 
   final List<WeeklyLoad> data;
 
@@ -546,8 +553,8 @@ class _TrainingLoadChart extends StatelessWidget {
 
 // --- Helper widgets ---
 
-class _ChartLoading extends StatelessWidget {
-  const _ChartLoading();
+class ChartLoading extends StatelessWidget {
+  const ChartLoading({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -558,8 +565,8 @@ class _ChartLoading extends StatelessWidget {
   }
 }
 
-class _ChartError extends StatelessWidget {
-  const _ChartError({required this.message});
+class ChartError extends StatelessWidget {
+  const ChartError({super.key, required this.message});
 
   final String message;
 

--- a/lib/features/analytics/presentation/widgets/analytics_desktop_view.dart
+++ b/lib/features/analytics/presentation/widgets/analytics_desktop_view.dart
@@ -1,0 +1,256 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:rep_foundry/l10n/generated/app_localizations.dart';
+
+import '../../../../core/widgets/desktop_top_bar.dart';
+import '../../../../core/widgets/kinetic.dart';
+import '../../../../core/widgets/kpi_strip.dart';
+import '../../../history/presentation/providers/workout_history_provider.dart';
+import '../providers/weekly_volume_provider.dart';
+import '../providers/muscle_balance_provider.dart';
+import '../providers/pr_timeline_provider.dart';
+import '../providers/training_load_provider.dart';
+import '../screens/analytics_screen.dart';
+
+/// Desktop "power layout" for Analytics — a multi-chart dashboard with a KPI
+/// strip on top and every chart visible at once in a two-column grid, so
+/// trends can be compared without drilling in.
+class AnalyticsDesktopView extends ConsumerWidget {
+  const AnalyticsDesktopView({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final s = S.of(context)!;
+
+    final volumeAsync = ref.watch(weeklyVolumeProvider);
+    final balanceAsync = ref.watch(muscleBalanceProvider);
+    final prAsync = ref.watch(prTimelineProvider);
+    final loadAsync = ref.watch(trainingLoadProvider);
+    final historyAsync = ref.watch(workoutHistoryWithSetsProvider);
+
+    return Scaffold(
+      body: Column(
+        children: [
+          DesktopTopBar(
+            eyebrow: s.analyticsTitle,
+            title: s.analyticsTitle,
+            subtitle: s.trainingLoadSubtitle,
+          ),
+          Expanded(
+            child: ListView(
+              padding: const EdgeInsets.fromLTRB(30, 24, 30, 40),
+              children: [
+                _KpiRow(
+                  volume: volumeAsync.asData?.value ?? const [],
+                  prCount: prAsync.asData?.value.length ?? 0,
+                  workoutCount: historyAsync.asData?.value.length ?? 0,
+                ),
+                const SizedBox(height: 18),
+
+                // Weekly volume — full width.
+                _DashCard(
+                  title: s.weeklyVolumeTitle,
+                  child: volumeAsync.when(
+                    data: (d) => d.isEmpty
+                        ? const _NoData()
+                        : WeeklyVolumeChart(data: d),
+                    loading: () => const ChartLoading(),
+                    error: (e, _) => ChartError(message: e.toString()),
+                  ),
+                ),
+                const SizedBox(height: 16),
+
+                // Muscle balance + training load — two columns.
+                _TwoColumn(
+                  left: _DashCard(
+                    title: s.muscleBalanceTitle,
+                    child: balanceAsync.when(
+                      data: (d) => d.isEmpty
+                          ? const _NoData()
+                          : MuscleBalanceChart(data: d),
+                      loading: () => const ChartLoading(),
+                      error: (e, _) => ChartError(message: e.toString()),
+                    ),
+                  ),
+                  right: _DashCard(
+                    title: s.trainingLoadTitle,
+                    subtitle: s.trainingLoadSubtitle,
+                    child: loadAsync.when(
+                      data: (d) => d.isEmpty
+                          ? const _NoData()
+                          : TrainingLoadChart(data: d),
+                      loading: () => const ChartLoading(),
+                      error: (e, _) => ChartError(message: e.toString()),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16),
+
+                // PR timeline — full width.
+                _DashCard(
+                  title: s.prTimelineTitle,
+                  child: prAsync.when(
+                    data: (d) =>
+                        d.isEmpty ? const _NoData() : PrTimeline(entries: d),
+                    loading: () => const ChartLoading(),
+                    error: (e, _) => ChartError(message: e.toString()),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ── KPI strip ─────────────────────────────────────────────────────────────
+
+class _KpiRow extends StatelessWidget {
+  const _KpiRow({
+    required this.volume,
+    required this.prCount,
+    required this.workoutCount,
+  });
+
+  final List<WeeklyVolume> volume;
+  final int prCount;
+  final int workoutCount;
+
+  @override
+  Widget build(BuildContext context) {
+    final s = S.of(context)!;
+    final totalVolume = volume.fold<double>(0, (sum, w) => sum + w.totalVolume);
+    final avgSession = workoutCount > 0 ? totalVolume / workoutCount : 0.0;
+
+    return KpiStrip(
+      tiles: [
+        KineticStatTile(
+          label: s.desktopTotalVolume,
+          value: _formatKg(totalVolume),
+          unit: 'kg',
+          valueSize: 26,
+        ),
+        KineticStatTile(
+          label: s.desktopWorkoutsLabel,
+          value: '$workoutCount',
+          valueSize: 26,
+        ),
+        KineticStatTile(
+          label: s.desktopAvgSessionLabel,
+          value: _formatKg(avgSession),
+          unit: 'kg',
+          valueSize: 26,
+        ),
+        KineticStatTile(
+          label: s.desktopPrsLabel,
+          value: '$prCount',
+          valueSize: 26,
+        ),
+      ],
+    );
+  }
+}
+
+// ── Layout helpers ────────────────────────────────────────────────────────
+
+class _TwoColumn extends StatelessWidget {
+  const _TwoColumn({required this.left, required this.right});
+
+  final Widget left;
+  final Widget right;
+
+  @override
+  Widget build(BuildContext context) {
+    return IntrinsicHeight(
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Expanded(child: left),
+          const SizedBox(width: 16),
+          Expanded(child: right),
+        ],
+      ),
+    );
+  }
+}
+
+class _DashCard extends StatelessWidget {
+  const _DashCard({
+    required this.title,
+    this.subtitle,
+    required this.child,
+  });
+
+  final String title;
+  final String? subtitle;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Container(
+      decoration: BoxDecoration(
+        color: cs.surfaceContainerLow,
+        borderRadius: BorderRadius.circular(20),
+      ),
+      padding: const EdgeInsets.all(20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: KineticText.display(
+              size: 16,
+              weight: FontWeight.w700,
+              letterSpacing: -0.2,
+              color: cs.onSurface,
+            ),
+          ),
+          if (subtitle != null) ...[
+            const SizedBox(height: 2),
+            Text(
+              subtitle!,
+              style: TextStyle(
+                fontSize: 12,
+                color: cs.onSurfaceVariant,
+              ),
+            ),
+          ],
+          const SizedBox(height: 16),
+          child,
+        ],
+      ),
+    );
+  }
+}
+
+class _NoData extends StatelessWidget {
+  const _NoData();
+
+  @override
+  Widget build(BuildContext context) {
+    final s = S.of(context)!;
+    final cs = Theme.of(context).colorScheme;
+    return SizedBox(
+      height: 160,
+      child: Center(
+        child: Text(
+          s.noAnalyticsData,
+          style: TextStyle(color: cs.onSurfaceVariant),
+        ),
+      ),
+    );
+  }
+}
+
+String _formatKg(double kg) {
+  final rounded = kg.round();
+  if (rounded >= 1000) {
+    final thousands = rounded ~/ 1000;
+    final remainder = (rounded % 1000).toString().padLeft(3, '0');
+    return '$thousands,$remainder';
+  }
+  return rounded.toString();
+}

--- a/lib/features/history/presentation/providers/workout_history_provider.dart
+++ b/lib/features/history/presentation/providers/workout_history_provider.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/providers.dart';
+import '../../../workout/domain/models/workout.dart';
+import '../../../workout/domain/models/workout_set.dart';
+
+/// A completed workout paired with its logged sets, with derived totals.
+class WorkoutWithSets {
+  final Workout workout;
+  final List<WorkoutSet> sets;
+
+  const WorkoutWithSets({required this.workout, required this.sets});
+
+  double get totalVolume => sets.fold<double>(0, (sum, s) => sum + s.volume);
+
+  int get setCount => sets.length;
+
+  int get exerciseCount => sets.map((s) => s.exerciseId).toSet().length;
+
+  /// Minutes between start and completion, or null if not yet completed.
+  int? get durationMinutes {
+    final completed = workout.completedAt;
+    if (completed == null) return null;
+    return completed.difference(workout.startedAt).inMinutes;
+  }
+}
+
+/// Workout history (newest first) with each workout's sets eagerly loaded.
+/// Shared by the desktop master-detail History layout.
+final workoutHistoryWithSetsProvider =
+    FutureProvider.autoDispose<List<WorkoutWithSets>>((ref) async {
+  final repo = ref.watch(workoutRepositoryProvider);
+  final workouts = await repo.getWorkoutHistory(limit: 50);
+  final result = <WorkoutWithSets>[];
+  for (final w in workouts) {
+    final sets = await repo.getSetsForWorkout(w.id);
+    result.add(WorkoutWithSets(workout: w, sets: sets));
+  }
+  return result;
+});

--- a/lib/features/history/presentation/screens/history_list_screen.dart
+++ b/lib/features/history/presentation/screens/history_list_screen.dart
@@ -6,7 +6,9 @@ import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:rep_foundry/l10n/generated/app_localizations.dart';
 import '../providers/volume_sparkline_provider.dart';
+import '../widgets/history_desktop_view.dart';
 import '../widgets/progress_view.dart';
+import '../../../../core/responsive/breakpoints.dart';
 import '../../../workout/domain/models/workout.dart';
 import '../../../workout/domain/models/workout_set.dart';
 import '../../../../core/providers.dart';
@@ -75,6 +77,11 @@ class _HistoryListScreenState extends State<HistoryListScreen>
   @override
   Widget build(BuildContext context) {
     final s = S.of(context)!;
+
+    // Wide screens use the desktop master–detail power layout.
+    if (context.isWide) {
+      return const HistoryDesktopView();
+    }
 
     return Scaffold(
       // The KineticAppHeader is rendered inside the scrollable History tab,

--- a/lib/features/history/presentation/widgets/history_desktop_view.dart
+++ b/lib/features/history/presentation/widgets/history_desktop_view.dart
@@ -1,0 +1,492 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:rep_foundry/l10n/generated/app_localizations.dart';
+
+import '../../../../core/extensions/datetime_extensions.dart';
+import '../../../../core/providers.dart';
+import '../../../../core/widgets/bar_sparkline_widget.dart';
+import '../../../../core/widgets/desktop_top_bar.dart';
+import '../../../../core/widgets/kinetic.dart';
+import '../../../../core/widgets/kpi_strip.dart';
+import '../../../../core/widgets/loading_widget.dart';
+import '../../../exercises/domain/models/exercise.dart';
+import '../../../workout/domain/models/workout_set.dart';
+import '../providers/workout_history_provider.dart';
+
+/// Desktop "power layout" for History — a master–detail split: a filterable
+/// session list on the left and the selected workout's full breakdown on the
+/// right. Selection is handled in-pane (no route navigation), so the rail and
+/// list stay put while you browse sessions.
+class HistoryDesktopView extends ConsumerStatefulWidget {
+  const HistoryDesktopView({super.key});
+
+  @override
+  ConsumerState<HistoryDesktopView> createState() => _HistoryDesktopViewState();
+}
+
+class _HistoryDesktopViewState extends ConsumerState<HistoryDesktopView> {
+  String? _selectedId;
+
+  @override
+  Widget build(BuildContext context) {
+    final s = S.of(context)!;
+    final cs = Theme.of(context).colorScheme;
+    final historyAsync = ref.watch(workoutHistoryWithSetsProvider);
+
+    return Scaffold(
+      body: Column(
+        children: [
+          DesktopTopBar(
+            eyebrow: s.lastWeek,
+            title: s.trainingHistoryTitle,
+            subtitle: s.trainingHistorySubtitle,
+            actions: [
+              _TopBarIconButton(
+                icon: Icons.emoji_events_outlined,
+                tooltip: s.prHistoryTitle,
+                onPressed: () => context.push('/pr-history'),
+              ),
+            ],
+          ),
+          Expanded(
+            child: historyAsync.when(
+              loading: () => LoadingWidget(message: s.loadingHistory),
+              error: (e, _) => Center(child: Text(s.errorPrefix(e.toString()))),
+              data: (items) {
+                if (items.isEmpty) return _EmptyHistory();
+
+                // Default selection: most recent session.
+                final selected = items.firstWhere(
+                  (w) => w.workout.id == _selectedId,
+                  orElse: () => items.first,
+                );
+
+                return LayoutBuilder(
+                  builder: (context, constraints) {
+                    // Master list shrinks with the pane so the layout survives
+                    // a forced-desktop view on a narrow tablet.
+                    final masterWidth =
+                        (constraints.maxWidth * 0.42).clamp(0.0, 420.0);
+                    return Row(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        SizedBox(
+                          width: masterWidth,
+                          child: _SessionList(
+                            items: items,
+                            selectedId: selected.workout.id,
+                            onSelect: (id) => setState(() => _selectedId = id),
+                          ),
+                        ),
+                        Container(width: 1, color: cs.outlineVariant),
+                        Expanded(child: _DetailPane(item: selected)),
+                      ],
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ── Left pane: session list ───────────────────────────────────────────────
+
+class _SessionList extends StatelessWidget {
+  const _SessionList({
+    required this.items,
+    required this.selectedId,
+    required this.onSelect,
+  });
+
+  final List<WorkoutWithSets> items;
+  final String selectedId;
+  final ValueChanged<String> onSelect;
+
+  @override
+  Widget build(BuildContext context) {
+    final s = S.of(context)!;
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(20, 20, 20, 24),
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(bottom: 12),
+          child: KineticSectionLabel(
+              '${s.desktopSessionsLabel} · ${items.length}'),
+        ),
+        for (final item in items)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 10),
+            child: _SessionRow(
+              item: item,
+              selected: item.workout.id == selectedId,
+              onTap: () => onSelect(item.workout.id),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _SessionRow extends StatelessWidget {
+  const _SessionRow({
+    required this.item,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final WorkoutWithSets item;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final s = S.of(context)!;
+    final cs = Theme.of(context).colorScheme;
+
+    final duration = item.durationMinutes;
+    final meta = duration != null
+        ? '${duration}m · ${_formatKg(item.totalVolume)} kg'
+        : '${_formatKg(item.totalVolume)} kg';
+
+    return Material(
+      color: selected
+          ? cs.primary.withValues(alpha: 0.12)
+          : cs.surfaceContainerLow,
+      borderRadius: BorderRadius.circular(16),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(16),
+        child: Container(
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(16),
+            border: Border(
+              left: BorderSide(
+                color: selected ? cs.primary : Colors.transparent,
+                width: 3,
+              ),
+            ),
+          ),
+          padding: const EdgeInsets.fromLTRB(15, 14, 14, 14),
+          child: Row(
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      s.workoutFallbackName,
+                      style: KineticText.display(
+                        size: 16,
+                        weight: FontWeight.w700,
+                        letterSpacing: -0.2,
+                        color: cs.onSurface,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      meta,
+                      style: GoogleFonts.manrope(
+                        fontSize: 12,
+                        color: cs.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 8),
+              KineticPill(
+                item.workout.startedAt.toLocal().relativeLabel,
+                variant: KineticPillVariant.ghost,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ── Right pane: workout detail ────────────────────────────────────────────
+
+class _DetailPane extends ConsumerWidget {
+  const _DetailPane({required this.item});
+
+  final WorkoutWithSets item;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final s = S.of(context)!;
+    final cs = Theme.of(context).colorScheme;
+    final lookupAsync = ref.watch(exerciseLookupProvider);
+    final lookup = lookupAsync.maybeWhen(
+      data: (m) => m,
+      orElse: () => const <String, Exercise>{},
+    );
+
+    final duration = item.durationMinutes;
+    final setVolumes = item.sets.map((set) => set.volume).toList();
+
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(30, 26, 30, 40),
+      children: [
+        // Header.
+        Text(
+          s.workoutFallbackName,
+          style: KineticText.display(
+            size: 24,
+            weight: FontWeight.w700,
+            letterSpacing: -0.4,
+            color: cs.onSurface,
+          ),
+        ),
+        const SizedBox(height: 6),
+        Text(
+          item.workout.startedAt.toLocal().weekdayMonthDay,
+          style: GoogleFonts.manrope(
+            fontSize: 13,
+            color: cs.onSurfaceVariant,
+          ),
+        ),
+        const SizedBox(height: 22),
+
+        // KPI strip (reflows 4 → 2 → 1 columns as the pane narrows).
+        KpiStrip(
+          tiles: [
+            KineticStatTile(
+              label: s.desktopVolumeLabel,
+              value: _formatKg(item.totalVolume),
+              unit: 'kg',
+              valueSize: 26,
+            ),
+            KineticStatTile(
+              label: s.desktopDurationLabel,
+              value: duration != null ? '$duration' : '—',
+              unit: duration != null ? 'min' : null,
+              valueSize: 26,
+            ),
+            KineticStatTile(
+              label: s.desktopSetsLabel,
+              value: '${item.setCount}',
+              valueSize: 26,
+            ),
+            KineticStatTile(
+              label: s.desktopExercisesLabel,
+              value: '${item.exerciseCount}',
+              valueSize: 26,
+            ),
+          ],
+        ),
+
+        if (setVolumes.length > 1) ...[
+          const SizedBox(height: 26),
+          KineticSectionLabel(s.desktopPerSetVolume),
+          const SizedBox(height: 14),
+          SizedBox(height: 120, child: BarSparklineWidget(data: setVolumes)),
+        ],
+
+        const SizedBox(height: 26),
+        KineticSectionLabel(s.desktopExerciseBreakdown),
+        const SizedBox(height: 14),
+        ..._buildBreakdown(context, lookup),
+      ],
+    );
+  }
+
+  List<Widget> _buildBreakdown(
+    BuildContext context,
+    Map<String, Exercise> lookup,
+  ) {
+    // Group sets by exercise, preserving first-seen order.
+    final order = <String>[];
+    final byExercise = <String, List<WorkoutSet>>{};
+    for (final set in item.sets) {
+      byExercise.putIfAbsent(set.exerciseId, () {
+        order.add(set.exerciseId);
+        return <WorkoutSet>[];
+      }).add(set);
+    }
+
+    return [
+      for (final exerciseId in order)
+        Padding(
+          padding: const EdgeInsets.only(bottom: 12),
+          child: _ExerciseBreakdownCard(
+            name: lookup[exerciseId]?.name ?? '—',
+            sets: byExercise[exerciseId]!,
+          ),
+        ),
+    ];
+  }
+}
+
+class _ExerciseBreakdownCard extends StatelessWidget {
+  const _ExerciseBreakdownCard({required this.name, required this.sets});
+
+  final String name;
+  final List<WorkoutSet> sets;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final bestE1rm = sets.fold<double>(
+      0,
+      (best, set) =>
+          set.estimatedOneRepMax > best ? set.estimatedOneRepMax : best,
+    );
+
+    return Container(
+      decoration: BoxDecoration(
+        color: cs.surfaceContainerLow,
+        borderRadius: BorderRadius.circular(18),
+      ),
+      padding: const EdgeInsets.fromLTRB(18, 16, 18, 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  name,
+                  style: KineticText.display(
+                    size: 16,
+                    weight: FontWeight.w700,
+                    letterSpacing: -0.2,
+                    color: cs.onSurface,
+                  ),
+                ),
+              ),
+              KineticPill(
+                'e1RM ${bestE1rm.toStringAsFixed(0)}',
+                variant: KineticPillVariant.volt,
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              for (var i = 0; i < sets.length; i++)
+                _SetChip(index: i + 1, set: sets[i]),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SetChip extends StatelessWidget {
+  const _SetChip({required this.index, required this.set});
+
+  final int index;
+  final WorkoutSet set;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final warm = set.isWarmUp;
+    final reps = set.reps;
+    final weight = set.weight;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 9),
+      decoration: BoxDecoration(
+        color: warm ? cs.surfaceContainerHigh : cs.surfaceContainer,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Text(
+        '${warm ? 'W' : index} · ${_trimWeight(weight)}kg · ×$reps'
+        '${set.rpe != null ? ' · @${set.rpe!.toStringAsFixed(0)}' : ''}',
+        style: KineticText.mono(
+          size: 12,
+          weight: FontWeight.w600,
+          color: warm ? cs.onSurfaceVariant : cs.onSurface,
+        ),
+      ),
+    );
+  }
+}
+
+// ── Empty state ───────────────────────────────────────────────────────────
+
+class _EmptyHistory extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final s = S.of(context)!;
+    final cs = Theme.of(context).colorScheme;
+    final tt = Theme.of(context).textTheme;
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(Icons.history, size: 72, color: cs.outline),
+          const SizedBox(height: 16),
+          Text(s.noWorkoutsYet, style: tt.headlineSmall),
+          const SizedBox(height: 8),
+          Text(
+            s.noWorkoutsYetSubtitle,
+            style: tt.bodyMedium?.copyWith(color: cs.onSurfaceVariant),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ── Shared bits ───────────────────────────────────────────────────────────
+
+class _TopBarIconButton extends StatelessWidget {
+  const _TopBarIconButton({
+    required this.icon,
+    required this.tooltip,
+    required this.onPressed,
+  });
+
+  final IconData icon;
+  final String tooltip;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Tooltip(
+      message: tooltip,
+      child: Material(
+        color: cs.surfaceContainerLow,
+        borderRadius: BorderRadius.circular(13),
+        child: InkWell(
+          onTap: onPressed,
+          borderRadius: BorderRadius.circular(13),
+          child: SizedBox(
+            width: 42,
+            height: 42,
+            child: Icon(icon, size: 20, color: cs.onSurfaceVariant),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+String _formatKg(double kg) {
+  final rounded = kg.round();
+  if (rounded >= 1000) {
+    final thousands = rounded ~/ 1000;
+    final remainder = (rounded % 1000).toString().padLeft(3, '0');
+    return '$thousands,$remainder';
+  }
+  return rounded.toString();
+}
+
+String _trimWeight(double weight) {
+  if (weight == weight.roundToDouble()) return weight.toStringAsFixed(0);
+  return weight.toStringAsFixed(1);
+}

--- a/lib/features/settings/presentation/providers/layout_mode_provider.dart
+++ b/lib/features/settings/presentation/providers/layout_mode_provider.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../../../core/responsive/layout_mode.dart';
+
+/// App-wide [LayoutMode] override, persisted via SharedPreferences
+/// (`layout_mode`).
+///
+/// Drives the Layout (Auto / Mobile / Desktop) control on the Settings screen
+/// and the [LayoutModeScope] near the app root. Defaults to [LayoutMode.auto],
+/// i.e. the layout follows the window width. The override only takes effect at
+/// tablet widths and above; phones always use the mobile layout.
+final layoutModeProvider = NotifierProvider<LayoutModeNotifier, LayoutMode>(
+  LayoutModeNotifier.new,
+);
+
+class LayoutModeNotifier extends Notifier<LayoutMode> {
+  static const _prefsKey = 'layout_mode';
+
+  @override
+  LayoutMode build() {
+    _load();
+    return LayoutMode.auto;
+  }
+
+  Future<void> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final value = prefs.getString(_prefsKey);
+    if (value != null) state = _fromString(value);
+  }
+
+  Future<void> set(LayoutMode mode) async {
+    state = mode;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_prefsKey, mode.name);
+  }
+
+  LayoutMode _fromString(String value) {
+    switch (value) {
+      case 'mobile':
+        return LayoutMode.mobile;
+      case 'desktop':
+        return LayoutMode.desktop;
+      default:
+        return LayoutMode.auto;
+    }
+  }
+}

--- a/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/lib/features/settings/presentation/screens/settings_screen.dart
@@ -24,8 +24,10 @@ import '../../../sync/presentation/widgets/sync_consent_dialog.dart';
 import '../../../health_sync/presentation/providers/health_sync_settings_provider.dart';
 import '../providers/export_provider.dart';
 import '../providers/rest_timer_settings_provider.dart';
+import '../providers/layout_mode_provider.dart';
 import '../providers/show_exercise_images_provider.dart';
 import '../providers/theme_mode_provider.dart';
+import '../../../../core/responsive/layout_mode.dart';
 import '../providers/user_age_provider.dart';
 import '../../../notifications/presentation/providers/reminder_settings_provider.dart';
 import '../../../notifications/domain/models/reminder_settings.dart';
@@ -62,6 +64,7 @@ class SettingsScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final themeMode = ref.watch(themeModeProvider);
+    final layoutMode = ref.watch(layoutModeProvider);
     final weightUnit = ref.watch(_weightUnitProvider);
     final userAge = ref.watch(userAgeProvider);
     final profile = ref.watch(healthProfileProvider);
@@ -316,6 +319,34 @@ class SettingsScreen extends ConsumerWidget {
                   ],
                   onSelected: (v) =>
                       ref.read(themeModeProvider.notifier).set(v),
+                ),
+              ),
+              // Layout — Auto / Mobile / Desktop (override applies on tablet+).
+              _Set2Row(
+                icon: Icons.devices,
+                title: s.layoutLabel,
+                subtitle: s.layoutSubtitle,
+                trailing: _CompactSegmented<LayoutMode>(
+                  selected: layoutMode,
+                  options: [
+                    _SegOption(
+                      value: LayoutMode.auto,
+                      icon: Icons.brightness_auto,
+                      label: s.themeAuto,
+                    ),
+                    _SegOption(
+                      value: LayoutMode.mobile,
+                      icon: Icons.smartphone,
+                      label: s.layoutMobile,
+                    ),
+                    _SegOption(
+                      value: LayoutMode.desktop,
+                      icon: Icons.desktop_windows,
+                      label: s.layoutDesktop,
+                    ),
+                  ],
+                  onSelected: (v) =>
+                      ref.read(layoutModeProvider.notifier).set(v),
                 ),
               ),
             ]),

--- a/lib/features/templates/presentation/providers/template_list_provider.dart
+++ b/lib/features/templates/presentation/providers/template_list_provider.dart
@@ -1,0 +1,11 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/providers.dart';
+import '../../domain/models/workout_template.dart';
+
+/// All workout templates, newest changes reflected live. Shared by the mobile
+/// list and the desktop library + canvas layout.
+final templateListProvider =
+    StreamProvider.autoDispose<List<WorkoutTemplate>>((ref) {
+  return ref.watch(workoutTemplateRepositoryProvider).watchAllTemplates();
+});

--- a/lib/features/templates/presentation/screens/template_list_screen.dart
+++ b/lib/features/templates/presentation/screens/template_list_screen.dart
@@ -4,7 +4,9 @@ import 'package:go_router/go_router.dart';
 import 'package:rep_foundry/l10n/generated/app_localizations.dart';
 import 'package:uuid/uuid.dart';
 import '../../domain/models/workout_template.dart';
+import '../widgets/templates_desktop_view.dart';
 import '../../../../core/providers.dart';
+import '../../../../core/responsive/breakpoints.dart';
 
 final _templateListProvider =
     StreamProvider.autoDispose<List<WorkoutTemplate>>((ref) {
@@ -17,6 +19,12 @@ class TemplateListScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final s = S.of(context)!;
+
+    // Wide screens use the desktop library + canvas power layout.
+    if (context.isWide) {
+      return const TemplatesDesktopView();
+    }
+
     final templatesAsync = ref.watch(_templateListProvider);
 
     return Scaffold(

--- a/lib/features/templates/presentation/widgets/templates_desktop_view.dart
+++ b/lib/features/templates/presentation/widgets/templates_desktop_view.dart
@@ -1,0 +1,525 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:rep_foundry/l10n/generated/app_localizations.dart';
+
+import '../../../../core/providers.dart';
+import '../../../../core/widgets/desktop_top_bar.dart';
+import '../../../../core/widgets/kinetic.dart';
+import '../../domain/models/workout_template.dart';
+import '../providers/template_list_provider.dart';
+
+/// Desktop "power layout" for Templates — a library + canvas split: the
+/// template library on the left and the selected template's exercise canvas on
+/// the right. The canvas opens the full inline editor for deeper edits.
+class TemplatesDesktopView extends ConsumerStatefulWidget {
+  const TemplatesDesktopView({super.key});
+
+  @override
+  ConsumerState<TemplatesDesktopView> createState() =>
+      _TemplatesDesktopViewState();
+}
+
+class _TemplatesDesktopViewState extends ConsumerState<TemplatesDesktopView> {
+  String? _selectedId;
+
+  @override
+  Widget build(BuildContext context) {
+    final s = S.of(context)!;
+    final cs = Theme.of(context).colorScheme;
+    final templatesAsync = ref.watch(templateListProvider);
+
+    return Scaffold(
+      body: Column(
+        children: [
+          DesktopTopBar(
+            eyebrow: s.navGroupPlan,
+            title: s.templatesTitle,
+            actions: [
+              _PrimaryButton(
+                icon: Icons.add,
+                label: s.newTemplate,
+                onPressed: () => _createTemplate(context, ref),
+              ),
+            ],
+          ),
+          Expanded(
+            child: templatesAsync.when(
+              loading: () => const Center(child: CircularProgressIndicator()),
+              error: (e, _) =>
+                  Center(child: Text(s.failedToLoadTemplates(e.toString()))),
+              data: (templates) {
+                if (templates.isEmpty) return _EmptyTemplates();
+
+                final selected = templates.firstWhere(
+                  (t) => t.id == _selectedId,
+                  orElse: () => templates.first,
+                );
+
+                return LayoutBuilder(
+                  builder: (context, constraints) {
+                    final libraryWidth =
+                        (constraints.maxWidth * 0.34).clamp(0.0, 320.0);
+                    return Row(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        SizedBox(
+                          width: libraryWidth,
+                          child: _LibraryPane(
+                            templates: templates,
+                            selectedId: selected.id,
+                            onSelect: (id) => setState(() => _selectedId = id),
+                          ),
+                        ),
+                        Container(width: 1, color: cs.outlineVariant),
+                        Expanded(child: _CanvasPane(template: selected)),
+                      ],
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _createTemplate(BuildContext context, WidgetRef ref) async {
+    final s = S.of(context)!;
+    final controller = TextEditingController();
+    final name = await showDialog<String>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(s.newTemplateTitle),
+        content: TextField(
+          controller: controller,
+          autofocus: true,
+          textCapitalization: TextCapitalization.words,
+          decoration: InputDecoration(
+            labelText: s.templateNameLabel,
+            border: const OutlineInputBorder(),
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: Text(s.cancel),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, controller.text.trim()),
+            child: Text(s.create),
+          ),
+        ],
+      ),
+    );
+    if (name == null || name.isEmpty || !context.mounted) return;
+    final template = WorkoutTemplate.create(name: name);
+    await ref.read(workoutTemplateRepositoryProvider).createTemplate(template);
+    if (context.mounted) {
+      setState(() => _selectedId = template.id);
+      context.push('/templates/${template.id}');
+    }
+  }
+}
+
+// ── Left pane: library ────────────────────────────────────────────────────
+
+class _LibraryPane extends StatelessWidget {
+  const _LibraryPane({
+    required this.templates,
+    required this.selectedId,
+    required this.onSelect,
+  });
+
+  final List<WorkoutTemplate> templates;
+  final String selectedId;
+  final ValueChanged<String> onSelect;
+
+  @override
+  Widget build(BuildContext context) {
+    final s = S.of(context)!;
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(18, 20, 18, 24),
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(bottom: 12),
+          child:
+              KineticSectionLabel('${s.templatesTitle} · ${templates.length}'),
+        ),
+        for (final template in templates)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 8),
+            child: _LibraryRow(
+              template: template,
+              selected: template.id == selectedId,
+              onTap: () => onSelect(template.id),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _LibraryRow extends StatelessWidget {
+  const _LibraryRow({
+    required this.template,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final WorkoutTemplate template;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final s = S.of(context)!;
+    final cs = Theme.of(context).colorScheme;
+    return Material(
+      color: selected
+          ? cs.primary.withValues(alpha: 0.12)
+          : cs.surfaceContainerLow,
+      borderRadius: BorderRadius.circular(14),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(14),
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(14, 13, 12, 13),
+          child: Row(
+            children: [
+              Container(
+                width: 36,
+                height: 36,
+                decoration: BoxDecoration(
+                  color: selected
+                      ? cs.primary.withValues(alpha: 0.18)
+                      : cs.surfaceContainerHigh,
+                  borderRadius: BorderRadius.circular(11),
+                ),
+                child: Icon(
+                  Icons.dashboard_outlined,
+                  size: 18,
+                  color: selected ? cs.primary : cs.onSurfaceVariant,
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      template.name,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: KineticText.display(
+                        size: 15,
+                        weight: FontWeight.w700,
+                        letterSpacing: -0.2,
+                        color: cs.onSurface,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      s.exerciseCount(template.exercises.length),
+                      style: GoogleFonts.manrope(
+                        fontSize: 11.5,
+                        color: cs.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ── Right pane: canvas ────────────────────────────────────────────────────
+
+class _CanvasPane extends StatelessWidget {
+  const _CanvasPane({required this.template});
+
+  final WorkoutTemplate template;
+
+  @override
+  Widget build(BuildContext context) {
+    final s = S.of(context)!;
+    final cs = Theme.of(context).colorScheme;
+    final exercises = [...template.exercises]
+      ..sort((a, b) => a.orderIndex.compareTo(b.orderIndex));
+
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(30, 26, 30, 40),
+      children: [
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    template.name,
+                    style: KineticText.display(
+                      size: 24,
+                      weight: FontWeight.w700,
+                      letterSpacing: -0.4,
+                      color: cs.onSurface,
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  Text(
+                    s.exerciseCount(exercises.length),
+                    style: GoogleFonts.manrope(
+                      fontSize: 13,
+                      color: cs.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            _OutlineButton(
+              icon: Icons.edit_outlined,
+              label: s.editTemplate,
+              onPressed: () => context.push('/templates/${template.id}'),
+            ),
+          ],
+        ),
+        const SizedBox(height: 24),
+        if (exercises.isEmpty)
+          _CanvasEmpty(
+            onAdd: () => context.push('/templates/${template.id}'),
+          )
+        else
+          for (var i = 0; i < exercises.length; i++)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 12),
+              child: _CanvasExerciseCard(
+                index: i + 1,
+                name: exercises[i].exerciseName,
+                sets: exercises[i].targetSets,
+                reps: exercises[i].targetReps,
+              ),
+            ),
+      ],
+    );
+  }
+}
+
+class _CanvasExerciseCard extends StatelessWidget {
+  const _CanvasExerciseCard({
+    required this.index,
+    required this.name,
+    required this.sets,
+    required this.reps,
+  });
+
+  final int index;
+  final String name;
+  final int sets;
+  final int reps;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Container(
+      decoration: BoxDecoration(
+        color: cs.surfaceContainerLow,
+        borderRadius: BorderRadius.circular(18),
+      ),
+      padding: const EdgeInsets.fromLTRB(18, 16, 18, 16),
+      child: Row(
+        children: [
+          Text(
+            index.toString().padLeft(2, '0'),
+            style: KineticText.mono(
+              size: 14,
+              weight: FontWeight.w700,
+              color: cs.outline,
+            ),
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Text(
+              name,
+              style: KineticText.display(
+                size: 16,
+                weight: FontWeight.w700,
+                letterSpacing: -0.2,
+                color: cs.onSurface,
+              ),
+            ),
+          ),
+          KineticPill(
+            '$sets × $reps',
+            variant: KineticPillVariant.accent,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CanvasEmpty extends StatelessWidget {
+  const _CanvasEmpty({required this.onAdd});
+
+  final VoidCallback onAdd;
+
+  @override
+  Widget build(BuildContext context) {
+    final s = S.of(context)!;
+    final cs = Theme.of(context).colorScheme;
+    return Container(
+      height: 200,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(18),
+        border: Border.all(color: cs.outlineVariant),
+      ),
+      child: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.add_circle_outline, size: 34, color: cs.outline),
+            const SizedBox(height: 12),
+            Text(
+              s.noExercisesFound,
+              style: GoogleFonts.manrope(
+                fontSize: 13.5,
+                color: cs.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: 14),
+            _OutlineButton(
+              icon: Icons.add,
+              label: s.addExerciseToTemplate,
+              onPressed: onAdd,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ── Empty library ─────────────────────────────────────────────────────────
+
+class _EmptyTemplates extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final s = S.of(context)!;
+    final cs = Theme.of(context).colorScheme;
+    final tt = Theme.of(context).textTheme;
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(Icons.view_list, size: 72, color: cs.outline),
+          const SizedBox(height: 16),
+          Text(s.noTemplatesYet, style: tt.headlineSmall),
+          const SizedBox(height: 8),
+          Text(
+            s.noTemplatesYetSubtitle,
+            style: tt.bodyMedium?.copyWith(color: cs.onSurfaceVariant),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ── Buttons ───────────────────────────────────────────────────────────────
+
+class _PrimaryButton extends StatelessWidget {
+  const _PrimaryButton({
+    required this.icon,
+    required this.label,
+    required this.onPressed,
+  });
+
+  final IconData icon;
+  final String label;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Material(
+      color: cs.primary,
+      borderRadius: BorderRadius.circular(14),
+      child: InkWell(
+        onTap: onPressed,
+        borderRadius: BorderRadius.circular(14),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 11),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(icon, size: 18, color: cs.onPrimary),
+              const SizedBox(width: 8),
+              Text(
+                label,
+                style: KineticText.mono(
+                  size: 12.5,
+                  letterSpacing: 0.6,
+                  color: cs.onPrimary,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _OutlineButton extends StatelessWidget {
+  const _OutlineButton({
+    required this.icon,
+    required this.label,
+    required this.onPressed,
+  });
+
+  final IconData icon;
+  final String label;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Material(
+      color: Colors.transparent,
+      borderRadius: BorderRadius.circular(14),
+      child: InkWell(
+        onTap: onPressed,
+        borderRadius: BorderRadius.circular(14),
+        child: Container(
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(14),
+            border: Border.all(color: cs.outlineVariant),
+          ),
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(icon, size: 17, color: cs.onSurface),
+              const SizedBox(width: 8),
+              Text(
+                label,
+                style: KineticText.mono(
+                  size: 12.5,
+                  letterSpacing: 0.6,
+                  color: cs.onSurface,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -9,6 +9,72 @@
   "navHeartRate": "Heart Rate",
   "navSettings": "Settings",
 
+  "navGroupTrain": "Train",
+  "@navGroupTrain": {
+    "description": "Desktop side-rail group heading for training screens"
+  },
+  "navGroupReview": "Review",
+  "@navGroupReview": {
+    "description": "Desktop side-rail group heading for review/analysis screens"
+  },
+  "navGroupPlan": "Plan",
+  "@navGroupPlan": {
+    "description": "Desktop side-rail group heading for planning screens"
+  },
+
+  "desktopSessionsLabel": "Sessions",
+  "@desktopSessionsLabel": {
+    "description": "Heading for the session list pane in the desktop History layout"
+  },
+  "desktopVolumeLabel": "Volume",
+  "@desktopVolumeLabel": {
+    "description": "Stat label for total lifted volume"
+  },
+  "desktopDurationLabel": "Duration",
+  "@desktopDurationLabel": {
+    "description": "Stat label for a workout's duration"
+  },
+  "desktopSetsLabel": "Sets",
+  "@desktopSetsLabel": {
+    "description": "Stat label for the number of sets in a workout"
+  },
+  "desktopExercisesLabel": "Exercises",
+  "@desktopExercisesLabel": {
+    "description": "Stat label for the number of exercises in a workout"
+  },
+  "desktopPerSetVolume": "Per-set volume",
+  "@desktopPerSetVolume": {
+    "description": "Section label above the per-set volume chart"
+  },
+  "desktopExerciseBreakdown": "Exercise breakdown",
+  "@desktopExerciseBreakdown": {
+    "description": "Section label above the per-exercise set breakdown"
+  },
+  "desktopSelectSession": "Select a session to view its full breakdown.",
+  "@desktopSelectSession": {
+    "description": "Empty-state prompt in the desktop History detail pane"
+  },
+  "desktopSelectTemplate": "Select a template to view its exercises.",
+  "@desktopSelectTemplate": {
+    "description": "Empty-state prompt in the desktop Templates canvas pane"
+  },
+  "desktopTotalVolume": "Total volume",
+  "@desktopTotalVolume": {
+    "description": "Analytics KPI label for cumulative volume"
+  },
+  "desktopWorkoutsLabel": "Workouts",
+  "@desktopWorkoutsLabel": {
+    "description": "Analytics KPI label for the number of workouts"
+  },
+  "desktopAvgSessionLabel": "Avg session",
+  "@desktopAvgSessionLabel": {
+    "description": "Analytics KPI label for average session volume"
+  },
+  "desktopPrsLabel": "PRs",
+  "@desktopPrsLabel": {
+    "description": "Analytics KPI label for the number of personal records"
+  },
+
   "start": "Start",
   "pause": "Pause",
   "resume": "Resume",
@@ -125,6 +191,23 @@
   "themeLight": "Light",
   "themeDark": "Dark",
   "themeAuto": "Auto",
+
+  "layoutLabel": "Layout",
+  "@layoutLabel": {
+    "description": "Settings row title for the layout (mobile/desktop) override"
+  },
+  "layoutMobile": "Mobile",
+  "@layoutMobile": {
+    "description": "Layout option that forces the mobile layout on tablet+ widths"
+  },
+  "layoutDesktop": "Desktop",
+  "@layoutDesktop": {
+    "description": "Layout option that forces the desktop layout on tablet+ widths"
+  },
+  "layoutSubtitle": "Auto follows window size · applies on tablets and larger",
+  "@layoutSubtitle": {
+    "description": "Settings subtitle explaining the layout override scope"
+  },
 
   "weightUnitLabel": "Weight Unit",
 

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -138,6 +138,102 @@ abstract class S {
   /// **'Settings'**
   String get navSettings;
 
+  /// Desktop side-rail group heading for training screens
+  ///
+  /// In en, this message translates to:
+  /// **'Train'**
+  String get navGroupTrain;
+
+  /// Desktop side-rail group heading for review/analysis screens
+  ///
+  /// In en, this message translates to:
+  /// **'Review'**
+  String get navGroupReview;
+
+  /// Desktop side-rail group heading for planning screens
+  ///
+  /// In en, this message translates to:
+  /// **'Plan'**
+  String get navGroupPlan;
+
+  /// Heading for the session list pane in the desktop History layout
+  ///
+  /// In en, this message translates to:
+  /// **'Sessions'**
+  String get desktopSessionsLabel;
+
+  /// Stat label for total lifted volume
+  ///
+  /// In en, this message translates to:
+  /// **'Volume'**
+  String get desktopVolumeLabel;
+
+  /// Stat label for a workout's duration
+  ///
+  /// In en, this message translates to:
+  /// **'Duration'**
+  String get desktopDurationLabel;
+
+  /// Stat label for the number of sets in a workout
+  ///
+  /// In en, this message translates to:
+  /// **'Sets'**
+  String get desktopSetsLabel;
+
+  /// Stat label for the number of exercises in a workout
+  ///
+  /// In en, this message translates to:
+  /// **'Exercises'**
+  String get desktopExercisesLabel;
+
+  /// Section label above the per-set volume chart
+  ///
+  /// In en, this message translates to:
+  /// **'Per-set volume'**
+  String get desktopPerSetVolume;
+
+  /// Section label above the per-exercise set breakdown
+  ///
+  /// In en, this message translates to:
+  /// **'Exercise breakdown'**
+  String get desktopExerciseBreakdown;
+
+  /// Empty-state prompt in the desktop History detail pane
+  ///
+  /// In en, this message translates to:
+  /// **'Select a session to view its full breakdown.'**
+  String get desktopSelectSession;
+
+  /// Empty-state prompt in the desktop Templates canvas pane
+  ///
+  /// In en, this message translates to:
+  /// **'Select a template to view its exercises.'**
+  String get desktopSelectTemplate;
+
+  /// Analytics KPI label for cumulative volume
+  ///
+  /// In en, this message translates to:
+  /// **'Total volume'**
+  String get desktopTotalVolume;
+
+  /// Analytics KPI label for the number of workouts
+  ///
+  /// In en, this message translates to:
+  /// **'Workouts'**
+  String get desktopWorkoutsLabel;
+
+  /// Analytics KPI label for average session volume
+  ///
+  /// In en, this message translates to:
+  /// **'Avg session'**
+  String get desktopAvgSessionLabel;
+
+  /// Analytics KPI label for the number of personal records
+  ///
+  /// In en, this message translates to:
+  /// **'PRs'**
+  String get desktopPrsLabel;
+
   /// No description provided for @start.
   ///
   /// In en, this message translates to:
@@ -599,6 +695,30 @@ abstract class S {
   /// In en, this message translates to:
   /// **'Auto'**
   String get themeAuto;
+
+  /// Settings row title for the layout (mobile/desktop) override
+  ///
+  /// In en, this message translates to:
+  /// **'Layout'**
+  String get layoutLabel;
+
+  /// Layout option that forces the mobile layout on tablet+ widths
+  ///
+  /// In en, this message translates to:
+  /// **'Mobile'**
+  String get layoutMobile;
+
+  /// Layout option that forces the desktop layout on tablet+ widths
+  ///
+  /// In en, this message translates to:
+  /// **'Desktop'**
+  String get layoutDesktop;
+
+  /// Settings subtitle explaining the layout override scope
+  ///
+  /// In en, this message translates to:
+  /// **'Auto follows window size · applies on tablets and larger'**
+  String get layoutSubtitle;
 
   /// No description provided for @weightUnitLabel.
   ///

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -27,6 +27,56 @@ class SEn extends S {
   String get navSettings => 'Settings';
 
   @override
+  String get navGroupTrain => 'Train';
+
+  @override
+  String get navGroupReview => 'Review';
+
+  @override
+  String get navGroupPlan => 'Plan';
+
+  @override
+  String get desktopSessionsLabel => 'Sessions';
+
+  @override
+  String get desktopVolumeLabel => 'Volume';
+
+  @override
+  String get desktopDurationLabel => 'Duration';
+
+  @override
+  String get desktopSetsLabel => 'Sets';
+
+  @override
+  String get desktopExercisesLabel => 'Exercises';
+
+  @override
+  String get desktopPerSetVolume => 'Per-set volume';
+
+  @override
+  String get desktopExerciseBreakdown => 'Exercise breakdown';
+
+  @override
+  String get desktopSelectSession =>
+      'Select a session to view its full breakdown.';
+
+  @override
+  String get desktopSelectTemplate =>
+      'Select a template to view its exercises.';
+
+  @override
+  String get desktopTotalVolume => 'Total volume';
+
+  @override
+  String get desktopWorkoutsLabel => 'Workouts';
+
+  @override
+  String get desktopAvgSessionLabel => 'Avg session';
+
+  @override
+  String get desktopPrsLabel => 'PRs';
+
+  @override
   String get start => 'Start';
 
   @override
@@ -272,6 +322,19 @@ class SEn extends S {
 
   @override
   String get themeAuto => 'Auto';
+
+  @override
+  String get layoutLabel => 'Layout';
+
+  @override
+  String get layoutMobile => 'Mobile';
+
+  @override
+  String get layoutDesktop => 'Desktop';
+
+  @override
+  String get layoutSubtitle =>
+      'Auto follows window size · applies on tablets and larger';
 
   @override
   String get weightUnitLabel => 'Weight Unit';

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -27,6 +27,56 @@ class SJa extends S {
   String get navSettings => '設定';
 
   @override
+  String get navGroupTrain => 'Train';
+
+  @override
+  String get navGroupReview => 'Review';
+
+  @override
+  String get navGroupPlan => 'Plan';
+
+  @override
+  String get desktopSessionsLabel => 'Sessions';
+
+  @override
+  String get desktopVolumeLabel => 'Volume';
+
+  @override
+  String get desktopDurationLabel => 'Duration';
+
+  @override
+  String get desktopSetsLabel => 'Sets';
+
+  @override
+  String get desktopExercisesLabel => 'Exercises';
+
+  @override
+  String get desktopPerSetVolume => 'Per-set volume';
+
+  @override
+  String get desktopExerciseBreakdown => 'Exercise breakdown';
+
+  @override
+  String get desktopSelectSession =>
+      'Select a session to view its full breakdown.';
+
+  @override
+  String get desktopSelectTemplate =>
+      'Select a template to view its exercises.';
+
+  @override
+  String get desktopTotalVolume => 'Total volume';
+
+  @override
+  String get desktopWorkoutsLabel => 'Workouts';
+
+  @override
+  String get desktopAvgSessionLabel => 'Avg session';
+
+  @override
+  String get desktopPrsLabel => 'PRs';
+
+  @override
   String get start => 'スタート';
 
   @override
@@ -268,6 +318,19 @@ class SJa extends S {
 
   @override
   String get themeAuto => '自動';
+
+  @override
+  String get layoutLabel => 'Layout';
+
+  @override
+  String get layoutMobile => 'Mobile';
+
+  @override
+  String get layoutDesktop => 'Desktop';
+
+  @override
+  String get layoutSubtitle =>
+      'Auto follows window size · applies on tablets and larger';
 
   @override
   String get weightUnitLabel => '重量単位';

--- a/lib/l10n/generated/app_localizations_ko.dart
+++ b/lib/l10n/generated/app_localizations_ko.dart
@@ -27,6 +27,56 @@ class SKo extends S {
   String get navSettings => '설정';
 
   @override
+  String get navGroupTrain => 'Train';
+
+  @override
+  String get navGroupReview => 'Review';
+
+  @override
+  String get navGroupPlan => 'Plan';
+
+  @override
+  String get desktopSessionsLabel => 'Sessions';
+
+  @override
+  String get desktopVolumeLabel => 'Volume';
+
+  @override
+  String get desktopDurationLabel => 'Duration';
+
+  @override
+  String get desktopSetsLabel => 'Sets';
+
+  @override
+  String get desktopExercisesLabel => 'Exercises';
+
+  @override
+  String get desktopPerSetVolume => 'Per-set volume';
+
+  @override
+  String get desktopExerciseBreakdown => 'Exercise breakdown';
+
+  @override
+  String get desktopSelectSession =>
+      'Select a session to view its full breakdown.';
+
+  @override
+  String get desktopSelectTemplate =>
+      'Select a template to view its exercises.';
+
+  @override
+  String get desktopTotalVolume => 'Total volume';
+
+  @override
+  String get desktopWorkoutsLabel => 'Workouts';
+
+  @override
+  String get desktopAvgSessionLabel => 'Avg session';
+
+  @override
+  String get desktopPrsLabel => 'PRs';
+
+  @override
   String get start => '시작';
 
   @override
@@ -268,6 +318,19 @@ class SKo extends S {
 
   @override
   String get themeAuto => '자동';
+
+  @override
+  String get layoutLabel => 'Layout';
+
+  @override
+  String get layoutMobile => 'Mobile';
+
+  @override
+  String get layoutDesktop => 'Desktop';
+
+  @override
+  String get layoutSubtitle =>
+      'Auto follows window size · applies on tablets and larger';
 
   @override
   String get weightUnitLabel => '무게 단위';

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -27,6 +27,56 @@ class SZh extends S {
   String get navSettings => '设置';
 
   @override
+  String get navGroupTrain => 'Train';
+
+  @override
+  String get navGroupReview => 'Review';
+
+  @override
+  String get navGroupPlan => 'Plan';
+
+  @override
+  String get desktopSessionsLabel => 'Sessions';
+
+  @override
+  String get desktopVolumeLabel => 'Volume';
+
+  @override
+  String get desktopDurationLabel => 'Duration';
+
+  @override
+  String get desktopSetsLabel => 'Sets';
+
+  @override
+  String get desktopExercisesLabel => 'Exercises';
+
+  @override
+  String get desktopPerSetVolume => 'Per-set volume';
+
+  @override
+  String get desktopExerciseBreakdown => 'Exercise breakdown';
+
+  @override
+  String get desktopSelectSession =>
+      'Select a session to view its full breakdown.';
+
+  @override
+  String get desktopSelectTemplate =>
+      'Select a template to view its exercises.';
+
+  @override
+  String get desktopTotalVolume => 'Total volume';
+
+  @override
+  String get desktopWorkoutsLabel => 'Workouts';
+
+  @override
+  String get desktopAvgSessionLabel => 'Avg session';
+
+  @override
+  String get desktopPrsLabel => 'PRs';
+
+  @override
   String get start => '开始';
 
   @override
@@ -268,6 +318,19 @@ class SZh extends S {
 
   @override
   String get themeAuto => '自动';
+
+  @override
+  String get layoutLabel => 'Layout';
+
+  @override
+  String get layoutMobile => 'Mobile';
+
+  @override
+  String get layoutDesktop => 'Desktop';
+
+  @override
+  String get layoutSubtitle =>
+      'Auto follows window size · applies on tablets and larger';
 
   @override
   String get weightUnitLabel => '体重单位';

--- a/src/docs/modules/ROOT/nav.adoc
+++ b/src/docs/modules/ROOT/nav.adoc
@@ -3,6 +3,7 @@
 * xref:architecture.adoc[Architecture]
 * xref:database.adoc[Database]
 * xref:state-management.adoc[State Management]
+* xref:responsive-desktop.adoc[Responsive Desktop Layouts]
 * Features
 ** xref:features/workout.adoc[Workout Logging]
 ** xref:features/cardio.adoc[Cardio Tracking]

--- a/src/docs/modules/ROOT/pages/responsive-desktop.adoc
+++ b/src/docs/modules/ROOT/pages/responsive-desktop.adoc
@@ -1,0 +1,234 @@
+= Responsive Desktop Layouts
+Paul Snow
+:description: How RepFoundry adapts its navigation shell and screen layouts for tablet and desktop widths using a mobile-first breakpoint strategy
+:keywords: responsive, desktop, breakpoints, nav rail, two-pane, adaptive layout, master-detail
+
+RepFoundry is a mobile-first application.
+Above defined breakpoints, the navigation shell switches to a persistent side-rail and selected screens reflow into denser two-pane *power layouts* that make productive use of the extra width — for reviewing history, analysing training trends, and editing templates.
+
+The guiding principle is *same app, more context*: the Kinetic Green theme tokens, type scale, and chart helpers remain identical across all widths.
+Only the layout changes between breakpoints, and every workflow stays round-trippable with the mobile presentation.
+
+== Breakpoints
+
+Breakpoints are defined in `lib/core/responsive/breakpoints.dart` as constants on the `Breakpoints` class.
+The `ResponsiveContext` extension on `BuildContext` exposes convenience getters so screens never need to write `MediaQuery.sizeOf(context).width` comparisons by hand.
+
+[cols="1,1,2,2",options="header"]
+|===
+| Name | Width | Navigation | Layout behaviour
+
+| Mobile
+| < 600 px
+| Glass bottom nav bar (five core tabs only)
+| Single-pane phone layouts; unchanged.
+
+| Tablet
+| 600 – 1 023 px
+| Persistent labelled side-rail (252 px)
+| Two-pane layouts where they fit; `context.hasNavRail` is `true`.
+
+| Desktop
+| ≥ 1 024 px
+| Full labelled side-rail (252 px)
+| Bespoke two-pane power layouts; `context.isWide` is `true`.
+|===
+
+.Breakpoint constants and context getters
+[cols="2,3",options="header"]
+|===
+| Symbol | Value / meaning
+
+| `Breakpoints.tablet`
+| `600`
+
+| `Breakpoints.desktop`
+| `1024`
+
+| `Breakpoints.navRailWidth`
+| `252`
+
+| `context.isMobile`
+| `width < 600`
+
+| `context.isTablet`
+| `600 <= width < 1024`
+
+| `context.isDesktop`
+| `width >= 1024`
+
+| `context.hasNavRail`
+| `width >= 600` — rail is visible
+
+| `context.isWide`
+| `width >= 1024` — power layouts active
+|===
+
+== Layout override setting
+
+By default the layout tier is chosen automatically from the window width (`LayoutMode.auto`).
+A manual override is available at *Settings -> Appearance -> Layout*: a compact segmented control offering three options.
+
+[cols="1,3",options="header"]
+|===
+| Option | Behaviour
+
+| *Auto*
+| Follows window width: side-rail from 600 px, two-pane power layouts from 1 024 px.
+  This is the default.
+
+| *Mobile*
+| Forces the mobile experience (bottom nav, single-pane) regardless of window width.
+  Content is presented as a centred phone-width column rather than stretched.
+
+| *Desktop*
+| Forces the desktop experience (side-rail + two-pane power layouts) from tablet width (≥ 600 px) upward.
+|===
+
+=== Phone-width guard
+
+The override applies *only at tablet and desktop widths (≥ 600 px)*.
+On phone widths (< 600 px) the app always uses the mobile layout and any saved override is silently ignored.
+This ensures the desktop chrome can never be forced onto a screen too narrow to accommodate it.
+
+=== Implementation
+
+[cols="2,3",options="header"]
+|===
+| File | Purpose
+
+| `lib/core/responsive/layout_mode.dart`
+| Defines `enum LayoutMode { auto, mobile, desktop }` and the `LayoutModeScope` `InheritedWidget` that exposes the active mode to the widget tree.
+
+| `lib/features/settings/presentation/providers/layout_mode_provider.dart`
+| `layoutModeProvider` — SharedPreferences-backed Riverpod provider (key `layout_mode`, default `auto`).
+
+| `lib/app/app.dart`
+| Injects `LayoutModeScope` near the app root via the `MaterialApp.router` `builder` callback so every descendant can read the active mode.
+|===
+
+The `ResponsiveContext` getters `hasNavRail` and `isWide` consult `LayoutModeScope.of(context)` and apply the phone-width guard before returning a value.
+Because `LayoutModeScope` is an `InheritedWidget`, switching the setting triggers a rebuild of all dependants — the app reflows live without a restart.
+
+=== Robustness under forced desktop on narrow tablets
+
+When *Desktop* is forced on a tablet that is narrower than a typical desktop viewport, the two-pane layouts reflow rather than overflow:
+
+* KPI strips reflow from 4 to 2 to 1 columns via the shared `KpiStrip` widget (`lib/core/widgets/kpi_strip.dart`).
+* Master and library panes clamp their width to a fraction of the available pane width, preventing either pane from squeezing its content to zero.
+
+== Adaptive Navigation Shell
+
+`ScaffoldWithNavBar` (`lib/core/widgets/scaffold_with_nav_bar.dart`) is the `ShellRoute` builder registered in `lib/app/router.dart`.
+It is responsible for switching between the bottom nav bar and the side-rail.
+
+=== Mobile (< 600 px)
+
+A glass-effect bottom navigation bar is shown for the five core tabs: Workout, History, Cardio, Heart Rate, and Settings.
+Deeper routes that the shell also wraps (Analytics, Templates, Programmes) retain their full-screen presentation with no bottom nav visible.
+
+=== Tablet and desktop (≥ 600 px)
+
+A persistent `DesktopNavRail` (`lib/core/widgets/desktop_nav_rail.dart`, 252 px wide) appears on the left.
+Destinations are organised by intent:
+
+* *Train* — Workout, Cardio
+* *Review* — History, Analytics, Heart Rate
+* *Plan* — Templates, Programmes
+* *Settings* — pinned at the bottom of the rail
+
+The active destination uses an accent-soft background fill, accent-coloured text, and a filled icon variant.
+
+All eight primary destinations, plus selected detail and edit routes (for example `/templates/:id`), are nested inside the `ShellRoute`.
+This keeps the rail visible during template editing and other in-context workflows.
+
+=== Readable maximum width
+
+Screens that do not implement a bespoke two-pane layout are centred at a maximum content width of 980 px inside the rail shell rather than being stretched across the full remaining pane.
+This prevents readability problems on ultra-wide viewports for screens that have not yet adopted a power layout.
+
+== Two-Pane Power Layout Patterns
+
+Three screens implement bespoke desktop layouts.
+Each follows one of two compositional patterns:
+
+[cols="1,2,2,3",options="header"]
+|===
+| Pattern | Screen | Widget file | Description
+
+| Master–detail
+| History
+| `lib/features/history/presentation/widgets/history_desktop_view.dart`
+| Fixed-width session list on the left (~420 px) with the selected workout's full breakdown on the right: a KPI strip, per-set volume chart, and per-exercise set breakdown. Selection is held in widget state — no route navigation — so the rail and list remain stable.
+
+| Dashboard grid
+| Analytics
+| `lib/features/analytics/presentation/widgets/analytics_desktop_view.dart`
+| KPI strip across the top followed by all charts visible simultaneously in a two-column grid: weekly volume (full width); muscle balance and training load (side by side); PR timeline (full width). No drill-down step is required.
+
+| Library + canvas
+| Templates
+| `lib/features/templates/presentation/widgets/templates_desktop_view.dart`
+| Fixed-width template library on the left (~320 px) feeding a selected-template exercise canvas on the right. The canvas hosts the full inline editor for exercise additions, set targets, and progressions.
+|===
+
+=== Shared desktop building blocks
+
+`DesktopTopBar` (`lib/core/widgets/desktop_top_bar.dart`) provides a consistent eyebrow label, title/subtitle row, and contextual action slot.
+It replaces the Material `AppBar` in power layouts.
+
+Reusable Kinetic atoms are defined in `lib/core/widgets/kinetic.dart`:
+
+* `KineticStatTile` — compact stat card (label + value + optional unit)
+* `KineticPill` — small badge/chip component
+* `KineticSectionLabel` — section divider with label
+
+Exercise id-to-name resolution in detail panes uses `exerciseLookupProvider` from `lib/core/providers.dart`.
+
+NOTE: Prefer operational tables, inline-editable cells, and dense charts over decorative card arrangements.
+Desktop layouts reuse the same tokens and chart helpers as mobile; only the spatial organisation changes.
+
+== Adding a Desktop Layout to a Screen
+
+Follow this pattern for any screen that benefits from a bespoke wide layout:
+
+. Create a desktop view widget under the feature's `presentation/widgets/` directory (for example `my_feature_desktop_view.dart`).
+. In the screen's `build` method, branch on `context.isWide` and return the desktop widget when `true`; fall through to the existing mobile layout otherwise.
+. Use `DesktopTopBar` instead of an `AppBar`, and `KineticStatTile` / `KineticSectionLabel` for the stat strip and section dividers.
+
+[source,dart]
+----
+// lib/features/my_feature/presentation/screens/my_feature_screen.dart
+
+import 'package:repfoundry/core/responsive/breakpoints.dart';
+
+@override
+Widget build(BuildContext context) {
+  if (context.isWide) {
+    return const MyFeatureDesktopView(); // <1>
+  }
+
+  // Existing mobile layout — untouched
+  return Scaffold(
+    appBar: AppBar(title: const Text('My Feature')),
+    body: const MyFeatureMobileBody(),
+  );
+}
+----
+<1> `context.isWide` is the `ResponsiveContext` getter — no manual `MediaQuery` call needed.
+
+The mobile layout is never altered; the desktop view is an additive opt-in.
+
+== Testing
+
+Layout tests verify the shell adapts correctly by pumping the widget tree at specific viewport widths:
+
+* *390 px wide* — expect the bottom navigation bar to be present and `DesktopNavRail` to be absent.
+* *1 280 px wide* — expect `DesktopNavRail` to be present and the bottom navigation bar to be absent.
+
+Relevant test files:
+
+* `test/core/widgets/adaptive_nav_shell_test.dart`
+* `test/features/history/presentation/screens/history_desktop_view_test.dart`
+
+Follow the same pump-at-width pattern when testing any new desktop view widget.

--- a/test/core/widgets/adaptive_nav_shell_test.dart
+++ b/test/core/widgets/adaptive_nav_shell_test.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:rep_foundry/core/responsive/layout_mode.dart';
+import 'package:rep_foundry/core/widgets/desktop_nav_rail.dart';
+import 'package:rep_foundry/core/widgets/scaffold_with_nav_bar.dart';
+import 'package:rep_foundry/l10n/generated/app_localizations.dart';
+
+/// Verifies the navigation shell adapts between a bottom nav on mobile and a
+/// persistent side-rail on desktop, per the desktop power-layout pattern.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Future<void> useViewport(WidgetTester tester, Size size) async {
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+  }
+
+  GoRouter buildRouter() {
+    Widget label(String text) => Scaffold(body: Text(text));
+    return GoRouter(
+      initialLocation: '/workout',
+      routes: [
+        ShellRoute(
+          builder: (_, __, child) => ScaffoldWithNavBar(child: child),
+          routes: [
+            GoRoute(
+                path: '/workout', builder: (_, __) => label('Workout screen')),
+            GoRoute(
+                path: '/history', builder: (_, __) => label('History screen')),
+            GoRoute(
+                path: '/cardio', builder: (_, __) => label('Cardio screen')),
+            GoRoute(
+                path: '/heart-rate', builder: (_, __) => label('Heart screen')),
+            GoRoute(
+                path: '/analytics',
+                builder: (_, __) => label('Analytics screen')),
+            GoRoute(
+                path: '/templates',
+                builder: (_, __) => label('Templates screen')),
+            GoRoute(
+                path: '/programmes',
+                builder: (_, __) => label('Programmes screen')),
+            GoRoute(
+                path: '/settings',
+                builder: (_, __) => label('Settings screen')),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget buildApp(GoRouter router, {LayoutMode mode = LayoutMode.auto}) =>
+      MaterialApp.router(
+        localizationsDelegates: S.localizationsDelegates,
+        supportedLocales: S.supportedLocales,
+        routerConfig: router,
+        builder: (context, child) => LayoutModeScope(mode: mode, child: child!),
+      );
+
+  group('adaptive navigation shell', () {
+    testWidgets('mobile width (390) shows bottom nav, not the rail',
+        (tester) async {
+      await useViewport(tester, const Size(390, 844));
+      await tester.pumpWidget(buildApp(buildRouter()));
+      await tester.pumpAndSettle();
+
+      // No desktop rail.
+      expect(find.byType(DesktopNavRail), findsNothing);
+      // Bottom nav renders uppercase mono labels.
+      expect(find.text('WORKOUT'), findsOneWidget);
+      expect(find.text('SETTINGS'), findsOneWidget);
+    });
+
+    testWidgets('desktop width (1280) shows the side-rail, not the bottom nav',
+        (tester) async {
+      await useViewport(tester, const Size(1280, 900));
+      await tester.pumpWidget(buildApp(buildRouter()));
+      await tester.pumpAndSettle();
+
+      // Rail present.
+      expect(find.byType(DesktopNavRail), findsOneWidget);
+      // Rail labels are title-case (not the uppercase bottom-nav labels).
+      expect(find.text('Workout'), findsOneWidget);
+      expect(find.text('Analytics'), findsOneWidget);
+      expect(find.text('Templates'), findsOneWidget);
+      expect(find.text('Programmes'), findsOneWidget);
+      // The uppercase bottom-nav label is absent at this width.
+      expect(find.text('WORKOUT'), findsNothing);
+    });
+
+    testWidgets('desktop rail navigates to grouped destinations',
+        (tester) async {
+      await useViewport(tester, const Size(1280, 900));
+      final router = buildRouter();
+      await tester.pumpWidget(buildApp(router));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Analytics'));
+      await tester.pumpAndSettle();
+
+      expect(
+        router.routerDelegate.currentConfiguration.uri.path,
+        '/analytics',
+      );
+      expect(find.text('Analytics screen'), findsOneWidget);
+    });
+  });
+
+  group('layout override (tablet-and-up only)', () {
+    testWidgets('forcing Desktop on a tablet width shows the side-rail',
+        (tester) async {
+      await useViewport(tester, const Size(800, 1000));
+      await tester
+          .pumpWidget(buildApp(buildRouter(), mode: LayoutMode.desktop));
+      await tester.pumpAndSettle();
+
+      // 800px would normally be tablet-only chrome; forcing Desktop shows the
+      // rail (and would also enable two-pane layouts via context.isWide).
+      expect(find.byType(DesktopNavRail), findsOneWidget);
+      expect(find.text('WORKOUT'), findsNothing);
+    });
+
+    testWidgets('forcing Mobile on a desktop width shows the bottom nav',
+        (tester) async {
+      await useViewport(tester, const Size(1280, 900));
+      await tester.pumpWidget(buildApp(buildRouter(), mode: LayoutMode.mobile));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(DesktopNavRail), findsNothing);
+      expect(find.text('WORKOUT'), findsOneWidget);
+    });
+
+    testWidgets('phone width ignores a Desktop override (mobile wins)',
+        (tester) async {
+      await useViewport(tester, const Size(390, 844));
+      await tester
+          .pumpWidget(buildApp(buildRouter(), mode: LayoutMode.desktop));
+      await tester.pumpAndSettle();
+
+      // The override never applies below the tablet breakpoint.
+      expect(find.byType(DesktopNavRail), findsNothing);
+      expect(find.text('WORKOUT'), findsOneWidget);
+    });
+  });
+}

--- a/test/core/widgets/scaffold_with_nav_bar_test.dart
+++ b/test/core/widgets/scaffold_with_nav_bar_test.dart
@@ -7,6 +7,17 @@ import 'package:rep_foundry/l10n/generated/app_localizations.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  // The glass bottom navigation is mobile-only; pin a phone-sized viewport so
+  // these tests exercise it rather than the desktop side-rail.
+  Future<void> useMobileViewport(WidgetTester tester) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+  }
+
   GoRouter buildRouter() {
     Widget label(String text) => Scaffold(body: Text(text));
 
@@ -41,8 +52,9 @@ void main() {
     );
   }
 
-  group('ScaffoldWithNavBar', () {
+  group('ScaffoldWithNavBar (mobile bottom nav)', () {
     testWidgets('renders all five nav labels in uppercase', (tester) async {
+      await useMobileViewport(tester);
       await tester.pumpWidget(buildApp(buildRouter()));
       await tester.pumpAndSettle();
 
@@ -55,6 +67,7 @@ void main() {
     });
 
     testWidgets('renders all five nav icons', (tester) async {
+      await useMobileViewport(tester);
       await tester.pumpWidget(buildApp(buildRouter()));
       await tester.pumpAndSettle();
 
@@ -67,6 +80,7 @@ void main() {
 
     testWidgets('initial location /workout shows the workout child',
         (tester) async {
+      await useMobileViewport(tester);
       await tester.pumpWidget(buildApp(buildRouter()));
       await tester.pumpAndSettle();
 
@@ -74,6 +88,7 @@ void main() {
     });
 
     testWidgets('tapping HISTORY navigates to /history', (tester) async {
+      await useMobileViewport(tester);
       final router = buildRouter();
       await tester.pumpWidget(buildApp(router));
       await tester.pumpAndSettle();
@@ -86,6 +101,7 @@ void main() {
     });
 
     testWidgets('tapping CARDIO navigates to /cardio', (tester) async {
+      await useMobileViewport(tester);
       final router = buildRouter();
       await tester.pumpWidget(buildApp(router));
       await tester.pumpAndSettle();
@@ -97,6 +113,7 @@ void main() {
     });
 
     testWidgets('tapping HEART RATE navigates to /heart-rate', (tester) async {
+      await useMobileViewport(tester);
       final router = buildRouter();
       await tester.pumpWidget(buildApp(router));
       await tester.pumpAndSettle();
@@ -111,6 +128,7 @@ void main() {
     });
 
     testWidgets('tapping SETTINGS navigates to /settings', (tester) async {
+      await useMobileViewport(tester);
       final router = buildRouter();
       await tester.pumpWidget(buildApp(router));
       await tester.pumpAndSettle();

--- a/test/features/history/presentation/screens/history_desktop_view_test.dart
+++ b/test/features/history/presentation/screens/history_desktop_view_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_foundry/core/providers.dart';
+import 'package:rep_foundry/core/responsive/layout_mode.dart';
+import 'package:rep_foundry/features/exercises/data/exercise_repository_impl.dart';
+import 'package:rep_foundry/features/history/presentation/screens/history_list_screen.dart';
+import 'package:rep_foundry/features/workout/data/workout_repository_impl.dart';
+import 'package:rep_foundry/features/workout/domain/models/workout.dart';
+import 'package:rep_foundry/features/workout/domain/models/workout_set.dart';
+import 'package:rep_foundry/l10n/generated/app_localizations.dart';
+
+/// At desktop widths the History screen swaps the mobile tabbed layout for the
+/// master–detail power layout (session list + detail pane), with no bottom
+/// tabs.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Future<void> useDesktopViewport(WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1280, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+  }
+
+  Widget buildScreen(
+    InMemoryWorkoutRepository workoutRepo,
+    InMemoryExerciseRepository exerciseRepo, {
+    LayoutMode mode = LayoutMode.auto,
+  }) {
+    return ProviderScope(
+      overrides: [
+        workoutRepositoryProvider.overrideWithValue(workoutRepo),
+        exerciseRepositoryProvider.overrideWithValue(exerciseRepo),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: S.localizationsDelegates,
+        supportedLocales: S.supportedLocales,
+        builder: (context, child) => LayoutModeScope(mode: mode, child: child!),
+        home: const HistoryListScreen(),
+      ),
+    );
+  }
+
+  Future<void> seed(InMemoryWorkoutRepository repo) async {
+    final now = DateTime.utc(2026, 6, 1, 9);
+    await repo.createWorkout(
+      Workout(
+        id: 'w1',
+        startedAt: now,
+        completedAt: now.add(const Duration(minutes: 45)),
+        updatedAt: now,
+      ),
+    );
+    await repo.addSet(
+      WorkoutSet.create(
+        workoutId: 'w1',
+        exerciseId: 'e1',
+        setOrder: 1,
+        weight: 40,
+        reps: 10,
+      ),
+    );
+  }
+
+  testWidgets('renders the master-detail layout at desktop width',
+      (tester) async {
+    await useDesktopViewport(tester);
+
+    final workoutRepo = InMemoryWorkoutRepository();
+    final exerciseRepo = InMemoryExerciseRepository();
+    await seed(workoutRepo);
+
+    await tester.pumpWidget(buildScreen(workoutRepo, exerciseRepo));
+    await tester.pumpAndSettle();
+
+    // Desktop layout: no mobile tab shell, a desktop top bar, and the detail
+    // pane KPI strip (KineticStatTile uppercases its label).
+    expect(find.byType(TabBar), findsNothing);
+    expect(find.text('Training History'), findsOneWidget);
+    expect(find.text('VOLUME'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('forced desktop on a narrow tablet width does not overflow',
+      (tester) async {
+    // A 640px-wide forced-desktop view is the tight end of the range; the
+    // master list and KPI strip must reflow rather than overflow.
+    tester.view.physicalSize = const Size(640, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    final workoutRepo = InMemoryWorkoutRepository();
+    final exerciseRepo = InMemoryExerciseRepository();
+    await seed(workoutRepo);
+
+    await tester.pumpWidget(
+      buildScreen(workoutRepo, exerciseRepo, mode: LayoutMode.desktop),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Training History'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+}


### PR DESCRIPTION
Implements the responsive desktop power-layouts from #39 — a desktop/tablet layer over the mobile-first UI that keeps the same Kinetic Green identity ("same app, more context", not a stretched mobile UI).

## Navigation shell
- Adaptive `ScaffoldWithNavBar`: glass bottom nav below 600px, persistent labelled side-rail (Train / Review / Plan + Settings) from 600px up.
- Analytics / Templates / Programmes pulled into the `ShellRoute` so the rail persists across all eight surfaces; mobile keeps full-screen pages with no bottom nav.
- Bottom-nav items now flex so they fit true phone widths (390px).

## Two-pane power layouts (engage at ≥1024px)
- **History** — master-detail: session list + selected workout breakdown (KPI strip, per-set volume chart, exercise breakdown), in-pane selection.
- **Analytics** — dashboard grid: KPI strip + all charts visible at once.
- **Templates** — library + canvas, opening the full editor for deeper edits.
- Other screens centre at a readable max width rather than stretch.

## Manual layout override (Settings → Appearance → Layout)
- `LayoutMode` auto / mobile / desktop, persisted via SharedPreferences, applied **tablet-and-up only** so phones always stay mobile. Switches the app live.
- Desktop panes reflow (`KpiStrip` 4→2→1 columns, clamped master widths) so a forced-desktop view on a narrow tablet never overflows.

## Tests & docs
- Layout tests at mobile (390px) and desktop (1280px) breakpoints, the override (forced desktop/mobile, phone-ignores-override), and a forced-desktop-narrow no-overflow check.
- New Antora docs page documenting the desktop power-layout pattern and the override.
- `dart analyze` clean, `flutter test` (868 tests) green, `gradle21w antora` builds clean.

## Acceptance criteria (#39)
- [x] Dedicated desktop layout on History, Analytics, and Templates.
- [x] Mobile layouts unchanged / intentionally equivalent.
- [x] Navigation adapts between bottom nav (mobile) and side-rail (desktop).
- [x] Layout tests cover mobile and desktop breakpoints.
- [x] Documentation notes the desktop power-layout pattern for future screens.

Closes #39