### PR TITLE
fix: keep cardio tracking accurate and alive when the phone is locked

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,10 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <!-- Foreground service keeps GPS/HR tracking alive during cardio sessions -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
     <!-- BLE permissions for heart rate monitors -->
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
@@ -44,6 +48,13 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+        <!-- Cardio session tracking service (flutter_foreground_task).
+             Warning: do not change the service name. -->
+        <service
+            android:name="com.pravera.flutter_foreground_task.service.ForegroundService"
+            android:foregroundServiceType="location|connectedDevice"
+            android:exported="false"
+            android:stopWithTask="true" />
         <receiver android:exported="false" android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationReceiver" />
         <receiver android:exported="false" android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationBootReceiver">
             <intent-filter>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -70,6 +70,11 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>location</string>
+		<string>bluetooth-central</string>
+	</array>
 	<key>NSHealthShareUsageDescription</key>
 	<string>RepFoundry reads body weight from Apple Health to keep your metrics in sync.</string>
 	<key>NSHealthUpdateUsageDescription</key>

--- a/lib/core/providers.dart
+++ b/lib/core/providers.dart
@@ -16,6 +16,7 @@ import '../features/settings/application/import_data_use_case.dart';
 import '../features/cardio/data/drift_cardio_session_repository.dart';
 import '../features/cardio/data/flutter_blue_heart_rate_service.dart';
 import '../features/cardio/data/heart_rate_service.dart';
+import '../features/cardio/data/foreground_session_service.dart';
 import '../features/cardio/data/location_service.dart';
 import '../features/cardio/domain/repositories/cardio_session_repository.dart';
 import '../features/cardio/application/save_cardio_session_use_case.dart';
@@ -106,6 +107,11 @@ final locationServiceProvider = Provider<LocationService>((ref) {
 
 final heartRateServiceProvider = Provider<HeartRateService>((ref) {
   return FlutterBlueHeartRateService();
+});
+
+final foregroundSessionServiceProvider =
+    Provider<ForegroundSessionService>((ref) {
+  return FlutterForegroundSessionService();
 });
 
 final healthSyncServiceProvider = Provider<HealthSyncService>((ref) {

--- a/lib/features/cardio/data/foreground_session_service.dart
+++ b/lib/features/cardio/data/foreground_session_service.dart
@@ -1,0 +1,95 @@
+import 'dart:io';
+
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+
+/// Keeps the app process alive on Android while a cardio session is
+/// running so GPS and BLE heart-rate streams survive the phone being
+/// locked, showing the platform-required ongoing notification. iOS
+/// background execution is handled by UIBackgroundModes and the
+/// background-capable location subscription instead.
+abstract class ForegroundSessionService {
+  /// Reconcile the platform foreground service with the session state.
+  Future<void> update({
+    required bool sessionRunning,
+    required bool gpsEnabled,
+    required bool hrConnected,
+  });
+}
+
+class FlutterForegroundSessionService implements ForegroundSessionService {
+  bool _initialised = false;
+  bool _running = false;
+  bool _gps = false;
+  bool _hr = false;
+
+  void _init() {
+    if (_initialised) return;
+    _initialised = true;
+    FlutterForegroundTask.init(
+      androidNotificationOptions: AndroidNotificationOptions(
+        channelId: 'cardio_tracking',
+        channelName: 'Cardio tracking',
+        channelDescription:
+            'Shown while RepFoundry is tracking a cardio session.',
+        onlyAlertOnce: true,
+      ),
+      iosNotificationOptions: const IOSNotificationOptions(
+        showNotification: false,
+        playSound: false,
+      ),
+      foregroundTaskOptions: ForegroundTaskOptions(
+        eventAction: ForegroundTaskEventAction.nothing(),
+      ),
+    );
+  }
+
+  @override
+  Future<void> update({
+    required bool sessionRunning,
+    required bool gpsEnabled,
+    required bool hrConnected,
+  }) async {
+    if (!Platform.isAndroid) return;
+    // Android 14+ requires a permitted service type; without GPS or an HR
+    // monitor there is nothing to keep alive (the elapsed timer is
+    // wall-clock based and self-corrects on resume).
+    final wantsService = sessionRunning && (gpsEnabled || hrConnected);
+    try {
+      if (!wantsService) {
+        if (_running) {
+          _running = false;
+          await FlutterForegroundTask.stopService();
+        }
+        return;
+      }
+      final typesChanged = gpsEnabled != _gps || hrConnected != _hr;
+      if (_running && !typesChanged) return;
+      _init();
+      if (_running && typesChanged) {
+        // Service types can only be set at start, so restart with the
+        // new capability set.
+        await FlutterForegroundTask.stopService();
+        _running = false;
+      }
+      final permission =
+          await FlutterForegroundTask.checkNotificationPermission();
+      if (permission != NotificationPermission.granted) {
+        await FlutterForegroundTask.requestNotificationPermission();
+      }
+      await FlutterForegroundTask.startService(
+        serviceId: 257,
+        serviceTypes: [
+          if (gpsEnabled) ForegroundServiceTypes.location,
+          if (hrConnected) ForegroundServiceTypes.connectedDevice,
+        ],
+        notificationTitle: 'RepFoundry is tracking your workout',
+        notificationText: 'Cardio session in progress',
+      );
+      _running = true;
+      _gps = gpsEnabled;
+      _hr = hrConnected;
+    } on Exception {
+      // Best-effort: background tracking must never break the session.
+    }
+  }
+}

--- a/lib/features/cardio/data/location_service.dart
+++ b/lib/features/cardio/data/location_service.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:geolocator/geolocator.dart';
 
@@ -30,12 +31,26 @@ class GeolocatorLocationService implements LocationService {
 
   @override
   Stream<Position> getPositionStream() {
-    return Geolocator.getPositionStream(
-      locationSettings: const LocationSettings(
+    // iOS keeps delivering updates while the phone is locked (requires the
+    // UIBackgroundModes location entry and shows the system location
+    // indicator); Android relies on the cardio foreground service to keep
+    // the process alive instead.
+    final LocationSettings settings;
+    if (Platform.isIOS) {
+      settings = AppleSettings(
         accuracy: LocationAccuracy.high,
         distanceFilter: 5,
-      ),
-    );
+        allowBackgroundLocationUpdates: true,
+        showBackgroundLocationIndicator: true,
+        pauseLocationUpdatesAutomatically: false,
+      );
+    } else {
+      settings = const LocationSettings(
+        accuracy: LocationAccuracy.high,
+        distanceFilter: 5,
+      );
+    }
+    return Geolocator.getPositionStream(locationSettings: settings);
   }
 
   @override

--- a/lib/features/cardio/presentation/controllers/cardio_tracking_controller.dart
+++ b/lib/features/cardio/presentation/controllers/cardio_tracking_controller.dart
@@ -8,6 +8,7 @@ import '../../../../core/providers.dart';
 import '../../../health_sync/data/health_sync_service.dart';
 import '../../../health_sync/presentation/providers/health_sync_settings_provider.dart';
 import '../../application/save_cardio_session_use_case.dart';
+import '../../data/foreground_session_service.dart';
 import '../../data/heart_rate_service.dart';
 import '../../data/location_service.dart';
 import '../../domain/repositories/cardio_session_repository.dart';
@@ -30,6 +31,8 @@ class CardioTrackingController extends Notifier<CardioTrackingState> {
   SaveCardioSessionUseCase get _saveUseCase =>
       ref.read(saveCardioSessionUseCaseProvider);
   LocationService get _locationService => ref.read(locationServiceProvider);
+  ForegroundSessionService get _foregroundService =>
+      ref.read(foregroundSessionServiceProvider);
   HeartRateService get _heartRateService => ref.read(heartRateServiceProvider);
   HealthSyncService get _healthSyncService =>
       ref.read(healthSyncServiceProvider);
@@ -65,6 +68,17 @@ class CardioTrackingController extends Notifier<CardioTrackingState> {
     if (state.gpsEnabled) {
       _startGpsTracking();
     }
+    _syncForegroundService();
+  }
+
+  /// Best-effort reconciliation of the Android foreground service that
+  /// keeps GPS/HR streams alive while the phone is locked.
+  void _syncForegroundService() {
+    unawaited(_foregroundService.update(
+      sessionRunning: state.isRunning,
+      gpsEnabled: state.gpsEnabled,
+      hrConnected: state.hrConnected,
+    ));
   }
 
   int get _wallClockElapsedSeconds {
@@ -87,6 +101,7 @@ class CardioTrackingController extends Notifier<CardioTrackingState> {
       isRunning: false,
       elapsedSeconds: _wallClockElapsedSeconds,
     );
+    _syncForegroundService();
   }
 
   void reset() {
@@ -102,6 +117,7 @@ class CardioTrackingController extends Notifier<CardioTrackingState> {
       hrConnected: state.hrConnected,
       hrDeviceName: state.hrDeviceName,
     );
+    _syncForegroundService();
   }
 
   Future<void> toggleGps() async {
@@ -112,6 +128,7 @@ class CardioTrackingController extends Notifier<CardioTrackingState> {
         gpsDistanceMeters: 0,
         gpsAcquiring: false,
       );
+      _syncForegroundService();
       return;
     }
 
@@ -128,6 +145,7 @@ class CardioTrackingController extends Notifier<CardioTrackingState> {
     if (state.isRunning) {
       _startGpsTracking();
     }
+    _syncForegroundService();
   }
 
   void _startGpsTracking() {
@@ -219,6 +237,7 @@ class CardioTrackingController extends Notifier<CardioTrackingState> {
         hrConnecting: false,
         hrDeviceName: deviceName,
       );
+      _syncForegroundService();
     } on Exception catch (e) {
       state = state.copyWith(
         hrConnecting: false,
@@ -241,6 +260,7 @@ class CardioTrackingController extends Notifier<CardioTrackingState> {
       clearHrDeviceName: true,
       heartRateReadings: const [],
     );
+    _syncForegroundService();
   }
 
   Future<void> selectExercise(String id, String name) async {
@@ -323,6 +343,7 @@ class CardioTrackingController extends Notifier<CardioTrackingState> {
       _hrConnectionSub?.cancel();
       _hrConnectionSub = null;
       state = const CardioTrackingState(savedSuccessfully: true);
+      _syncForegroundService();
     } on SaveCardioSessionException catch (e) {
       state = state.copyWith(isSaving: false, error: e.message);
     }

--- a/lib/features/cardio/presentation/controllers/cardio_tracking_controller.dart
+++ b/lib/features/cardio/presentation/controllers/cardio_tracking_controller.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:clock/clock.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:geolocator/geolocator.dart';
 
@@ -18,6 +19,11 @@ class CardioTrackingController extends Notifier<CardioTrackingState> {
   Position? _lastPosition;
   StreamSubscription<int>? _hrSub;
   StreamSubscription<HrConnectionState>? _hrConnectionSub;
+  // Elapsed time is derived from the wall clock rather than counted ticks,
+  // so time spent suspended by the OS (phone locked, app backgrounded) is
+  // still accounted for after resume.
+  DateTime? _runningSince;
+  Duration _accumulated = Duration.zero;
 
   CardioSessionRepository get _cardioRepository =>
       ref.read(cardioSessionRepositoryProvider);
@@ -52,22 +58,41 @@ class CardioTrackingController extends Notifier<CardioTrackingState> {
       savedSuccessfully: false,
       heartRateReadings: isFreshSession ? const [] : state.heartRateReadings,
     );
+    _runningSince = clock.now();
     _timer = Timer.periodic(const Duration(seconds: 1), (_) {
-      state = state.copyWith(elapsedSeconds: state.elapsedSeconds + 1);
+      state = state.copyWith(elapsedSeconds: _wallClockElapsedSeconds);
     });
     if (state.gpsEnabled) {
       _startGpsTracking();
     }
   }
 
+  int get _wallClockElapsedSeconds {
+    final runningSince = _runningSince;
+    final live = runningSince == null
+        ? Duration.zero
+        : clock.now().difference(runningSince);
+    return (_accumulated + live).inSeconds;
+  }
+
   void pause() {
     _timer?.cancel();
     _positionSub?.pause();
-    state = state.copyWith(isRunning: false);
+    final runningSince = _runningSince;
+    if (runningSince != null) {
+      _accumulated += clock.now().difference(runningSince);
+      _runningSince = null;
+    }
+    state = state.copyWith(
+      isRunning: false,
+      elapsedSeconds: _wallClockElapsedSeconds,
+    );
   }
 
   void reset() {
     _timer?.cancel();
+    _runningSince = null;
+    _accumulated = Duration.zero;
     _stopGpsTracking();
     state = CardioTrackingState(
       selectedExerciseId: state.selectedExerciseId,
@@ -234,6 +259,11 @@ class CardioTrackingController extends Notifier<CardioTrackingState> {
     double? incline,
     int? avgHeartRate,
   }) async {
+    // Refresh elapsed from the wall clock so a suspension immediately
+    // before saving cannot truncate the recorded duration.
+    if (_runningSince != null || _accumulated > Duration.zero) {
+      state = state.copyWith(elapsedSeconds: _wallClockElapsedSeconds);
+    }
     if (state.selectedExerciseId == null || state.elapsedSeconds <= 0) return;
 
     // Use GPS distance if GPS is enabled and has data.
@@ -280,6 +310,8 @@ class CardioTrackingController extends Notifier<CardioTrackingState> {
       }
 
       _timer?.cancel();
+      _runningSince = null;
+      _accumulated = Duration.zero;
       _stopGpsTracking();
       // Cancel only this controller's subscriptions; never disconnect the
       // shared HeartRateService singleton, since the dedicated HR panel

--- a/lib/features/heart_rate/presentation/controllers/heart_rate_panel_controller.dart
+++ b/lib/features/heart_rate/presentation/controllers/heart_rate_panel_controller.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:clock/clock.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/providers.dart';
@@ -10,6 +11,18 @@ class HeartRatePanelController extends Notifier<HeartRatePanelState> {
   Timer? _timer;
   StreamSubscription<int>? _hrSub;
   StreamSubscription<HrConnectionState>? _hrConnectionSub;
+  // Elapsed time is derived from the wall clock rather than counted ticks,
+  // so time spent suspended by the OS is still accounted for after resume.
+  DateTime? _monitoringSince;
+  Duration _accumulated = Duration.zero;
+
+  int get _wallClockElapsedSeconds {
+    final monitoringSince = _monitoringSince;
+    final live = monitoringSince == null
+        ? Duration.zero
+        : clock.now().difference(monitoringSince);
+    return (_accumulated + live).inSeconds;
+  }
 
   HeartRateService get _heartRateService => ref.read(heartRateServiceProvider);
 
@@ -59,19 +72,32 @@ class HeartRatePanelController extends Notifier<HeartRatePanelState> {
     }
 
     state = state.copyWith(isMonitoring: true);
+    _monitoringSince = clock.now();
     _timer?.cancel();
     _timer = Timer.periodic(const Duration(seconds: 1), (_) {
-      state = state.copyWith(elapsedSeconds: state.elapsedSeconds + 1);
+      state = state.copyWith(elapsedSeconds: _wallClockElapsedSeconds);
     });
   }
 
   void stopMonitoring() {
     _timer?.cancel();
     _timer = null;
-    state = state.copyWith(isMonitoring: false);
+    final monitoringSince = _monitoringSince;
+    if (monitoringSince != null) {
+      _accumulated += clock.now().difference(monitoringSince);
+      _monitoringSince = null;
+    }
+    state = state.copyWith(
+      isMonitoring: false,
+      elapsedSeconds: _wallClockElapsedSeconds,
+    );
   }
 
   void resetReadings() {
+    _accumulated = Duration.zero;
+    // Restart the anchor if monitoring is still active so elapsed
+    // continues counting from zero, matching the previous behaviour.
+    _monitoringSince = _timer == null ? null : clock.now();
     state = state.copyWith(
       readings: const [],
       elapsedSeconds: 0,
@@ -80,6 +106,8 @@ class HeartRatePanelController extends Notifier<HeartRatePanelState> {
 
   Future<void> disconnectHeartRate() async {
     stopMonitoring();
+    _monitoringSince = null;
+    _accumulated = Duration.zero;
     _hrSub?.cancel();
     _hrSub = null;
     _hrConnectionSub?.cancel();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   hr_zones: ^0.0.2
   flutter_timezone: ^5.1.0
   clock: ^1.1.1
+  flutter_foreground_task: ^9.2.2
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
   app_settings: ^7.0.0
   hr_zones: ^0.0.2
   flutter_timezone: ^5.1.0
+  clock: ^1.1.1
 
 dev_dependencies:
   flutter_test:
@@ -51,6 +52,7 @@ dev_dependencies:
   mockito: ^5.4.4
   drift_dev: ^2.32.0
   build_runner: ^2.4.14
+  fake_async: ^1.3.1
 
 flutter:
   generate: true

--- a/test/features/cardio/data/fake_foreground_session_service.dart
+++ b/test/features/cardio/data/fake_foreground_session_service.dart
@@ -1,0 +1,23 @@
+import 'package:rep_foundry/features/cardio/data/foreground_session_service.dart';
+
+/// Records every reconciliation request for assertions in controller tests.
+class FakeForegroundSessionService implements ForegroundSessionService {
+  final List<({bool sessionRunning, bool gpsEnabled, bool hrConnected})>
+      updates = [];
+
+  ({bool sessionRunning, bool gpsEnabled, bool hrConnected})? get last =>
+      updates.isEmpty ? null : updates.last;
+
+  @override
+  Future<void> update({
+    required bool sessionRunning,
+    required bool gpsEnabled,
+    required bool hrConnected,
+  }) async {
+    updates.add((
+      sessionRunning: sessionRunning,
+      gpsEnabled: gpsEnabled,
+      hrConnected: hrConnected,
+    ));
+  }
+}

--- a/test/features/cardio/presentation/controllers/cardio_tracking_controller_test.dart
+++ b/test/features/cardio/presentation/controllers/cardio_tracking_controller_test.dart
@@ -1,3 +1,4 @@
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:rep_foundry/core/providers.dart';
@@ -87,6 +88,69 @@ void main() {
         controller.start();
         controller.start();
         expect(controller.state.isRunning, isTrue);
+      });
+
+      test('elapsed time follows the wall clock, not tick count', () {
+        fakeAsync((async) {
+          controller.start();
+          async.elapse(const Duration(seconds: 5));
+          expect(controller.state.elapsedSeconds, 5);
+
+          // Simulate OS suspension: wall time passes but no ticks fire.
+          async.elapseBlocking(const Duration(minutes: 10));
+          // The next tick after resume corrects the display.
+          async.elapse(const Duration(seconds: 1));
+          expect(controller.state.elapsedSeconds, 5 + 600 + 1);
+          controller.reset();
+        });
+      });
+
+      test('pause() freezes elapsed and resume accumulates correctly', () {
+        fakeAsync((async) {
+          controller.start();
+          async.elapse(const Duration(seconds: 10));
+          controller.pause();
+          // Time passing while paused must not count.
+          async.elapse(const Duration(minutes: 5));
+          expect(controller.state.elapsedSeconds, 10);
+
+          controller.start();
+          async.elapse(const Duration(seconds: 20));
+          expect(controller.state.elapsedSeconds, 30);
+          controller.reset();
+        });
+      });
+
+      test('reset() zeroes the wall-clock accumulator', () {
+        fakeAsync((async) {
+          controller.start();
+          async.elapse(const Duration(seconds: 30));
+          controller.reset();
+          controller.start();
+          async.elapse(const Duration(seconds: 3));
+          expect(controller.state.elapsedSeconds, 3);
+          controller.reset();
+        });
+      });
+
+      test('save() persists wall-clock duration even without a recent tick',
+          () {
+        fakeAsync((async) {
+          controller.selectExercise('e1', 'Treadmill');
+          async.flushMicrotasks();
+
+          controller.start();
+          async.elapse(const Duration(seconds: 5));
+          // Suspension right before save: no tick fires for 10 minutes.
+          async.elapseBlocking(const Duration(minutes: 10));
+          controller.save(distanceMeters: 1000);
+          async.flushMicrotasks();
+
+          late List<CardioSession> sessions;
+          cardioRepo.getSessionsForExercise('e1').then((s) => sessions = s);
+          async.flushMicrotasks();
+          expect(sessions.single.durationSeconds, 605);
+        });
       });
     });
 

--- a/test/features/cardio/presentation/controllers/cardio_tracking_controller_test.dart
+++ b/test/features/cardio/presentation/controllers/cardio_tracking_controller_test.dart
@@ -12,6 +12,7 @@ import 'package:rep_foundry/features/health_sync/data/health_sync_service.dart';
 import 'package:rep_foundry/features/health_sync/presentation/providers/health_sync_settings_provider.dart';
 import 'package:rep_foundry/features/workout/data/workout_repository_impl.dart';
 
+import '../../data/fake_foreground_session_service.dart';
 import '../../data/fake_heart_rate_service.dart';
 import '../../data/fake_location_service.dart';
 
@@ -21,6 +22,7 @@ void main() {
   late SaveCardioSessionUseCase useCase;
   late FakeLocationService locationService;
   late FakeHeartRateService heartRateService;
+  late FakeForegroundSessionService foregroundService;
   late ProviderContainer container;
   late CardioTrackingController controller;
 
@@ -35,12 +37,14 @@ void main() {
     );
     locationService = FakeLocationService();
     heartRateService = FakeHeartRateService();
+    foregroundService = FakeForegroundSessionService();
     container = ProviderContainer(
       overrides: [
         cardioSessionRepositoryProvider.overrideWithValue(cardioRepo),
         saveCardioSessionUseCaseProvider.overrideWithValue(useCase),
         locationServiceProvider.overrideWithValue(locationService),
         heartRateServiceProvider.overrideWithValue(heartRateService),
+        foregroundSessionServiceProvider.overrideWithValue(foregroundService),
         healthSyncServiceProvider.overrideWithValue(HealthSyncService()),
         healthSyncSettingsProvider
             .overrideWith(() => HealthSyncSettingsNotifier()),
@@ -558,6 +562,64 @@ void main() {
         expect(controller.state.hrReconnecting, isFalse);
         expect(controller.state.currentHeartRate, isNull);
         expect(controller.state.error, isNotNull);
+      });
+    });
+
+    group('foreground session service', () {
+      test('start() activates the service with current capabilities', () {
+        controller.start();
+        expect(
+          foregroundService.last,
+          (sessionRunning: true, gpsEnabled: false, hrConnected: false),
+        );
+        controller.reset();
+      });
+
+      test('pause() deactivates the service', () {
+        controller.start();
+        controller.pause();
+        expect(foregroundService.last?.sessionRunning, isFalse);
+      });
+
+      test('reset() deactivates the service', () {
+        controller.start();
+        controller.reset();
+        expect(foregroundService.last?.sessionRunning, isFalse);
+      });
+
+      test('toggleGps() while running updates the service capabilities',
+          () async {
+        controller.start();
+        await controller.toggleGps();
+        expect(
+          foregroundService.last,
+          (sessionRunning: true, gpsEnabled: true, hrConnected: false),
+        );
+        controller.reset();
+      });
+
+      test('connectHeartRate() while running updates the capabilities',
+          () async {
+        controller.start();
+        await controller.connectHeartRate('dev1', 'Polar H10');
+        expect(
+          foregroundService.last,
+          (sessionRunning: true, gpsEnabled: false, hrConnected: true),
+        );
+        controller.reset();
+      });
+
+      test('save() deactivates the service', () async {
+        await controller.selectExercise('e1', 'Treadmill');
+        controller.start();
+        await Future<void>.delayed(
+            const Duration(seconds: 1, milliseconds: 100));
+        await controller.save(distanceMeters: 500);
+        expect(controller.state.savedSuccessfully, isTrue);
+        expect(foregroundService.last?.sessionRunning, isFalse);
+        // Let the lazily mounted health-sync settings finish loading
+        // before tearDown disposes the container.
+        await Future<void>.delayed(const Duration(milliseconds: 50));
       });
     });
   });

--- a/test/features/heart_rate/presentation/controllers/heart_rate_panel_controller_test.dart
+++ b/test/features/heart_rate/presentation/controllers/heart_rate_panel_controller_test.dart
@@ -1,3 +1,4 @@
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:rep_foundry/core/providers.dart';
@@ -69,6 +70,48 @@ void main() {
 
       expect(controller.state.currentHeartRate, 145);
       expect(controller.state.readings, hasLength(2));
+    });
+
+    test('elapsed time follows the wall clock across suspension', () {
+      fakeAsync((async) {
+        controller.startMonitoring();
+        async.elapse(const Duration(seconds: 5));
+        expect(controller.state.elapsedSeconds, 5);
+
+        // Simulate OS suspension: wall time passes but no ticks fire.
+        async.elapseBlocking(const Duration(minutes: 10));
+        async.elapse(const Duration(seconds: 1));
+        expect(controller.state.elapsedSeconds, 5 + 600 + 1);
+        controller.stopMonitoring();
+      });
+    });
+
+    test('stopMonitoring freezes elapsed; restart accumulates', () {
+      fakeAsync((async) {
+        controller.startMonitoring();
+        async.elapse(const Duration(seconds: 10));
+        controller.stopMonitoring();
+        async.elapse(const Duration(minutes: 2));
+        expect(controller.state.elapsedSeconds, 10);
+
+        controller.startMonitoring();
+        async.elapse(const Duration(seconds: 5));
+        expect(controller.state.elapsedSeconds, 15);
+        controller.stopMonitoring();
+      });
+    });
+
+    test('resetReadings zeroes the wall-clock accumulator', () {
+      fakeAsync((async) {
+        controller.startMonitoring();
+        async.elapse(const Duration(seconds: 30));
+        controller.stopMonitoring();
+        controller.resetReadings();
+        controller.startMonitoring();
+        async.elapse(const Duration(seconds: 3));
+        expect(controller.state.elapsedSeconds, 3);
+        controller.stopMonitoring();
+      });
     });
 
     test('startMonitoring is idempotent', () async {


### PR DESCRIPTION
Fixes #57

## Wall-clock timers (both controllers)

`CardioTrackingController` and `HeartRatePanelController` counted `Timer.periodic` ticks, so OS suspension (phone locked, app backgrounded) silently lost time and produced wrong saved durations and pace. Elapsed time is now derived from a `clock.now()` running-since anchor plus an accumulated paused duration:

- Each tick recomputes from the wall clock, so the first tick after resume self-corrects.
- `save()` refreshes elapsed before persisting, so suspension immediately before saving cannot truncate the session.
- Verified by `fake_async` tests that advance the clock with `elapseBlocking` (time passes, no ticks fire) — the reported failure mode reproduced exactly (8s counted vs 606s wall time).

## Android foreground service

New `ForegroundSessionService` abstraction (cardio data layer), reconciled from the controller on every session/capability change. The `flutter_foreground_task` implementation:

- starts when a session is running with GPS and/or an HR monitor active, using the matching `location`/`connectedDevice` service types (Android 14+ runtime-check compliant), and restarts on capability change;
- shows the required ongoing "RepFoundry is tracking your workout" notification and requests notification permission best-effort;
- stops on pause/reset/save; all failures are swallowed — background tracking never breaks the session;
- is a no-op off Android and when neither GPS nor HR is in use (the wall-clock timer needs no service).

Manifest adds `FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_LOCATION`, `FOREGROUND_SERVICE_CONNECTED_DEVICE` and the service declaration (`stopWithTask=true`). Verified with `flutter build apk --debug --flavor dev`.

## iOS background modes

`UIBackgroundModes` (`location`, `bluetooth-central`) added to Info.plist, and the geolocator subscription now uses `AppleSettings` with `allowBackgroundLocationUpdates`, `showBackgroundLocationIndicator`, and auto-pause disabled. Note: App Store review will expect the location-banner justification discussed in the issue. iOS build not verified (Linux host).

## Scope notes

- Incremental GPS-point persistence (issue item 4) is deferred — cumulative distance remains in-memory during a session.
- Full suite: 949 tests pass; `dart analyze` zero issues; format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzdnbyMxVjus4iasvmQ9Zr