### PR TITLE
feat: convert a finished workout into a reusable template

### DIFF
--- a/lib/core/providers.dart
+++ b/lib/core/providers.dart
@@ -24,6 +24,7 @@ import '../features/heart_rate/data/noop_analytics_reporter.dart';
 import '../features/heart_rate/domain/analytics_events.dart';
 import '../features/history/data/drift_personal_record_repository.dart';
 import '../features/history/domain/repositories/personal_record_repository.dart';
+import '../features/templates/application/convert_workout_to_template_use_case.dart';
 import '../features/templates/data/drift_workout_template_repository.dart';
 import '../features/templates/domain/repositories/workout_template_repository.dart';
 import '../features/programmes/data/drift_programme_repository.dart';
@@ -155,6 +156,15 @@ final calculateProgressUseCaseProvider =
     Provider<CalculateProgressUseCase>((ref) {
   return CalculateProgressUseCase(
     workoutRepository: ref.watch(workoutRepositoryProvider),
+  );
+});
+
+final convertWorkoutToTemplateUseCaseProvider =
+    Provider<ConvertWorkoutToTemplateUseCase>((ref) {
+  return ConvertWorkoutToTemplateUseCase(
+    workoutRepository: ref.watch(workoutRepositoryProvider),
+    exerciseRepository: ref.watch(exerciseRepositoryProvider),
+    templateRepository: ref.watch(workoutTemplateRepositoryProvider),
   );
 });
 

--- a/lib/features/history/presentation/screens/workout_detail_screen.dart
+++ b/lib/features/history/presentation/screens/workout_detail_screen.dart
@@ -5,6 +5,7 @@ import 'package:rep_foundry/l10n/generated/app_localizations.dart';
 import '../../../workout/domain/models/workout.dart';
 import '../../../workout/domain/models/workout_set.dart';
 import '../../../workout/presentation/controllers/active_workout_controller.dart';
+import '../../../templates/application/convert_workout_to_template_use_case.dart';
 import '../../../exercises/domain/models/exercise.dart';
 import '../../../stretching/domain/models/stretching_session.dart';
 import '../../../stretching/presentation/widgets/stretch_preset_localiser.dart';
@@ -87,6 +88,11 @@ class WorkoutDetailScreen extends ConsumerWidget {
         leading: BackButton(onPressed: () => context.go('/history')),
         actions: [
           IconButton(
+            icon: const Icon(Icons.bookmark_add_outlined),
+            tooltip: s.saveAsTemplate,
+            onPressed: () => _saveAsTemplate(context, ref, s),
+          ),
+          IconButton(
             icon: const Icon(Icons.play_arrow),
             tooltip: s.continueWorkout,
             onPressed: () => _continueWorkout(context, ref, s),
@@ -120,6 +126,58 @@ class WorkoutDetailScreen extends ConsumerWidget {
     } else {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text(s.continueWorkoutBlocked)),
+      );
+    }
+  }
+
+  Future<void> _saveAsTemplate(
+    BuildContext context,
+    WidgetRef ref,
+    S s,
+  ) async {
+    final data = ref.read(_workoutDetailProvider(workoutId)).asData?.value;
+    final defaultName = data?.workout.startedAt.toLocal().relativeLabel ?? '';
+    final controller = TextEditingController(text: defaultName);
+
+    final name = await showDialog<String>(
+      context: context,
+      builder: (dialogContext) {
+        return AlertDialog(
+          title: Text(s.saveAsTemplateTitle),
+          content: TextField(
+            controller: controller,
+            autofocus: true,
+            decoration: InputDecoration(hintText: s.saveAsTemplateHint),
+            onSubmitted: (value) => Navigator.of(dialogContext).pop(value),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(),
+              child: Text(s.cancel),
+            ),
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(controller.text),
+              child: Text(s.save),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (name == null || name.trim().isEmpty || !context.mounted) return;
+
+    try {
+      await ref
+          .read(convertWorkoutToTemplateUseCaseProvider)
+          .execute(workoutId: workoutId, name: name);
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(s.saveAsTemplateSuccess(name.trim()))),
+      );
+    } on ConvertWorkoutToTemplateException {
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(s.saveAsTemplateEmpty)),
       );
     }
   }

--- a/lib/features/templates/application/convert_workout_to_template_use_case.dart
+++ b/lib/features/templates/application/convert_workout_to_template_use_case.dart
@@ -1,0 +1,115 @@
+import 'package:uuid/uuid.dart';
+
+import '../../exercises/domain/repositories/exercise_repository.dart';
+import '../../workout/domain/models/workout_set.dart';
+import '../../workout/domain/repositories/workout_repository.dart';
+import '../domain/models/workout_template.dart';
+import '../domain/repositories/workout_template_repository.dart';
+
+class ConvertWorkoutToTemplateException implements Exception {
+  final String message;
+  const ConvertWorkoutToTemplateException(this.message);
+
+  @override
+  String toString() => 'ConvertWorkoutToTemplateException: $message';
+}
+
+/// Converts a logged workout into a reusable [WorkoutTemplate].
+///
+/// Groups the workout's sets by exercise (preserving the order each exercise
+/// first appears) and derives planning metadata: [TemplateExercise.targetSets]
+/// is the number of working sets logged for that exercise, and
+/// [TemplateExercise.targetReps] is the most common rep count among them.
+class ConvertWorkoutToTemplateUseCase {
+  final WorkoutRepository _workoutRepository;
+  final ExerciseRepository _exerciseRepository;
+  final WorkoutTemplateRepository _templateRepository;
+
+  const ConvertWorkoutToTemplateUseCase({
+    required WorkoutRepository workoutRepository,
+    required ExerciseRepository exerciseRepository,
+    required WorkoutTemplateRepository templateRepository,
+  })  : _workoutRepository = workoutRepository,
+        _exerciseRepository = exerciseRepository,
+        _templateRepository = templateRepository;
+
+  Future<WorkoutTemplate> execute({
+    required String workoutId,
+    required String name,
+  }) async {
+    final trimmedName = name.trim();
+    if (trimmedName.isEmpty) {
+      throw const ConvertWorkoutToTemplateException('Name cannot be empty');
+    }
+
+    final workout = await _workoutRepository.getWorkout(workoutId);
+    if (workout == null) {
+      throw const ConvertWorkoutToTemplateException('Workout not found');
+    }
+
+    final sets = await _workoutRepository.getSetsForWorkout(workoutId);
+    if (sets.isEmpty) {
+      throw const ConvertWorkoutToTemplateException('Workout has no sets');
+    }
+
+    final Map<String, List<WorkoutSet>> byExercise = {};
+    for (final set in sets) {
+      byExercise.putIfAbsent(set.exerciseId, () => []).add(set);
+    }
+
+    final exercises = await _exerciseRepository.getAllExercises();
+    final exercisesById = {for (final e in exercises) e.id: e};
+
+    final now = DateTime.now().toUtc();
+    final templateId = const Uuid().v4();
+
+    var orderIndex = 0;
+    final templateExercises = <TemplateExercise>[];
+    for (final entry in byExercise.entries) {
+      final exerciseSets = entry.value;
+      final working = exerciseSets.where((s) => !s.isWarmUp).toList();
+      final counted = working.isNotEmpty ? working : exerciseSets;
+
+      templateExercises.add(
+        TemplateExercise(
+          id: const Uuid().v4(),
+          templateId: templateId,
+          exerciseId: entry.key,
+          exerciseName: exercisesById[entry.key]?.name ?? entry.key,
+          targetSets: counted.length,
+          targetReps: _mostCommonReps(counted),
+          orderIndex: orderIndex++,
+          updatedAt: now,
+        ),
+      );
+    }
+
+    final template = WorkoutTemplate(
+      id: templateId,
+      name: trimmedName,
+      createdAt: now,
+      updatedAt: now,
+      exercises: templateExercises,
+    );
+
+    return _templateRepository.createTemplate(template);
+  }
+
+  /// Returns the most frequent rep count, breaking ties by first occurrence.
+  int _mostCommonReps(List<WorkoutSet> sets) {
+    final counts = <int, int>{};
+    for (final set in sets) {
+      counts[set.reps] = (counts[set.reps] ?? 0) + 1;
+    }
+    var best = sets.first.reps;
+    var bestCount = 0;
+    for (final set in sets) {
+      final count = counts[set.reps]!;
+      if (count > bestCount) {
+        bestCount = count;
+        best = set.reps;
+      }
+    }
+    return best;
+  }
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -335,6 +335,14 @@
   "finishWorkoutContent": "This will save your workout and end the session.",
   "continueWorkout": "Continue Workout",
   "continueWorkoutBlocked": "Finish your current workout before continuing this one.",
+  "saveAsTemplate": "Save as Template",
+  "saveAsTemplateTitle": "Save as Template",
+  "saveAsTemplateHint": "Template name",
+  "saveAsTemplateSuccess": "Saved \"{name}\" as a template",
+  "@saveAsTemplateSuccess": {
+    "placeholders": { "name": { "type": "String" } }
+  },
+  "saveAsTemplateEmpty": "Add some sets before saving as a template.",
   "tableHeaderHash": "#",
   "tableHeaderWeight": "Weight",
   "tableHeaderReps": "Reps",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -1266,6 +1266,36 @@ abstract class S {
   /// **'Finish your current workout before continuing this one.'**
   String get continueWorkoutBlocked;
 
+  /// No description provided for @saveAsTemplate.
+  ///
+  /// In en, this message translates to:
+  /// **'Save as Template'**
+  String get saveAsTemplate;
+
+  /// No description provided for @saveAsTemplateTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Save as Template'**
+  String get saveAsTemplateTitle;
+
+  /// No description provided for @saveAsTemplateHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Template name'**
+  String get saveAsTemplateHint;
+
+  /// No description provided for @saveAsTemplateSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Saved \"{name}\" as a template'**
+  String saveAsTemplateSuccess(String name);
+
+  /// No description provided for @saveAsTemplateEmpty.
+  ///
+  /// In en, this message translates to:
+  /// **'Add some sets before saving as a template.'**
+  String get saveAsTemplateEmpty;
+
   /// No description provided for @tableHeaderHash.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -647,6 +647,24 @@ class SEn extends S {
       'Finish your current workout before continuing this one.';
 
   @override
+  String get saveAsTemplate => 'Save as Template';
+
+  @override
+  String get saveAsTemplateTitle => 'Save as Template';
+
+  @override
+  String get saveAsTemplateHint => 'Template name';
+
+  @override
+  String saveAsTemplateSuccess(String name) {
+    return 'Saved \"$name\" as a template';
+  }
+
+  @override
+  String get saveAsTemplateEmpty =>
+      'Add some sets before saving as a template.';
+
+  @override
   String get tableHeaderHash => '#';
 
   @override

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -629,6 +629,24 @@ class SJa extends S {
       'Finish your current workout before continuing this one.';
 
   @override
+  String get saveAsTemplate => 'Save as Template';
+
+  @override
+  String get saveAsTemplateTitle => 'Save as Template';
+
+  @override
+  String get saveAsTemplateHint => 'Template name';
+
+  @override
+  String saveAsTemplateSuccess(String name) {
+    return 'Saved \"$name\" as a template';
+  }
+
+  @override
+  String get saveAsTemplateEmpty =>
+      'Add some sets before saving as a template.';
+
+  @override
   String get tableHeaderHash => '#';
 
   @override

--- a/lib/l10n/generated/app_localizations_ko.dart
+++ b/lib/l10n/generated/app_localizations_ko.dart
@@ -627,6 +627,24 @@ class SKo extends S {
       'Finish your current workout before continuing this one.';
 
   @override
+  String get saveAsTemplate => 'Save as Template';
+
+  @override
+  String get saveAsTemplateTitle => 'Save as Template';
+
+  @override
+  String get saveAsTemplateHint => 'Template name';
+
+  @override
+  String saveAsTemplateSuccess(String name) {
+    return 'Saved \"$name\" as a template';
+  }
+
+  @override
+  String get saveAsTemplateEmpty =>
+      'Add some sets before saving as a template.';
+
+  @override
   String get tableHeaderHash => '#';
 
   @override

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -626,6 +626,24 @@ class SZh extends S {
       'Finish your current workout before continuing this one.';
 
   @override
+  String get saveAsTemplate => 'Save as Template';
+
+  @override
+  String get saveAsTemplateTitle => 'Save as Template';
+
+  @override
+  String get saveAsTemplateHint => 'Template name';
+
+  @override
+  String saveAsTemplateSuccess(String name) {
+    return 'Saved \"$name\" as a template';
+  }
+
+  @override
+  String get saveAsTemplateEmpty =>
+      'Add some sets before saving as a template.';
+
+  @override
   String get tableHeaderHash => '#';
 
   @override

--- a/test/features/history/presentation/screens/workout_detail_screen_test.dart
+++ b/test/features/history/presentation/screens/workout_detail_screen_test.dart
@@ -3,11 +3,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:rep_foundry/core/providers.dart';
 import 'package:rep_foundry/features/exercises/data/exercise_repository_impl.dart';
+import 'package:rep_foundry/features/exercises/domain/models/exercise.dart';
 import 'package:rep_foundry/features/history/data/personal_record_repository_impl.dart';
 import 'package:rep_foundry/features/history/presentation/screens/workout_detail_screen.dart';
 import 'package:rep_foundry/features/stretching/data/in_memory_stretching_session_repository.dart';
+import 'package:rep_foundry/features/templates/data/workout_template_repository_impl.dart';
 import 'package:rep_foundry/features/workout/data/workout_repository_impl.dart';
 import 'package:rep_foundry/features/workout/domain/models/workout.dart';
+import 'package:rep_foundry/features/workout/domain/models/workout_set.dart';
 import 'package:rep_foundry/l10n/generated/app_localizations.dart';
 
 void main() {
@@ -50,5 +53,68 @@ void main() {
 
     expect(find.byIcon(Icons.play_arrow), findsOneWidget);
     expect(find.byTooltip('Continue Workout'), findsOneWidget);
+  });
+
+  testWidgets('saves the workout as a template via the action', (tester) async {
+    final repo = InMemoryWorkoutRepository();
+    final exerciseRepo = InMemoryExerciseRepository();
+    final templateRepo = InMemoryWorkoutTemplateRepository();
+    final now = DateTime.utc(2026, 6, 1, 9);
+
+    final bench = Exercise.create(
+      name: 'Bench Press',
+      category: ExerciseCategory.strength,
+      muscleGroup: MuscleGroup.chest,
+      equipmentType: EquipmentType.barbell,
+    );
+    await exerciseRepo.createExercise(bench);
+
+    await repo.createWorkout(
+      Workout(
+        id: 'w1',
+        startedAt: now,
+        completedAt: now.add(const Duration(minutes: 45)),
+        updatedAt: now,
+      ),
+    );
+    await repo.addSet(WorkoutSet.create(
+      workoutId: 'w1',
+      exerciseId: bench.id,
+      setOrder: 0,
+      weight: 60,
+      reps: 5,
+    ));
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          workoutRepositoryProvider.overrideWithValue(repo),
+          exerciseRepositoryProvider.overrideWithValue(exerciseRepo),
+          personalRecordRepositoryProvider
+              .overrideWithValue(InMemoryPersonalRecordRepository()),
+          stretchingSessionRepositoryProvider
+              .overrideWithValue(InMemoryStretchingSessionRepository()),
+          workoutTemplateRepositoryProvider.overrideWithValue(templateRepo),
+        ],
+        child: const MaterialApp(
+          localizationsDelegates: S.localizationsDelegates,
+          supportedLocales: S.supportedLocales,
+          home: WorkoutDetailScreen(workoutId: 'w1'),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byTooltip('Save as Template'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), 'My Template');
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    final templates = await templateRepo.getAllTemplates();
+    expect(templates, hasLength(1));
+    expect(templates.single.name, 'My Template');
+    expect(templates.single.exercises.single.exerciseName, 'Bench Press');
   });
 }

--- a/test/features/templates/application/convert_workout_to_template_use_case_test.dart
+++ b/test/features/templates/application/convert_workout_to_template_use_case_test.dart
@@ -1,0 +1,235 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_foundry/features/exercises/data/exercise_repository_impl.dart';
+import 'package:rep_foundry/features/exercises/domain/models/exercise.dart';
+import 'package:rep_foundry/features/templates/application/convert_workout_to_template_use_case.dart';
+import 'package:rep_foundry/features/templates/data/workout_template_repository_impl.dart';
+import 'package:rep_foundry/features/workout/data/workout_repository_impl.dart';
+import 'package:rep_foundry/features/workout/domain/models/workout.dart';
+import 'package:rep_foundry/features/workout/domain/models/workout_set.dart';
+
+void main() {
+  late InMemoryWorkoutRepository workoutRepo;
+  late InMemoryExerciseRepository exerciseRepo;
+  late InMemoryWorkoutTemplateRepository templateRepo;
+  late ConvertWorkoutToTemplateUseCase useCase;
+
+  late Exercise bench;
+  late Exercise squat;
+
+  setUp(() async {
+    workoutRepo = InMemoryWorkoutRepository();
+    exerciseRepo = InMemoryExerciseRepository();
+    templateRepo = InMemoryWorkoutTemplateRepository();
+    useCase = ConvertWorkoutToTemplateUseCase(
+      workoutRepository: workoutRepo,
+      exerciseRepository: exerciseRepo,
+      templateRepository: templateRepo,
+    );
+
+    bench = Exercise.create(
+      name: 'Bench Press',
+      category: ExerciseCategory.strength,
+      muscleGroup: MuscleGroup.chest,
+      equipmentType: EquipmentType.barbell,
+    );
+    squat = Exercise.create(
+      name: 'Squat',
+      category: ExerciseCategory.strength,
+      muscleGroup: MuscleGroup.quadriceps,
+      equipmentType: EquipmentType.barbell,
+    );
+    await exerciseRepo.createExercise(bench);
+    await exerciseRepo.createExercise(squat);
+  });
+
+  Future<Workout> seedWorkout(List<WorkoutSet> Function(String id) sets) async {
+    final now = DateTime.utc(2026, 6, 1, 9);
+    final workout = Workout(
+      id: 'w1',
+      startedAt: now,
+      completedAt: now.add(const Duration(minutes: 45)),
+      updatedAt: now,
+    );
+    await workoutRepo.createWorkout(workout);
+    for (final set in sets(workout.id)) {
+      await workoutRepo.addSet(set);
+    }
+    return workout;
+  }
+
+  test('builds a template with one TemplateExercise per exercise', () async {
+    await seedWorkout((id) => [
+          WorkoutSet.create(
+              workoutId: id,
+              exerciseId: bench.id,
+              setOrder: 0,
+              weight: 60,
+              reps: 5),
+          WorkoutSet.create(
+              workoutId: id,
+              exerciseId: bench.id,
+              setOrder: 1,
+              weight: 60,
+              reps: 5),
+          WorkoutSet.create(
+              workoutId: id,
+              exerciseId: squat.id,
+              setOrder: 2,
+              weight: 100,
+              reps: 8),
+        ]);
+
+    final template = await useCase.execute(workoutId: 'w1', name: 'Leg Day');
+
+    expect(template.name, 'Leg Day');
+    expect(template.exercises, hasLength(2));
+    final benchEx =
+        template.exercises.firstWhere((e) => e.exerciseId == bench.id);
+    expect(benchEx.exerciseName, 'Bench Press');
+    expect(benchEx.templateId, template.id);
+    expect(benchEx.targetSets, 2);
+    expect(benchEx.targetReps, 5);
+  });
+
+  test('persists the template via the repository', () async {
+    await seedWorkout((id) => [
+          WorkoutSet.create(
+              workoutId: id,
+              exerciseId: bench.id,
+              setOrder: 0,
+              weight: 60,
+              reps: 5),
+        ]);
+
+    final template = await useCase.execute(workoutId: 'w1', name: 'Push');
+
+    final stored = await templateRepo.getTemplate(template.id);
+    expect(stored, isNotNull);
+    expect(stored!.exercises, hasLength(1));
+  });
+
+  test('preserves exercise order by first appearance and sets orderIndex',
+      () async {
+    await seedWorkout((id) => [
+          WorkoutSet.create(
+              workoutId: id,
+              exerciseId: squat.id,
+              setOrder: 0,
+              weight: 100,
+              reps: 8),
+          WorkoutSet.create(
+              workoutId: id,
+              exerciseId: bench.id,
+              setOrder: 1,
+              weight: 60,
+              reps: 5),
+        ]);
+
+    final template = await useCase.execute(workoutId: 'w1', name: 'Full Body');
+
+    expect(template.exercises[0].exerciseId, squat.id);
+    expect(template.exercises[0].orderIndex, 0);
+    expect(template.exercises[1].exerciseId, bench.id);
+    expect(template.exercises[1].orderIndex, 1);
+  });
+
+  test('counts only working sets, ignoring warm-ups, for targetSets', () async {
+    await seedWorkout((id) => [
+          WorkoutSet.create(
+              workoutId: id,
+              exerciseId: bench.id,
+              setOrder: 0,
+              weight: 20,
+              reps: 10,
+              isWarmUp: true),
+          WorkoutSet.create(
+              workoutId: id,
+              exerciseId: bench.id,
+              setOrder: 1,
+              weight: 60,
+              reps: 5),
+          WorkoutSet.create(
+              workoutId: id,
+              exerciseId: bench.id,
+              setOrder: 2,
+              weight: 60,
+              reps: 5),
+        ]);
+
+    final template = await useCase.execute(workoutId: 'w1', name: 'Push');
+
+    expect(template.exercises.single.targetSets, 2);
+    expect(template.exercises.single.targetReps, 5);
+  });
+
+  test('uses the most common rep count for targetReps', () async {
+    await seedWorkout((id) => [
+          WorkoutSet.create(
+              workoutId: id,
+              exerciseId: bench.id,
+              setOrder: 0,
+              weight: 60,
+              reps: 8),
+          WorkoutSet.create(
+              workoutId: id,
+              exerciseId: bench.id,
+              setOrder: 1,
+              weight: 60,
+              reps: 6),
+          WorkoutSet.create(
+              workoutId: id,
+              exerciseId: bench.id,
+              setOrder: 2,
+              weight: 60,
+              reps: 6),
+        ]);
+
+    final template = await useCase.execute(workoutId: 'w1', name: 'Push');
+
+    expect(template.exercises.single.targetReps, 6);
+  });
+
+  test('throws when the workout does not exist', () async {
+    expect(
+      () => useCase.execute(workoutId: 'missing', name: 'X'),
+      throwsA(isA<ConvertWorkoutToTemplateException>()),
+    );
+  });
+
+  test('throws when the workout has no sets', () async {
+    await seedWorkout((id) => []);
+    expect(
+      () => useCase.execute(workoutId: 'w1', name: 'X'),
+      throwsA(isA<ConvertWorkoutToTemplateException>()),
+    );
+  });
+
+  test('throws when the name is blank', () async {
+    await seedWorkout((id) => [
+          WorkoutSet.create(
+              workoutId: id,
+              exerciseId: bench.id,
+              setOrder: 0,
+              weight: 60,
+              reps: 5),
+        ]);
+    expect(
+      () => useCase.execute(workoutId: 'w1', name: '   '),
+      throwsA(isA<ConvertWorkoutToTemplateException>()),
+    );
+  });
+
+  test('trims the template name', () async {
+    await seedWorkout((id) => [
+          WorkoutSet.create(
+              workoutId: id,
+              exerciseId: bench.id,
+              setOrder: 0,
+              weight: 60,
+              reps: 5),
+        ]);
+    final template =
+        await useCase.execute(workoutId: 'w1', name: '  Leg Day  ');
+    expect(template.name, 'Leg Day');
+  });
+}


### PR DESCRIPTION
## Summary

Implements issue #48 — *"I might finish a workout or look back on it and set it up as a template for future"*.

Adds a **Save as Template** action (bookmark icon) to the workout detail screen. Tapping it prompts for a template name (pre-filled with the workout's date) and saves the workout as a reusable `WorkoutTemplate`.

## How it works

- New `ConvertWorkoutToTemplateUseCase` (templates application layer):
  - Groups the workout's sets by exercise, preserving the order each exercise first appears.
  - `targetSets` = number of working sets (warm-ups excluded; falls back to all sets if every set was a warm-up).
  - `targetReps` = most common rep count among those sets (ties broken by first occurrence).
  - Resolves `exerciseName` from the exercise repository.
  - Persists the template (and its exercises) in one transaction via `createTemplate`.
  - Validates: throws `ConvertWorkoutToTemplateException` on blank name, missing workout, or a workout with no sets.
- Wired via `convertWorkoutToTemplateUseCaseProvider`.
- The templates list refreshes automatically (stream-backed by Drift).

## Tests

- 9 use-case tests (grouping, order, warm-up handling, rep mode, validation, persistence, name trimming).
- Widget test driving the full action: tap → name → save → template persisted.
- Full suite green (887 tests), `dart analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)