### PR TITLE
fix: reconcile app versioning and document the release scheme

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,15 @@
 name: Android APK Release
 
+# Versioning scheme: semver MAJOR.MINOR.PATCH, tags always v<semver>
+# (optionally with a -SNAPSHOT suffix for pre-releases, see the
+# "Determine release type" step below).
+#
+# The git tag is the source of truth for a released build's version — this
+# workflow injects it into the APK via --build-name/--build-number, so it
+# always overrides whatever `version:` currently sits in pubspec.yaml.
+# pubspec.yaml's version is kept roughly in step (bumped by hand ahead of
+# each release) purely so local/dev builds report a sensible number; it is
+# never read here.
 on:
   push:
     tags:

--- a/lib/features/settings/presentation/screens/about_screen.dart
+++ b/lib/features/settings/presentation/screens/about_screen.dart
@@ -19,7 +19,7 @@ class AboutScreen extends StatelessWidget {
       body: FutureBuilder<PackageInfo>(
         future: PackageInfo.fromPlatform(),
         builder: (context, snapshot) {
-          final version = snapshot.data?.version ?? '1.0.0';
+          final version = snapshot.data?.version ?? '0.1.0';
           final buildNumber = snapshot.data?.buildNumber ?? '';
           final versionDisplay =
               buildNumber.isNotEmpty ? '$version+$buildNumber' : version;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rep_foundry
 description: RepFoundry - A simple, fast workout tracking app for gym-goers.
-version: 1.0.0+1
+version: 0.1.0+1
 publish_to: 'none'
 
 environment:

--- a/src/docs/modules/ROOT/nav.adoc
+++ b/src/docs/modules/ROOT/nav.adoc
@@ -16,6 +16,7 @@
 ** xref:features/notifications.adoc[Notifications]
 * xref:testing.adoc[Testing]
 * xref:localisation.adoc[Localisation]
+* xref:release-versioning.adoc[Release Versioning]
 * Product
 ** xref:product/requirements.adoc[Product Requirements]
 ** xref:product/heart-rate-prd.adoc[Heart Rate PRD]

--- a/src/docs/modules/ROOT/pages/release-versioning.adoc
+++ b/src/docs/modules/ROOT/pages/release-versioning.adoc
@@ -1,0 +1,100 @@
+= Release Versioning
+Paul Snow
+:description: Reference for RepFoundry's version numbering and release tagging scheme
+:keywords: versioning, semver, release, tags, workflow, snapshot
+
+This page is the authoritative reference for how RepFoundry versions and releases are numbered. It describes the tag scheme, how the release workflow derives a build's version, and the (non-authoritative) role of `pubspec.yaml`.
+
+== Versioning Scheme
+
+RepFoundry follows https://semver.org/[semantic versioning] — `MAJOR.MINOR.PATCH` — for example `0.1.0`.
+
+Release tags always take the form `v<semver>`, optionally with a `-SNAPSHOT` suffix to mark a pre-release build:
+
+[cols="2,3",options="header"]
+|===
+| Tag example | Meaning
+
+| `v0.1.0`
+| A standard, signed release build.
+
+| `v0.2.0-SNAPSHOT`
+| A pre-release build. Marked as a *pre-release* on GitHub and does not require a signing keystore.
+|===
+
+The git tag is the single source of truth for a released build's version. Nothing else — including `pubspec.yaml` — determines what version number ships from the release workflow.
+
+[IMPORTANT]
+====
+Tags must always start with `v`. A tag without the `v` prefix will not match the workflow trigger and will silently build nothing. See <<Historical Note: The Missing v Prefix>> below.
+====
+
+== The Release Workflow
+
+The GitHub Actions workflow *Android APK Release* (`.github/workflows/release.yml`) triggers on push of any tag matching `v*` and drives the entire release process.
+
+=== Tag Parsing and Pre-release Detection
+
+The workflow determines the tag from `${GITHUB_REF#refs/tags/}` and checks whether it ends with `-SNAPSHOT` (case-insensitive, matching `-[Ss][Nn][Aa][Pp][Ss][Hh][Oo][Tt]$`) to decide whether the GitHub Release is marked as a pre-release:
+
+[cols="2,2",options="header"]
+|===
+| Tag matches `-SNAPSHOT` suffix? | `prerelease` flag
+
+| No
+| `false` — a standard release
+
+| Yes
+| `true` — marked as a pre-release on GitHub
+|===
+
+=== Signing Requirement
+
+Standard (non-snapshot) releases must be signed. If the tag is not a snapshot and the `KEYSTORE_BASE64` secret is empty, the workflow fails fast with an error rather than publishing an unsigned release. Snapshot releases have no such requirement.
+
+=== Build Name and Build Number
+
+The workflow builds the release APK with:
+
+[source,bash]
+----
+flutter build apk --release --flavor prod \
+  --build-name="$BUILD_NAME" \
+  --build-number="$GITHUB_RUN_NUMBER"
+----
+
+* `BUILD_NAME` is the tag with its leading `v` stripped — tag `v0.1.0` becomes build name `0.1.0`.
+* `BUILD_NUMBER` is `$GITHUB_RUN_NUMBER`, the GitHub Actions run number.
+
+The resulting APK is renamed to `RepFoundry-<tag>.apk` and attached to a GitHub Release created with `generate_release_notes: true`.
+
+== Role of pubspec.yaml
+
+The `version:` field in `pubspec.yaml` (currently `0.1.0+1`) is *not* read by the release workflow at all. It exists only so local and development builds — `flutter run`, or `flutter build apk` run without a tag — report a sensible version in the app's About screen and build information.
+
+It should be bumped by hand ahead of each release to stay roughly in step with the next intended tag, for traceability during development. It is never authoritative for what actually ships from the release workflow — the git tag is.
+
+== Historical Note: The Missing v Prefix
+
+Only `v0.0.1` has ever been released through the workflow. A tag `0.0.2` (without the `v` prefix) was once created pointing at the same commit as `v0.0.1`. Because it did not match the workflow's `v*` trigger, it never built or published anything — it sat as an inert, misleading duplicate. It has since been deleted as an erroneous tag.
+
+This is a cautionary example: always double-check the `v` prefix before pushing a release tag, since an incorrectly named tag fails silently rather than raising an error.
+
+== Cutting a Release
+
+. Bump the `version:` field in `pubspec.yaml` to match the intended next tag (for traceability and local build reporting only).
+. Commit that change.
+. Create the tag:
++
+[source,bash]
+----
+git tag v0.2.0
+----
+. Push the tag to trigger the release workflow:
++
+[source,bash]
+----
+git push origin v0.2.0
+----
+
+For a pre-release build, use a `-SNAPSHOT` suffix instead, for example `git tag v0.2.0-SNAPSHOT`.


### PR DESCRIPTION
Fixes #61

## Decisions made

- **Scheme**: semver `MAJOR.MINOR.PATCH`, release tags always `v<semver>`, `-SNAPSHOT` suffix for pre-releases (the workflow already special-cased this).
- **Source of truth**: the git tag, not `pubspec.yaml`. The release workflow already derives `--build-name`/`--build-number` from the tag; this PR just documents that explicitly and stops pretending pubspec is authoritative.
- **Launch version**: `0.1.0+1`. Only `v0.0.1` has ever actually released — the pubspec's frozen `1.0.0+1` overstated where the project actually is (still pre-launch, per the "before releasing to customers" framing of this issue).

## Changes

- `pubspec.yaml`: `1.0.0+1` → `0.1.0+1`.
- `about_screen.dart`: fallback version string (shown briefly before `PackageInfo` resolves) updated to match.
- `.github/workflows/release.yml`: header comment documents the scheme and clarifies pubspec is never read by the workflow. No logic change — the existing `BUILD_NAME="${TAG#v}"` derivation already matches.
- New Antora page `src/docs/modules/ROOT/pages/release-versioning.adoc` (added to nav) covering the scheme, tag parsing/pre-release detection, the signing requirement, build-name/number derivation, and a "Cutting a Release" checklist.
- Deleted the `0.0.2` tag (local + origin): it was a duplicate of `v0.0.1`'s commit, didn't match the `v*` trigger, and never built anything.

## Verification

- Full suite: 954 tests pass.
- `dart analyze`: zero issues.
- `dart format --set-exit-if-changed .`: clean.
- `gradle21w antora`: build succeeds with the new page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzdnbyMxVjus4iasvmQ9Zr