### PR TITLE
fix: register health plugin and stop settings labels wrapping per-character

### DIFF
--- a/android/app/src/main/kotlin/com/repfoundry/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/repfoundry/app/MainActivity.kt
@@ -1,5 +1,5 @@
 package com.repfoundry.app
 
-import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.android.FlutterFragmentActivity
 
-class MainActivity : FlutterActivity()
+class MainActivity : FlutterFragmentActivity()

--- a/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/lib/features/settings/presentation/screens/settings_screen.dart
@@ -683,6 +683,8 @@ class _Set2Row extends StatelessWidget {
               children: [
                 Text(
                   title,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
                   style: KineticText.display(
                     size: 14.5,
                     weight: FontWeight.w600,
@@ -694,6 +696,8 @@ class _Set2Row extends StatelessWidget {
                   const SizedBox(height: 2),
                   Text(
                     subtitle!,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
                     style: GoogleFonts.manrope(
                       fontSize: 11.5,
                       height: 1.35,


### PR DESCRIPTION
## Summary
- `MainActivity` extended plain `FlutterActivity`, which the `health` plugin cannot cast to `ComponentActivity`, so it silently failed to register on every launch (confirmed via real-device logs: `ClassCastException` in `GeneratedPluginRegistrant`). Switched to `FlutterFragmentActivity` (extends `FragmentActivity` -> `ComponentActivity`) to fix registration.
- Settings rows with a wide trailing segmented control (Theme, Layout) had no overflow handling on their title/subtitle text, so narrow screens squeezed the labels down to one character per line. Constrained to `maxLines` with ellipsis instead.

Both issues were found and verified by running the app on physical Android devices (Samsung Galaxy S23-series and Galaxy S9+).

## Test plan
- [x] `dart analyze` clean on changed files
- [x] `flutter test test/features/settings/` — all 60 tests pass
- [x] Rebuilt and ran on physical device (Galaxy S9+): confirmed `health` plugin registers without error, confirmed Settings > Appearance no longer renders vertical/garbled text

Claude-Session: https://claude.ai/code/session_01UtDqCSdCEwoj638j4GGkbN