### PR TITLE
fix: compare new sets against stored all-time bests for PR detection

### DIFF
--- a/lib/features/workout/application/log_set_use_case.dart
+++ b/lib/features/workout/application/log_set_use_case.dart
@@ -88,68 +88,29 @@ class LogSetUseCase {
   }
 
   Future<List<PersonalRecord>> _checkForPersonalRecords(WorkoutSet set) async {
-    final previousSets = await _workoutRepository.getSetsForExercise(
-      set.exerciseId,
-      limit: 100,
-    );
+    final repository = _personalRecordRepository;
+    // Without a record store there is no authoritative all-time best to
+    // compare against, so PR detection is skipped.
+    if (repository == null) return const [];
 
-    final others = previousSets.where((s) => s.id != set.id && !s.isWarmUp);
+    final candidates = <(RecordType, double)>[
+      (RecordType.estimatedOneRepMax, set.estimatedOneRepMax),
+      (RecordType.maxWeight, set.weight),
+      (RecordType.maxReps, set.reps.toDouble()),
+      (RecordType.maxVolume, set.volume),
+    ];
+
     final records = <PersonalRecord>[];
-
-    // e1RM PR
-    final bestE1rm = others.fold<double>(
-      0,
-      (max, s) => s.estimatedOneRepMax > max ? s.estimatedOneRepMax : max,
-    );
-    if (set.estimatedOneRepMax > bestE1rm) {
-      records.add(PersonalRecord.create(
-        exerciseId: set.exerciseId,
-        recordType: RecordType.estimatedOneRepMax,
-        value: set.estimatedOneRepMax,
-        workoutSetId: set.id,
-      ));
-    }
-
-    // Max weight PR
-    final bestWeight = others.fold<double>(
-      0,
-      (max, s) => s.weight > max ? s.weight : max,
-    );
-    if (set.weight > bestWeight) {
-      records.add(PersonalRecord.create(
-        exerciseId: set.exerciseId,
-        recordType: RecordType.maxWeight,
-        value: set.weight,
-        workoutSetId: set.id,
-      ));
-    }
-
-    // Max reps PR
-    final bestReps = others.fold<int>(
-      0,
-      (max, s) => s.reps > max ? s.reps : max,
-    );
-    if (set.reps > bestReps) {
-      records.add(PersonalRecord.create(
-        exerciseId: set.exerciseId,
-        recordType: RecordType.maxReps,
-        value: set.reps.toDouble(),
-        workoutSetId: set.id,
-      ));
-    }
-
-    // Max volume PR
-    final bestVolume = others.fold<double>(
-      0,
-      (max, s) => s.volume > max ? s.volume : max,
-    );
-    if (set.volume > bestVolume) {
-      records.add(PersonalRecord.create(
-        exerciseId: set.exerciseId,
-        recordType: RecordType.maxVolume,
-        value: set.volume,
-        workoutSetId: set.id,
-      ));
+    for (final (recordType, value) in candidates) {
+      final best = await repository.getBestRecord(set.exerciseId, recordType);
+      if (best == null || value > best.value) {
+        records.add(PersonalRecord.create(
+          exerciseId: set.exerciseId,
+          recordType: recordType,
+          value: value,
+          workoutSetId: set.id,
+        ));
+      }
     }
 
     return records;

--- a/test/features/workout/application/log_set_use_case_test.dart
+++ b/test/features/workout/application/log_set_use_case_test.dart
@@ -4,6 +4,7 @@ import 'package:rep_foundry/features/workout/application/log_set_use_case.dart';
 import 'package:rep_foundry/features/workout/domain/models/workout.dart';
 import 'package:rep_foundry/features/workout/domain/models/workout_set.dart';
 import 'package:rep_foundry/features/workout/domain/repositories/workout_repository.dart';
+import 'package:rep_foundry/features/history/data/personal_record_repository_impl.dart';
 import 'package:rep_foundry/features/history/domain/models/personal_record.dart';
 
 class _FakeWorkoutRepository implements WorkoutRepository {
@@ -20,7 +21,11 @@ class _FakeWorkoutRepository implements WorkoutRepository {
     String exerciseId, {
     int limit = 50,
   }) async {
-    return _sets.where((s) => s.exerciseId == exerciseId).take(limit).toList();
+    // Most recent first, matching the Drift implementation's
+    // ORDER BY timestamp DESC LIMIT.
+    final matching =
+        _sets.where((s) => s.exerciseId == exerciseId).toList().reversed;
+    return matching.take(limit).toList();
   }
 
   // Unused stubs
@@ -67,10 +72,15 @@ class _FakeWorkoutRepository implements WorkoutRepository {
 void main() {
   late LogSetUseCase useCase;
   late _FakeWorkoutRepository repository;
+  late InMemoryPersonalRecordRepository personalRecordRepository;
 
   setUp(() {
     repository = _FakeWorkoutRepository();
-    useCase = LogSetUseCase(workoutRepository: repository);
+    personalRecordRepository = InMemoryPersonalRecordRepository();
+    useCase = LogSetUseCase(
+      workoutRepository: repository,
+      personalRecordRepository: personalRecordRepository,
+    );
   });
 
   const validInput = LogSetInput(
@@ -248,6 +258,133 @@ void main() {
         reps: 5,
       ),
     );
+    expect(result.newPersonalRecords, isEmpty);
+  });
+
+  test('execute() does not report a PR when the stored all-time best is higher',
+      () async {
+    // Bests live in the PR repository but not in the recent sets window.
+    for (final seeded in [
+      (RecordType.estimatedOneRepMax, 300.0),
+      (RecordType.maxWeight, 250.0),
+      (RecordType.maxReps, 30.0),
+      (RecordType.maxVolume, 3000.0),
+    ]) {
+      await personalRecordRepository.createRecord(PersonalRecord.create(
+        exerciseId: 'e8',
+        recordType: seeded.$1,
+        value: seeded.$2,
+      ));
+    }
+
+    final result = await useCase.execute(
+      const LogSetInput(
+        workoutId: 'w1',
+        exerciseId: 'e8',
+        setOrder: 1,
+        weight: 150,
+        reps: 5,
+      ),
+    );
+    expect(result.newPersonalRecords, isEmpty);
+  });
+
+  test(
+      'execute() does not report a PR when the all-time best is older than '
+      'the last 100 sets', () async {
+    // All-time best, logged first so it falls outside the recent window.
+    await useCase.execute(
+      const LogSetInput(
+        workoutId: 'w1',
+        exerciseId: 'e9',
+        setOrder: 1,
+        weight: 200,
+        reps: 10,
+      ),
+    );
+    // 100 light sets push the best out of any 100-set window.
+    for (var i = 0; i < 100; i++) {
+      await useCase.execute(
+        LogSetInput(
+          workoutId: 'w1',
+          exerciseId: 'e9',
+          setOrder: i + 2,
+          weight: 50,
+          reps: 5,
+        ),
+      );
+    }
+    // Beats everything in the window but not the all-time best.
+    final result = await useCase.execute(
+      const LogSetInput(
+        workoutId: 'w1',
+        exerciseId: 'e9',
+        setOrder: 102,
+        weight: 100,
+        reps: 5,
+      ),
+    );
+    expect(result.newPersonalRecords, isEmpty);
+  });
+
+  test('execute() reports and persists a PR that beats the stored best',
+      () async {
+    for (final seeded in [
+      (RecordType.estimatedOneRepMax, 200.0),
+      (RecordType.maxWeight, 100.0),
+      (RecordType.maxReps, 10.0),
+      (RecordType.maxVolume, 1500.0),
+    ]) {
+      await personalRecordRepository.createRecord(PersonalRecord.create(
+        exerciseId: 'e10',
+        recordType: seeded.$1,
+        value: seeded.$2,
+      ));
+    }
+
+    // 120kg x 1: beats only the 100kg maxWeight best
+    // (e1RM 124, reps 1, volume 120).
+    final result = await useCase.execute(
+      const LogSetInput(
+        workoutId: 'w1',
+        exerciseId: 'e10',
+        setOrder: 1,
+        weight: 120,
+        reps: 1,
+      ),
+    );
+    expect(result.newPersonalRecords.length, 1);
+    expect(result.newPersonalRecords.single.recordType, RecordType.maxWeight);
+    expect(result.newPersonalRecords.single.value, 120.0);
+
+    final storedBest = await personalRecordRepository.getBestRecord(
+      'e10',
+      RecordType.maxWeight,
+    );
+    expect(storedBest!.value, 120.0);
+  });
+
+  test('execute() persists the first-ever set as the initial PRs', () async {
+    await useCase.execute(
+      const LogSetInput(
+        workoutId: 'w1',
+        exerciseId: 'e11',
+        setOrder: 1,
+        weight: 100,
+        reps: 5,
+      ),
+    );
+    for (final type in RecordType.values) {
+      final best = await personalRecordRepository.getBestRecord('e11', type);
+      expect(best, isNotNull, reason: 'expected initial PR for $type');
+    }
+  });
+
+  test(
+      'execute() skips PR detection when no PersonalRecordRepository '
+      'is provided', () async {
+    final noRepoUseCase = LogSetUseCase(workoutRepository: repository);
+    final result = await noRepoUseCase.execute(validInput);
     expect(result.newPersonalRecords, isEmpty);
   });
 


### PR DESCRIPTION
Fixes #60

## Problem

`LogSetUseCase._checkForPersonalRecords` derived the best-so-far by folding over the most recent 100 sets (`getSetsForExercise(limit: 100)`). Anyone with more than 100 logged sets on a lift could get false "new PR!" results for sub-maximal sets once their true best fell outside the window.

## Change

- PR detection now compares the incoming set against `PersonalRecordRepository.getBestRecord(exerciseId, recordType)` for each of the four record types (e1RM, max weight, max reps, max volume).
- First-ever set on an exercise (no stored record) is recorded as the initial PR.
- When no `PersonalRecordRepository` is supplied (it is nullable in the use case), PR detection is skipped — previously detected PRs were silently dropped anyway since there was nowhere to persist them.
- The `limit: 100` `getSetsForExercise` scan is removed from the use case; the repository method itself is retained for other callers.

## Tests

- New: stored all-time best higher than the new set → no PR reported.
- New: all-time best older than the last 100 sets → no false PR (literal reproduction of the issue; the test fake now returns most-recent-first to match the Drift repository's `ORDER BY timestamp DESC`).
- New: set beating the stored best reports exactly that PR and persists it.
- New: first-ever set persists initial PRs for all record types.
- New: no record repository → detection skipped.
- Existing tests updated to wire `InMemoryPersonalRecordRepository`; full suite (941 tests), `dart analyze`, and format check all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzdnbyMxVjus4iasvmQ9Zr