### PR TITLE
fix: prevent rest timer preset chips overflowing on narrow screens (#42)

### DIFF
--- a/lib/features/workout/presentation/widgets/rest_timer_widget.dart
+++ b/lib/features/workout/presentation/widgets/rest_timer_widget.dart
@@ -125,18 +125,32 @@ class _RestTimerWidgetState extends ConsumerState<RestTimerWidget> {
                     color: Theme.of(context).colorScheme.onSurfaceVariant,
                   ),
             ),
-          const Spacer(),
-          for (final seconds in const [60, 90, 120, 180])
-            Padding(
-              padding: const EdgeInsets.only(left: 4),
-              child: ActionChip(
-                label: Text(
-                    '${seconds ~/ 60}:${(seconds % 60).toString().padLeft(2, '0')}'),
-                onPressed: () => notifier.start(seconds),
-                padding: EdgeInsets.zero,
-                labelStyle: Theme.of(context).textTheme.labelSmall,
+          const SizedBox(width: 8),
+          // Right-aligned when there is room, but horizontally scrollable so the
+          // preset chips never overflow on narrow screens (issue #42).
+          Expanded(
+            child: Align(
+              alignment: Alignment.centerRight,
+              child: SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                child: Row(
+                  children: [
+                    for (final seconds in const [60, 90, 120, 180])
+                      Padding(
+                        padding: const EdgeInsets.only(left: 4),
+                        child: ActionChip(
+                          label: Text(
+                              '${seconds ~/ 60}:${(seconds % 60).toString().padLeft(2, '0')}'),
+                          onPressed: () => notifier.start(seconds),
+                          padding: EdgeInsets.zero,
+                          labelStyle: Theme.of(context).textTheme.labelSmall,
+                        ),
+                      ),
+                  ],
+                ),
               ),
             ),
+          ),
         ],
       ),
     );

--- a/test/features/workout/presentation/widgets/rest_timer_widget_test.dart
+++ b/test/features/workout/presentation/widgets/rest_timer_widget_test.dart
@@ -141,5 +141,20 @@ void main() {
       expect(find.text('Rest Timer'), findsOneWidget);
       expect(find.byIcon(Icons.stop), findsNothing);
     });
+
+    testWidgets('does not overflow horizontally on a narrow screen',
+        (tester) async {
+      tester.view.physicalSize = const Size(320, 640);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(buildHost());
+      await tester.pumpAndSettle();
+
+      // All four presets remain reachable and no RenderFlex overflows.
+      expect(find.byType(ActionChip), findsNWidgets(4));
+      expect(tester.takeException(), isNull);
+    });
   });
 }


### PR DESCRIPTION
## Problem

On real Android devices the active workout screen showed a *"RIGHT OVERFLOWED BY 3.9 PIXELS"* warning on the rest timer row (issue #42). The row laid out the four preset chips (1:00 / 1:30 / 2:00 / 3:00) after a `Spacer()` to right-align them. A `Spacer` cannot shrink below zero, so on narrow screens the fixed chip content exceeded the available width and Flutter reported a `RenderFlex` overflow.

## Fix

Replaced the `Spacer` + inline chips with an `Expanded` + `Align(centerRight)` + horizontally-scrollable `Row`. The chips stay right-aligned when there is room and scroll instead of overflowing when space is tight — robust against narrow widths and larger text scales.

## Testing

Added a widget test that pumps `RestTimerWidget` at a 320px-wide viewport and asserts no `RenderFlex` overflow while all four presets remain present. Confirmed it fails before the fix (159px overflow) and passes after. Full rest timer suite green; `dart analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)