### PR TITLE
fix: resolve breaking changes from major dependency upgrades

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.11.1" apply false
+    id "com.android.application" version "8.13.2" apply false
     id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 

--- a/lib/features/analytics/presentation/screens/analytics_screen.dart
+++ b/lib/features/analytics/presentation/screens/analytics_screen.dart
@@ -292,6 +292,25 @@ class MuscleBalanceChart extends StatelessWidget {
     final theme = Theme.of(context);
     final primaryColor = theme.colorScheme.primary;
 
+    // RadarChart requires at least 3 vertices; fewer groups would assert.
+    if (data.length < 3) {
+      return SizedBox(
+        height: 280,
+        child: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Text(
+              S.of(context)!.muscleBalanceNeedsMore,
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
     return SizedBox(
       height: 280,
       child: RadarChart(

--- a/lib/features/cardio/data/flutter_blue_heart_rate_service.dart
+++ b/lib/features/cardio/data/flutter_blue_heart_rate_service.dart
@@ -88,7 +88,7 @@ class FlutterBlueHeartRateService implements HeartRateService {
   Future<void> _connectAndSubscribe(String deviceId) async {
     final device = BluetoothDevice.fromId(deviceId);
 
-    await device.connect(license: License.free, autoConnect: false);
+    await device.connect(license: License.nonprofit, autoConnect: false);
     _connectedDevice = device;
 
     // Listen for disconnection events.

--- a/lib/features/notifications/data/notification_service.dart
+++ b/lib/features/notifications/data/notification_service.dart
@@ -54,7 +54,7 @@ class NotificationService {
   Future<void> _configureLocalTimeZone() async {
     try {
       final localName = await FlutterTimezone.getLocalTimezone();
-      tz.setLocalLocation(tz.getLocation(localName));
+      tz.setLocalLocation(tz.getLocation(localName.identifier));
     } catch (e) {
       debugPrint('Failed to detect local timezone, falling back to UTC: $e');
       tz.setLocalLocation(tz.UTC);

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -661,6 +661,7 @@
     "placeholders": { "change": { "type": "String" } }
   },
   "muscleBalanceTitle": "Muscle Group Balance",
+  "muscleBalanceNeedsMore": "Train at least 3 muscle groups to see your balance.",
   "prTimelineTitle": "PR Timeline",
   "trainingLoadTitle": "Weekly Training Load",
   "trainingLoadSubtitle": "Sets × avg RPE",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -578,6 +578,7 @@
     "placeholders": { "change": { "type": "String" } }
   },
   "muscleBalanceTitle": "筋肉群バランス",
+  "muscleBalanceNeedsMore": "バランスを表示するには、少なくとも3つの筋肉群をトレーニングしてください。",
   "prTimelineTitle": "自己記録タイムライン",
   "trainingLoadTitle": "週間トレーニング負荷",
   "trainingLoadSubtitle": "セット数 × 平均 RPE",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -578,6 +578,7 @@
     "placeholders": { "change": { "type": "String" } }
   },
   "muscleBalanceTitle": "근육 그룹 밸런스",
+  "muscleBalanceNeedsMore": "밸런스를 보려면 최소 3개의 근육 그룹을 운동하세요.",
   "prTimelineTitle": "개인 기록 타임라인",
   "trainingLoadTitle": "주간 트레이닝 부하",
   "trainingLoadSubtitle": "세트 × 평균 RPE",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -561,6 +561,7 @@
     "placeholders": { "change": { "type": "String" } }
   },
   "muscleBalanceTitle": "肌群平衡",
+  "muscleBalanceNeedsMore": "至少訓練 3 個肌群即可查看平衡分佈。",
   "prTimelineTitle": "个人纪录时间线",
   "trainingLoadTitle": "每周训练负荷",
   "trainingLoadSubtitle": "组数 × 平均 RPE",

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -561,6 +561,7 @@
     "placeholders": { "change": { "type": "String" } }
   },
   "muscleBalanceTitle": "肌群平衡",
+  "muscleBalanceNeedsMore": "至少训练 3 个肌群即可查看平衡分布。",
   "prTimelineTitle": "个人纪录时间线",
   "trainingLoadTitle": "每周训练负荷",
   "trainingLoadSubtitle": "组数 × 平均 RPE",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -2520,6 +2520,12 @@ abstract class S {
   /// **'Muscle Group Balance'**
   String get muscleBalanceTitle;
 
+  /// No description provided for @muscleBalanceNeedsMore.
+  ///
+  /// In en, this message translates to:
+  /// **'Train at least 3 muscle groups to see your balance.'**
+  String get muscleBalanceNeedsMore;
+
   /// No description provided for @prTimelineTitle.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -1358,6 +1358,10 @@ class SEn extends S {
   String get muscleBalanceTitle => 'Muscle Group Balance';
 
   @override
+  String get muscleBalanceNeedsMore =>
+      'Train at least 3 muscle groups to see your balance.';
+
+  @override
   String get prTimelineTitle => 'PR Timeline';
 
   @override

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -1324,6 +1324,9 @@ class SJa extends S {
   String get muscleBalanceTitle => '筋肉群バランス';
 
   @override
+  String get muscleBalanceNeedsMore => 'バランスを表示するには、少なくとも3つの筋肉群をトレーニングしてください。';
+
+  @override
   String get prTimelineTitle => '自己記録タイムライン';
 
   @override

--- a/lib/l10n/generated/app_localizations_ko.dart
+++ b/lib/l10n/generated/app_localizations_ko.dart
@@ -1323,6 +1323,9 @@ class SKo extends S {
   String get muscleBalanceTitle => '근육 그룹 밸런스';
 
   @override
+  String get muscleBalanceNeedsMore => '밸런스를 보려면 최소 3개의 근육 그룹을 운동하세요.';
+
+  @override
   String get prTimelineTitle => '개인 기록 타임라인';
 
   @override

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -1318,6 +1318,9 @@ class SZh extends S {
   String get muscleBalanceTitle => '肌群平衡';
 
   @override
+  String get muscleBalanceNeedsMore => '至少訓練 3 個肌群即可查看平衡分佈。';
+
+  @override
   String get prTimelineTitle => '个人纪录时间线';
 
   @override
@@ -3140,6 +3143,9 @@ class SZhHans extends SZh {
 
   @override
   String get muscleBalanceTitle => '肌群平衡';
+
+  @override
+  String get muscleBalanceNeedsMore => '至少训练 3 个肌群即可查看平衡分布。';
 
   @override
   String get prTimelineTitle => '个人纪录时间线';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   geolocator: ^14.0.2
   flutter_blue_plus: ^2.2.1
   share_plus: ^12.0.1
-  flutter_local_notifications: ^21.0.0
+  flutter_local_notifications: ^22.0.0
   timezone: ^0.11.0
   health: ^13.3.1
   google_sign_in: ^7.2.0
@@ -34,11 +34,11 @@ dependencies:
   connectivity_plus: ^7.0.0
   http: ^1.2.2
   url_launcher: ^6.2.5
-  package_info_plus: ^8.0.0
-  google_fonts: ^6.2.1
-  app_settings: ^5.1.1
+  package_info_plus: ^9.0.1
+  google_fonts: ^8.1.0
+  app_settings: ^7.0.0
   hr_zones: ^0.0.2
-  flutter_timezone: ^4.1.0
+  flutter_timezone: ^5.1.0
 
 dev_dependencies:
   flutter_test:

--- a/test/features/analytics/presentation/screens/analytics_screen_test.dart
+++ b/test/features/analytics/presentation/screens/analytics_screen_test.dart
@@ -1,7 +1,9 @@
+import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:rep_foundry/features/analytics/presentation/providers/muscle_balance_provider.dart';
+import 'package:rep_foundry/features/exercises/domain/models/exercise.dart';
 import 'package:rep_foundry/features/analytics/presentation/providers/pr_timeline_provider.dart';
 import 'package:rep_foundry/features/analytics/presentation/providers/training_load_provider.dart';
 import 'package:rep_foundry/features/analytics/presentation/providers/weekly_volume_provider.dart';
@@ -61,6 +63,40 @@ void main() {
       expect(find.text('Not enough data yet'), findsNothing);
       // All four section titles render as Cards with header text.
       expect(find.byType(Card), findsAtLeastNWidgets(1));
+    });
+  });
+
+  group('MuscleBalanceChart', () {
+    testWidgets('shows a prompt instead of crashing with fewer than 3 groups',
+        (tester) async {
+      await tester.pumpWidget(buildScreen(
+        balance: const [
+          MuscleBalance(group: MuscleGroup.chest, volumePercent: 60),
+          MuscleBalance(group: MuscleGroup.back, volumePercent: 40),
+        ],
+      ));
+      await tester.pumpAndSettle();
+
+      // The radar chart asserts on < 3 entries, so it must not be built.
+      expect(find.byType(RadarChart), findsNothing);
+      expect(
+        find.text('Train at least 3 muscle groups to see your balance.'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('renders the radar chart with three or more groups',
+        (tester) async {
+      await tester.pumpWidget(buildScreen(
+        balance: const [
+          MuscleBalance(group: MuscleGroup.chest, volumePercent: 40),
+          MuscleBalance(group: MuscleGroup.back, volumePercent: 35),
+          MuscleBalance(group: MuscleGroup.shoulders, volumePercent: 25),
+        ],
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(RadarChart), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## Summary

Upgrades several dependencies to new major versions and fixes the resulting compile, build, and runtime breakages.

Dependency bumps in `pubspec.yaml`:
- `flutter_local_notifications` ^21 → ^22
- `package_info_plus` ^8 → ^9
- `google_fonts` ^6 → ^8
- `app_settings` ^5 → ^7
- `flutter_timezone` ^4 → ^5

## Fixes

- **flutter_timezone 5.x**: `getLocalTimezone()` now returns `TimezoneInfo` instead of `String`; read `.identifier` when binding `tz.local` in `notification_service.dart`.
- **flutter_blue_plus**: `License.free` is deprecated → `License.nonprofit`.
- **package_info_plus 9.0** requires AGP ≥ 8.12.1; bump Android Gradle Plugin **8.11.1 → 8.13.2** to fix the `GeneratedPluginRegistrant` *"cannot find symbol PackageInfoPlugin"* build failure (Gradle 9.4.0 and KGP 2.2.20 already satisfied the other requirements).
- **MuscleBalanceChart**: guard against fewer than 3 muscle groups, which asserted in fl_chart's `RadarChart` (`Radar needs at least 3 RadarEntry`) and crashed the analytics screen. Now shows a localised prompt instead. Added `muscleBalanceNeedsMore` string across all locales (en/ja/ko/zh/zh_Hans) and regression tests.

## Not addressed (deliberately)

The KGP / built-in-Kotlin deprecation warnings are left as-is. The full migration assumes **AGP 9.0+** (still alpha), the app has Kotlin source, and several third-party plugins still apply KGP. The Flutter migrator's `android.builtInKotlin=false` / `android.newDsl=false` flags keep legacy AGP-8.x behaviour, so the app must keep applying `kotlin-android` for now.

## Verification

- `dart analyze` → No issues found
- `flutter test` → all tests pass (incl. new radar-chart regression tests)
- `flutter build apk --flavor dev --debug` → builds successfully