### PR TITLE
feat: reopen a finished workout to continue logging

### DIFF
--- a/lib/features/history/presentation/screens/workout_detail_screen.dart
+++ b/lib/features/history/presentation/screens/workout_detail_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:rep_foundry/l10n/generated/app_localizations.dart';
 import '../../../workout/domain/models/workout.dart';
 import '../../../workout/domain/models/workout_set.dart';
+import '../../../workout/presentation/controllers/active_workout_controller.dart';
 import '../../../exercises/domain/models/exercise.dart';
 import '../../../stretching/domain/models/stretching_session.dart';
 import '../../../stretching/presentation/widgets/stretch_preset_localiser.dart';
@@ -84,6 +85,13 @@ class WorkoutDetailScreen extends ConsumerWidget {
       appBar: AppBar(
         title: Text(s.workoutDetailTitle),
         leading: BackButton(onPressed: () => context.go('/history')),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.play_arrow),
+            tooltip: s.continueWorkout,
+            onPressed: () => _continueWorkout(context, ref, s),
+          ),
+        ],
       ),
       body: dataAsync.when(
         data: (data) {
@@ -96,6 +104,24 @@ class WorkoutDetailScreen extends ConsumerWidget {
         error: (e, _) => Center(child: Text(s.errorPrefix(e.toString()))),
       ),
     );
+  }
+
+  Future<void> _continueWorkout(
+    BuildContext context,
+    WidgetRef ref,
+    S s,
+  ) async {
+    final reopened = await ref
+        .read(activeWorkoutControllerProvider.notifier)
+        .reopenWorkout(workoutId);
+    if (!context.mounted) return;
+    if (reopened) {
+      context.go('/workout');
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(s.continueWorkoutBlocked)),
+      );
+    }
   }
 }
 

--- a/lib/features/workout/presentation/controllers/active_workout_controller.dart
+++ b/lib/features/workout/presentation/controllers/active_workout_controller.dart
@@ -359,6 +359,45 @@ class ActiveWorkoutController extends Notifier<ActiveWorkoutState> {
     }
   }
 
+  /// Reopens a previously completed workout so the user can add more sets
+  /// (e.g. an accidental finish, or remembering to log stretching).
+  ///
+  /// Clears the workout's `completedAt` so it becomes the active workout again
+  /// and rehydrates it into state. Returns `false` without making any change
+  /// when another workout is already in progress (the app supports only one
+  /// active workout at a time) or when the id cannot be found.
+  Future<bool> reopenWorkout(String workoutId) async {
+    // Block if a different workout is already active — the data layer assumes
+    // a single in-progress workout (getActiveWorkout uses getSingleOrNull).
+    final existingActive = await _workoutRepository.getActiveWorkout();
+    if (existingActive != null && existingActive.id != workoutId) {
+      return false;
+    }
+
+    final workout = await _workoutRepository.getWorkout(workoutId);
+    if (workout == null) return false;
+
+    state = state.copyWith(isLoading: true);
+    try {
+      // copyWith cannot null an existing completedAt, so rebuild directly.
+      final reopened = Workout(
+        id: workout.id,
+        startedAt: workout.startedAt,
+        completedAt: null,
+        templateId: workout.templateId,
+        notes: workout.notes,
+        updatedAt: DateTime.now().toUtc(),
+        deletedAt: workout.deletedAt,
+      );
+      await _workoutRepository.updateWorkout(reopened);
+      await _loadSets(reopened);
+      return true;
+    } catch (e) {
+      state = state.copyWith(isLoading: false, error: e.toString());
+      return false;
+    }
+  }
+
   Future<void> addExercise(Exercise exercise) async {
     if (state.activeWorkout == null) return;
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -333,6 +333,8 @@
   "addExercisesHint": "Add exercises using the button below",
   "finishWorkoutTitle": "Finish Workout?",
   "finishWorkoutContent": "This will save your workout and end the session.",
+  "continueWorkout": "Continue Workout",
+  "continueWorkoutBlocked": "Finish your current workout before continuing this one.",
   "tableHeaderHash": "#",
   "tableHeaderWeight": "Weight",
   "tableHeaderReps": "Reps",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -1254,6 +1254,18 @@ abstract class S {
   /// **'This will save your workout and end the session.'**
   String get finishWorkoutContent;
 
+  /// No description provided for @continueWorkout.
+  ///
+  /// In en, this message translates to:
+  /// **'Continue Workout'**
+  String get continueWorkout;
+
+  /// No description provided for @continueWorkoutBlocked.
+  ///
+  /// In en, this message translates to:
+  /// **'Finish your current workout before continuing this one.'**
+  String get continueWorkoutBlocked;
+
   /// No description provided for @tableHeaderHash.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -640,6 +640,13 @@ class SEn extends S {
       'This will save your workout and end the session.';
 
   @override
+  String get continueWorkout => 'Continue Workout';
+
+  @override
+  String get continueWorkoutBlocked =>
+      'Finish your current workout before continuing this one.';
+
+  @override
   String get tableHeaderHash => '#';
 
   @override

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -622,6 +622,13 @@ class SJa extends S {
   String get finishWorkoutContent => 'ワークアウトを保存してセッションを終了します。';
 
   @override
+  String get continueWorkout => 'Continue Workout';
+
+  @override
+  String get continueWorkoutBlocked =>
+      'Finish your current workout before continuing this one.';
+
+  @override
   String get tableHeaderHash => '#';
 
   @override

--- a/lib/l10n/generated/app_localizations_ko.dart
+++ b/lib/l10n/generated/app_localizations_ko.dart
@@ -620,6 +620,13 @@ class SKo extends S {
   String get finishWorkoutContent => '운동을 저장하고 세션을 종료합니다.';
 
   @override
+  String get continueWorkout => 'Continue Workout';
+
+  @override
+  String get continueWorkoutBlocked =>
+      'Finish your current workout before continuing this one.';
+
+  @override
   String get tableHeaderHash => '#';
 
   @override

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -619,6 +619,13 @@ class SZh extends S {
   String get finishWorkoutContent => '这将保存训练并结束本次会话。';
 
   @override
+  String get continueWorkout => 'Continue Workout';
+
+  @override
+  String get continueWorkoutBlocked =>
+      'Finish your current workout before continuing this one.';
+
+  @override
   String get tableHeaderHash => '#';
 
   @override

--- a/test/features/history/presentation/screens/workout_detail_screen_test.dart
+++ b/test/features/history/presentation/screens/workout_detail_screen_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_foundry/core/providers.dart';
+import 'package:rep_foundry/features/exercises/data/exercise_repository_impl.dart';
+import 'package:rep_foundry/features/history/data/personal_record_repository_impl.dart';
+import 'package:rep_foundry/features/history/presentation/screens/workout_detail_screen.dart';
+import 'package:rep_foundry/features/stretching/data/in_memory_stretching_session_repository.dart';
+import 'package:rep_foundry/features/workout/data/workout_repository_impl.dart';
+import 'package:rep_foundry/features/workout/domain/models/workout.dart';
+import 'package:rep_foundry/l10n/generated/app_localizations.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Widget buildScreen(InMemoryWorkoutRepository repo, String workoutId) {
+    return ProviderScope(
+      overrides: [
+        workoutRepositoryProvider.overrideWithValue(repo),
+        exerciseRepositoryProvider
+            .overrideWithValue(InMemoryExerciseRepository()),
+        personalRecordRepositoryProvider
+            .overrideWithValue(InMemoryPersonalRecordRepository()),
+        stretchingSessionRepositoryProvider
+            .overrideWithValue(InMemoryStretchingSessionRepository()),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: S.localizationsDelegates,
+        supportedLocales: S.supportedLocales,
+        home: WorkoutDetailScreen(workoutId: workoutId),
+      ),
+    );
+  }
+
+  testWidgets('shows a Continue Workout action for a completed workout',
+      (tester) async {
+    final repo = InMemoryWorkoutRepository();
+    final now = DateTime.utc(2026, 6, 1, 9);
+    await repo.createWorkout(
+      Workout(
+        id: 'w1',
+        startedAt: now,
+        completedAt: now.add(const Duration(minutes: 45)),
+        updatedAt: now,
+      ),
+    );
+
+    await tester.pumpWidget(buildScreen(repo, 'w1'));
+    await tester.pumpAndSettle();
+
+    expect(find.byIcon(Icons.play_arrow), findsOneWidget);
+    expect(find.byTooltip('Continue Workout'), findsOneWidget);
+  });
+}

--- a/test/features/workout/presentation/controllers/active_workout_controller_test.dart
+++ b/test/features/workout/presentation/controllers/active_workout_controller_test.dart
@@ -18,6 +18,8 @@ import 'package:rep_foundry/features/sync/presentation/providers/sync_settings_p
 import 'package:rep_foundry/features/templates/data/workout_template_repository_impl.dart';
 import 'package:rep_foundry/features/templates/domain/models/workout_template.dart';
 import 'package:rep_foundry/features/workout/data/workout_repository_impl.dart';
+import 'package:rep_foundry/features/workout/domain/models/workout.dart';
+import 'package:rep_foundry/features/workout/domain/models/workout_set.dart';
 import 'package:rep_foundry/features/workout/presentation/controllers/active_workout_controller.dart';
 
 class _FakeCloudSyncService implements CloudSyncService {
@@ -305,6 +307,82 @@ void main() {
         await syncOrchestrator.syncCalled;
 
         expect(syncOrchestrator.syncCalls, 1);
+      });
+    });
+
+    group('reopenWorkout', () {
+      test('reopens a completed workout and loads its sets into state',
+          () async {
+        await waitForInit();
+        final now = DateTime.now().toUtc();
+        final exercises = await exerciseRepo.getAllExercises();
+        final exercise = exercises.first;
+
+        await workoutRepo.createWorkout(
+          Workout(
+            id: 'w-done',
+            startedAt: now.subtract(const Duration(hours: 1)),
+            completedAt: now,
+            updatedAt: now,
+          ),
+        );
+        await workoutRepo.addSet(
+          WorkoutSet.create(
+            workoutId: 'w-done',
+            exerciseId: exercise.id,
+            setOrder: 0,
+            weight: 100,
+            reps: 5,
+          ),
+        );
+
+        final controller = readController();
+        final reopened = await controller.reopenWorkout('w-done');
+
+        expect(reopened, isTrue);
+        final state = readState();
+        expect(state.hasActiveWorkout, isTrue);
+        expect(state.activeWorkout!.id, 'w-done');
+        expect(state.activeWorkout!.completedAt, isNull);
+        expect(state.setsByExercise[exercise.id], hasLength(1));
+
+        // Persisted back as in-progress.
+        final active = await workoutRepo.getActiveWorkout();
+        expect(active!.id, 'w-done');
+      });
+
+      test('returns false when another workout is already active', () async {
+        await waitForInit();
+        final controller = readController();
+        await controller.startWorkout();
+        final activeId = readState().activeWorkout!.id;
+
+        final now = DateTime.now().toUtc();
+        await workoutRepo.createWorkout(
+          Workout(
+            id: 'w-old',
+            startedAt: now.subtract(const Duration(days: 1)),
+            completedAt: now.subtract(const Duration(days: 1)),
+            updatedAt: now,
+          ),
+        );
+
+        final reopened = await controller.reopenWorkout('w-old');
+
+        expect(reopened, isFalse);
+        // The currently active workout is untouched and 'w-old' stays completed.
+        expect(readState().activeWorkout!.id, activeId);
+        expect((await workoutRepo.getWorkout('w-old'))!.completedAt, isNotNull);
+      });
+
+      test('returns false for an unknown workout id', () async {
+        await waitForInit();
+        final controller = readController();
+
+        final reopened = await controller.reopenWorkout('does-not-exist');
+
+        expect(reopened, isFalse);
+        expect(readState().hasActiveWorkout, isFalse);
       });
     });
 


### PR DESCRIPTION
Closes #47.

## Problem

Once a workout is finished there's no way back. If you finish accidentally — or just decide you have time to add some stretching — you can't reopen the session to log more.

## Solution

Add a **Continue Workout** action (▶) to the history workout-detail screen.

- `ActiveWorkoutController.reopenWorkout(workoutId)` clears the workout's `completedAt` and rehydrates the workout + its sets into active state. (`completedAt` is rebuilt directly rather than via `copyWith`, which can't null a non-null field.)
- The reopened workout drops off the completed-only history list and reappears as the active session — consistent with how `getWorkoutHistory`/`getActiveWorkout` already filter on `completedAt`.
- **Concurrent-workout guard:** if a *different* workout is already in progress, reopen returns `false` and changes nothing — preserving the single-active-workout invariant that `getActiveWorkout` (`getSingleOrNull`) depends on. The UI shows a snackbar prompting the user to finish the current workout first.

## Tests (TDD — written first)

- Controller: reopens a completed workout and loads its sets; returns false when another workout is active; returns false for an unknown id.
- Widget: detail screen renders the Continue Workout action for a completed workout.

All workout + history suites pass (212 tests); `dart analyze` and `dart format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)