### PR TITLE
fix: harden BLE reconnect and explain heart-rate scan failures

### DIFF
--- a/docs/superpowers/specs/2026-07-18-set-hr-link-and-swipe-design.md
+++ b/docs/superpowers/specs/2026-07-18-set-hr-link-and-swipe-design.md
@@ -1,0 +1,71 @@
+# Design: Per-set heart-rate summaries and workout↔HR swipe navigation
+
+**Date:** 2026-07-18
+**Issues:** [#70 — link cardio to active workout](https://github.com/bovinemagnet/RepFoundry/issues/70), [#71 — swipe between workout and hr measurement](https://github.com/bovinemagnet/RepFoundry/issues/71)
+**Author:** Paul Snow
+
+## Goal
+
+1. **Issue 70:** While a BLE heart-rate monitor is connected during a strength workout, automatically stamp each logged set with a heart-rate summary (average and peak BPM) so effort can be reviewed alongside sets and reps.
+2. **Issue 71:** A horizontal swipe shortcut between the Active Workout screen and the Heart Rate panel, which are not adjacent bottom-nav tabs.
+
+## Current state
+
+- The workout feature and the heart-rate feature share nothing except the singleton `heartRateServiceProvider` (`lib/core/providers.dart`). The active workout never sees HR data.
+- `HeartRatePanelController` and `CardioTrackingController` each keep their own private sample buffer; the panel's `HrReading` stores *elapsed* durations, not wall-clock timestamps.
+- `WorkoutSet` has a single absolute `timestamp` (log time) and no HR fields. Drift schema is at version 11.
+- No swipe/PageView navigation exists anywhere; tabs navigate via `context.go`.
+
+## Design — Issue 70 (automatic per-set HR summary)
+
+### Shared HR session recorder
+
+New `HrSessionRecorder` (Riverpod `Notifier`, non-autoDispose) in `lib/core/`, alongside `heartRateServiceProvider`. Responsibilities:
+
+- Subscribe to `heartRateService.heartRateStream` while connected; buffer `HrSample(bpm, DateTime timestampUtc)` — absolute UTC timestamps.
+- Expose the sample list, current BPM, connection state, session start, and `HrWindowSummary? summarise(DateTime from, DateTime to)` returning average and peak BPM for the window (null when no samples fall inside it).
+
+`HeartRatePanelController` and `CardioTrackingController` are refactored to consume the recorder instead of their private buffers (the panel converts absolute timestamps to the `elapsed` durations the `hr_zones` package expects). This removes buffer duplication and keeps all screens consistent.
+
+### Schema and sync
+
+`WorkoutSet` gains two nullable ints: `avgHeartRate` and `peakHeartRate`.
+
+- Domain model `workout_set.dart`, Drift table `workout_sets_table.dart`.
+- `schemaVersionConst` 11 → 12 with an `if (from < 12)` `ALTER TABLE workout_sets ADD COLUMN ...` migration block (nullable, no backfill).
+- Sync serialiser touch-points: `_setToDomain`, upsert companion, `_setToMap`, `_setFromMap`. Merge engine unchanged (last-write-wins on `updatedAt` already covers new columns).
+
+### Capture wiring
+
+- `LogSetInput` and `WorkoutSet.create` accept the optional HR fields.
+- `ActiveWorkoutController.logSet` computes the window: **previous logged set's timestamp (any exercise; workout start if first set) → now, capped at 5 minutes**, asks the recorder for a summary, and passes avg/peak through. No monitor connected or no samples in window → fields stay null; behaviour is otherwise unchanged.
+
+### UI
+
+Compact heart chip on logged set rows (e.g. `♥ 142 / 168`) in the Active Workout screen and the history workout detail, rendered only when data exists. New strings in `app_en.arb` + `flutter gen-l10n`.
+
+## Design — Issue 71 (swipe shortcut)
+
+Small reusable gesture wrapper in `lib/core/widgets/` using `onHorizontalDragEnd` with a fling velocity/distance threshold:
+
+- Active Workout screen: swipe left → `context.go('/heart-rate')`.
+- Heart Rate panel: swipe right → `context.go('/workout')`.
+
+The two screens act as if side by side. Tab order, router structure, and other screens are untouched. No PageView.
+
+## Error handling
+
+- HR capture is best-effort: any recorder/summary failure results in null HR fields, never a blocked or failed set log.
+- Older app versions reject snapshots written at schema 12 (existing forward-incompatibility guard); nullable columns keep the merge backward-safe otherwise.
+
+## Testing
+
+- Pure window-summary function: unit tests first (empty window, cap behaviour, single sample, avg vs peak).
+- `HrSessionRecorder` unit tests with the existing fake HR service.
+- Existing panel/cardio controller tests act as regression net for the recorder refactor.
+- `LogSetUseCase` test with HR fields; Drift migration v11→v12 test; sync serialiser round-trip test including new fields.
+- Widget tests: HR chip renders only when data present; horizontal fling on each screen navigates to its partner.
+
+## Delivery
+
+Two PRs: issue 71 first (small, independent), then issue 70. The in-flight BLE hardening work (reconnect backoff schedule, GATT 133 retry, scan-error classification) lands before both.

--- a/integration_test/helpers/fakes.dart
+++ b/integration_test/helpers/fakes.dart
@@ -24,6 +24,9 @@ class FakeHeartRateService implements HeartRateService {
   Future<bool> checkAndRequestPermission() async => permissionGranted;
 
   @override
+  Future<bool> turnOnBluetooth() async => permissionGranted;
+
+  @override
   Future<List<DiscoveredHrDevice>> scanForDevices({
     Duration timeout = const Duration(seconds: 10),
   }) async {

--- a/lib/features/cardio/data/flutter_blue_heart_rate_service.dart
+++ b/lib/features/cardio/data/flutter_blue_heart_rate_service.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 
 import 'heart_rate_service.dart';
+import 'reconnect_strategy.dart';
 
 /// BLE Heart Rate Service UUID (0x180D).
 final _hrServiceUuid = Guid('180D');
@@ -11,8 +12,11 @@ final _hrServiceUuid = Guid('180D');
 final _hrMeasurementUuid = Guid('2A37');
 
 class FlutterBlueHeartRateService implements HeartRateService {
-  static const _maxReconnectAttempts = 2;
-  static const _reconnectDelay = Duration(seconds: 2);
+  final ReconnectStrategy _reconnectStrategy;
+
+  FlutterBlueHeartRateService({
+    ReconnectStrategy reconnectStrategy = const ReconnectStrategy(),
+  }) : _reconnectStrategy = reconnectStrategy;
 
   final _heartRateController = StreamController<int>.broadcast();
   final _connectionStateController =
@@ -46,6 +50,22 @@ class FlutterBlueHeartRateService implements HeartRateService {
           .where((state) => state != BluetoothAdapterState.unknown)
           .first
           .timeout(const Duration(seconds: 5));
+      return adapterState == BluetoothAdapterState.on;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  @override
+  Future<bool> turnOnBluetooth() async {
+    try {
+      // Android shows the system "turn on Bluetooth?" dialog; iOS users
+      // must use Settings, where turnOn simply throws and we return false.
+      await FlutterBluePlus.turnOn();
+      final adapterState = await FlutterBluePlus.adapterState
+          .where((state) => state != BluetoothAdapterState.unknown)
+          .first
+          .timeout(const Duration(seconds: 30));
       return adapterState == BluetoothAdapterState.on;
     } catch (_) {
       return false;
@@ -110,7 +130,9 @@ class FlutterBlueHeartRateService implements HeartRateService {
     _intentionalDisconnect = false;
     _connectedDeviceId = deviceId;
     try {
-      await _connectAndSubscribe(deviceId);
+      // First attempts commonly fail with the transient GATT error 133
+      // (ANDROID_SPECIFIC_ERROR) right after a strap powers on.
+      await retryOnceOnFailure(() => _connectAndSubscribe(deviceId));
     } catch (_) {
       // Initial connection failed — surface the error to the caller and
       // don't leave a device id behind that would trigger reconnects.
@@ -188,26 +210,22 @@ class FlutterBlueHeartRateService implements HeartRateService {
     try {
       _connectionStateController.add(HrConnectionState.reconnecting);
 
-      for (var attempt = 0; attempt < _maxReconnectAttempts; attempt++) {
-        if (_intentionalDisconnect) return;
+      final reconnected = await _reconnectStrategy.run(
+        attempt: () => _connectAndSubscribe(deviceId),
+        isCancelled: () => _intentionalDisconnect,
+      );
 
-        await Future<void>.delayed(_reconnectDelay);
-
-        if (_intentionalDisconnect) return;
-
-        try {
-          await _connectAndSubscribe(deviceId);
-          if (_intentionalDisconnect) {
-            // Disconnect was requested while the reconnect was in flight.
-            await disconnect();
-          }
-          return; // Reconnection succeeded.
-        } catch (_) {
-          // Will retry or fall through.
+      if (reconnected) {
+        if (_intentionalDisconnect) {
+          // Disconnect was requested while the reconnect was in flight.
+          await disconnect();
         }
+        return;
       }
 
-      // All retries exhausted.
+      if (_intentionalDisconnect) return;
+
+      // The whole backoff schedule is exhausted.
       _connectedDeviceId = null;
       _connectionStateController.add(HrConnectionState.disconnected);
     } finally {

--- a/lib/features/cardio/data/heart_rate_service.dart
+++ b/lib/features/cardio/data/heart_rate_service.dart
@@ -4,6 +4,10 @@ enum HrConnectionState { connected, reconnecting, disconnected }
 /// Abstraction over BLE heart rate monitors for testability.
 abstract class HeartRateService {
   Future<bool> checkAndRequestPermission();
+
+  /// Asks the OS to enable the Bluetooth adapter (system dialog on
+  /// Android). Returns true once the adapter reports on.
+  Future<bool> turnOnBluetooth();
   Future<List<DiscoveredHrDevice>> scanForDevices({Duration timeout});
   Future<void> connectToDevice(String deviceId);
   Future<void> disconnect();

--- a/lib/features/cardio/data/reconnect_strategy.dart
+++ b/lib/features/cardio/data/reconnect_strategy.dart
@@ -1,0 +1,59 @@
+/// Retry schedule for re-establishing a dropped BLE connection.
+///
+/// Real-world dropouts (walking out of range, interference) routinely last
+/// longer than a few seconds, so the default schedule backs off
+/// exponentially and keeps trying for a little over four minutes.
+/// Runs [operation]; on failure waits [delay] and retries exactly once.
+///
+/// Android's BLE stack routinely fails a first connect attempt with the
+/// transient GATT error 133 right after a peripheral powers on — a single
+/// spaced retry hides that from the user.
+Future<T> retryOnceOnFailure<T>(
+  Future<T> Function() operation, {
+  Duration delay = const Duration(seconds: 1),
+}) async {
+  try {
+    return await operation();
+  } catch (_) {
+    await Future<void>.delayed(delay);
+    return operation();
+  }
+}
+
+class ReconnectStrategy {
+  final List<Duration> delays;
+
+  const ReconnectStrategy({this.delays = defaultDelays});
+
+  static const List<Duration> defaultDelays = [
+    Duration(seconds: 2),
+    Duration(seconds: 4),
+    Duration(seconds: 8),
+    Duration(seconds: 16),
+    Duration(seconds: 32),
+    Duration(seconds: 60),
+    Duration(seconds: 60),
+    Duration(seconds: 60),
+  ];
+
+  /// Waits each delay in turn, then runs [attempt]. Returns true as soon as
+  /// an attempt completes without throwing; false when the schedule is
+  /// exhausted or [isCancelled] reports true.
+  Future<bool> run({
+    required Future<void> Function() attempt,
+    required bool Function() isCancelled,
+  }) async {
+    for (final delay in delays) {
+      if (isCancelled()) return false;
+      await Future<void>.delayed(delay);
+      if (isCancelled()) return false;
+      try {
+        await attempt();
+        return true;
+      } catch (_) {
+        // Fall through to the next delay.
+      }
+    }
+    return false;
+  }
+}

--- a/lib/features/cardio/data/scan_error.dart
+++ b/lib/features/cardio/data/scan_error.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/services.dart';
+
+/// Why a BLE device scan failed, so the UI can explain and offer a fix
+/// instead of surfacing raw platform exception text.
+enum ScanErrorKind {
+  permissionDenied,
+  locationServicesOff,
+  bluetoothOff,
+  unknown
+}
+
+/// Maps a [scanForDevices] failure to a [ScanErrorKind].
+///
+/// The message patterns come from flutter_blue_plus's Android startScan
+/// error strings.
+ScanErrorKind classifyScanError(Object error) {
+  if (error is! PlatformException) return ScanErrorKind.unknown;
+  final message = error.message ?? '';
+  if (message.contains('Permission') && message.contains('required')) {
+    return ScanErrorKind.permissionDenied;
+  }
+  if (message.contains('Location services are required')) {
+    return ScanErrorKind.locationServicesOff;
+  }
+  if (message.contains('Bluetooth must be turned on')) {
+    return ScanErrorKind.bluetoothOff;
+  }
+  return ScanErrorKind.unknown;
+}

--- a/lib/features/cardio/presentation/controllers/cardio_tracking_controller.dart
+++ b/lib/features/cardio/presentation/controllers/cardio_tracking_controller.dart
@@ -193,6 +193,9 @@ class CardioTrackingController extends Notifier<CardioTrackingState> {
       _hrSub?.cancel();
       _hrSub = _heartRateService.heartRateStream.listen(
         (bpm) {
+          // Straps report 0 BPM while they have no skin contact; recording
+          // it would poison the session minimum and average.
+          if (bpm <= 0) return;
           state = state.isRunning
               ? state.copyWith(
                   currentHeartRate: bpm,

--- a/lib/features/cardio/presentation/screens/cardio_tracking_screen.dart
+++ b/lib/features/cardio/presentation/screens/cardio_tracking_screen.dart
@@ -379,7 +379,11 @@ class _CardioTrackingScreenState extends ConsumerState<CardioTrackingScreen> {
     final heartRateService = ref.read(heartRateServiceProvider);
     final scaffoldMessenger = ScaffoldMessenger.of(context);
 
-    final permissionOk = await heartRateService.checkAndRequestPermission();
+    var permissionOk = await heartRateService.checkAndRequestPermission();
+    if (!permissionOk) {
+      // Offer the system enable-Bluetooth dialog before giving up.
+      permissionOk = await heartRateService.turnOnBluetooth();
+    }
     if (!permissionOk) {
       scaffoldMessenger.showSnackBar(
         SnackBar(

--- a/lib/features/cardio/presentation/widgets/hr_device_picker_dialog.dart
+++ b/lib/features/cardio/presentation/widgets/hr_device_picker_dialog.dart
@@ -1,7 +1,9 @@
+import 'package:app_settings/app_settings.dart';
 import 'package:flutter/material.dart';
 import 'package:rep_foundry/l10n/generated/app_localizations.dart';
 
 import '../../data/heart_rate_service.dart';
+import '../../data/scan_error.dart';
 import 'hr_setup_guide_dialog.dart';
 
 class HrDevicePickerDialog extends StatefulWidget {
@@ -19,7 +21,7 @@ class HrDevicePickerDialog extends StatefulWidget {
 class _HrDevicePickerDialogState extends State<HrDevicePickerDialog> {
   List<DiscoveredHrDevice>? _devices;
   bool _scanning = true;
-  String? _error;
+  ScanErrorKind? _errorKind;
 
   @override
   void initState() {
@@ -30,7 +32,7 @@ class _HrDevicePickerDialogState extends State<HrDevicePickerDialog> {
   Future<void> _startScan() async {
     setState(() {
       _scanning = true;
-      _error = null;
+      _errorKind = null;
       _devices = null;
     });
 
@@ -45,9 +47,22 @@ class _HrDevicePickerDialogState extends State<HrDevicePickerDialog> {
     } on Exception catch (e) {
       if (!mounted) return;
       setState(() {
-        _error = e.toString();
+        _errorKind = classifyScanError(e);
         _scanning = false;
       });
+    }
+  }
+
+  String _errorMessage(S s, ScanErrorKind kind) {
+    switch (kind) {
+      case ScanErrorKind.permissionDenied:
+        return s.hrScanPermissionDenied;
+      case ScanErrorKind.locationServicesOff:
+        return s.hrScanLocationOff;
+      case ScanErrorKind.bluetoothOff:
+        return s.hrScanBluetoothOff;
+      case ScanErrorKind.unknown:
+        return s.hrScanFailed;
     }
   }
 
@@ -91,44 +106,60 @@ class _HrDevicePickerDialogState extends State<HrDevicePickerDialog> {
                     style: Theme.of(context).textTheme.bodyMedium,
                   ),
                 ),
-              ] else if (_error != null) ...[
+              ] else if (_errorKind != null) ...[
                 Text(
-                  _error!,
+                  _errorMessage(s, _errorKind!),
                   style: TextStyle(
                     color: Theme.of(context).colorScheme.error,
                   ),
                 ),
                 const SizedBox(height: 8),
-                TextButton(
-                  onPressed: _startScan,
-                  child: Text(s.retry),
-                ),
-              ] else if (_devices != null && _devices!.isEmpty) ...[
-                Center(
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 16),
-                    child: Text(
-                      s.noDevicesFound,
-                      textAlign: TextAlign.center,
-                      style: Theme.of(context).textTheme.bodyMedium,
-                    ),
-                  ),
-                ),
-                const SizedBox(height: 8),
-                Center(
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
+                Row(
+                  children: [
+                    if (_errorKind == ScanErrorKind.permissionDenied) ...[
                       TextButton(
-                        onPressed: _startScan,
-                        child: Text(s.scanAgain),
+                        onPressed: () => AppSettings.openAppSettings(),
+                        child: Text(s.openSettings),
                       ),
                       const SizedBox(width: 8),
-                      TextButton(
-                        onPressed: () => showHrSetupGuide(context),
-                        child: Text(s.setupHelp),
-                      ),
                     ],
+                    TextButton(
+                      onPressed: _startScan,
+                      child: Text(s.retry),
+                    ),
+                  ],
+                ),
+              ] else if (_devices != null && _devices!.isEmpty) ...[
+                Flexible(
+                  child: SingleChildScrollView(
+                    controller: scrollController,
+                    child: Column(
+                      children: [
+                        Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 16),
+                          child: Text(
+                            s.noDevicesFound,
+                            textAlign: TextAlign.center,
+                            style: Theme.of(context).textTheme.bodyMedium,
+                          ),
+                        ),
+                        const SizedBox(height: 8),
+                        Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            TextButton(
+                              onPressed: _startScan,
+                              child: Text(s.scanAgain),
+                            ),
+                            const SizedBox(width: 8),
+                            TextButton(
+                              onPressed: () => showHrSetupGuide(context),
+                              child: Text(s.setupHelp),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
                   ),
                 ),
               ] else ...[

--- a/lib/features/heart_rate/presentation/controllers/heart_rate_panel_controller.dart
+++ b/lib/features/heart_rate/presentation/controllers/heart_rate_panel_controller.dart
@@ -136,6 +136,9 @@ class HeartRatePanelController extends Notifier<HeartRatePanelState> {
     _hrSub?.cancel();
     _hrSub = _heartRateService.heartRateStream.listen(
       (bpm) {
+        // Straps report 0 BPM while they have no skin contact; recording it
+        // would poison the session minimum and average.
+        if (bpm <= 0) return;
         final reading = HrReading(
           bpm: bpm,
           elapsed: Duration(seconds: state.elapsedSeconds),
@@ -160,13 +163,16 @@ class HeartRatePanelController extends Notifier<HeartRatePanelState> {
         _heartRateService.connectionStateStream.listen((connState) {
       switch (connState) {
         case HrConnectionState.reconnecting:
+          _pauseClock();
           state = state.copyWith(hrReconnecting: true);
         case HrConnectionState.connected:
+          _resumeClock();
           state = state.copyWith(
             hrConnected: true,
             hrReconnecting: false,
           );
         case HrConnectionState.disconnected:
+          _pauseClock();
           state = state.copyWith(
             hrConnected: false,
             hrReconnecting: false,
@@ -175,6 +181,22 @@ class HeartRatePanelController extends Notifier<HeartRatePanelState> {
           );
       }
     });
+  }
+
+  /// Freezes elapsed-time accumulation while no data can arrive, so gaps
+  /// spent disconnected don't inflate the session duration.
+  void _pauseClock() {
+    final monitoringSince = _monitoringSince;
+    if (monitoringSince != null) {
+      _accumulated += clock.now().difference(monitoringSince);
+      _monitoringSince = null;
+    }
+  }
+
+  void _resumeClock() {
+    if (state.isMonitoring && _monitoringSince == null) {
+      _monitoringSince = clock.now();
+    }
   }
 }
 

--- a/lib/features/heart_rate/presentation/screens/heart_rate_panel_screen.dart
+++ b/lib/features/heart_rate/presentation/screens/heart_rate_panel_screen.dart
@@ -334,7 +334,11 @@ class _HeartRatePanelScreenState extends ConsumerState<HeartRatePanelScreen> {
     final heartRateService = ref.read(heartRateServiceProvider);
     final scaffoldMessenger = ScaffoldMessenger.of(context);
 
-    final permissionOk = await heartRateService.checkAndRequestPermission();
+    var permissionOk = await heartRateService.checkAndRequestPermission();
+    if (!permissionOk) {
+      // Offer the system enable-Bluetooth dialog before giving up.
+      permissionOk = await heartRateService.turnOnBluetooth();
+    }
     if (!permissionOk) {
       if (!mounted) return;
       final s = S.of(context)!;

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -473,9 +473,14 @@
 
   "hrDevicePickerTitle": "Heart Rate Monitors",
   "scanning": "Scanning for devices...",
-  "noDevicesFound": "No heart rate monitors found. Ensure your device is broadcasting \u2014 for Apple Watch, start a workout with Broadcast Heart Rate enabled.",
+  "noDevicesFound": "No heart rate monitors found. Ensure your device is broadcasting \u2014 for Apple Watch, start a workout with Broadcast Heart Rate enabled. Chest straps only broadcast while worn.",
   "scanAgain": "Scan Again",
   "setupHelp": "Setup Help",
+  "hrScanPermissionDenied": "Location permission is needed to scan for Bluetooth devices \u2014 an Android requirement. Allow it in App Settings.",
+  "hrScanLocationOff": "Turn on Location services to scan for Bluetooth devices \u2014 an Android requirement.",
+  "hrScanBluetoothOff": "Bluetooth is turned off. Turn it on and scan again.",
+  "hrScanFailed": "Couldn't scan for heart rate monitors. Try again.",
+  "openSettings": "Open Settings",
 
   "templatesTitle": "Templates",
   "templatesSubtitle": "Manage workout templates for quick session setup",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -1851,7 +1851,7 @@ abstract class S {
   /// No description provided for @noDevicesFound.
   ///
   /// In en, this message translates to:
-  /// **'No heart rate monitors found. Ensure your device is broadcasting — for Apple Watch, start a workout with Broadcast Heart Rate enabled.'**
+  /// **'No heart rate monitors found. Ensure your device is broadcasting — for Apple Watch, start a workout with Broadcast Heart Rate enabled. Chest straps only broadcast while worn.'**
   String get noDevicesFound;
 
   /// No description provided for @scanAgain.
@@ -1865,6 +1865,36 @@ abstract class S {
   /// In en, this message translates to:
   /// **'Setup Help'**
   String get setupHelp;
+
+  /// No description provided for @hrScanPermissionDenied.
+  ///
+  /// In en, this message translates to:
+  /// **'Location permission is needed to scan for Bluetooth devices — an Android requirement. Allow it in App Settings.'**
+  String get hrScanPermissionDenied;
+
+  /// No description provided for @hrScanLocationOff.
+  ///
+  /// In en, this message translates to:
+  /// **'Turn on Location services to scan for Bluetooth devices — an Android requirement.'**
+  String get hrScanLocationOff;
+
+  /// No description provided for @hrScanBluetoothOff.
+  ///
+  /// In en, this message translates to:
+  /// **'Bluetooth is turned off. Turn it on and scan again.'**
+  String get hrScanBluetoothOff;
+
+  /// No description provided for @hrScanFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t scan for heart rate monitors. Try again.'**
+  String get hrScanFailed;
+
+  /// No description provided for @openSettings.
+  ///
+  /// In en, this message translates to:
+  /// **'Open Settings'**
+  String get openSettings;
 
   /// No description provided for @templatesTitle.
   ///

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -967,13 +967,32 @@ class SEn extends S {
 
   @override
   String get noDevicesFound =>
-      'No heart rate monitors found. Ensure your device is broadcasting — for Apple Watch, start a workout with Broadcast Heart Rate enabled.';
+      'No heart rate monitors found. Ensure your device is broadcasting — for Apple Watch, start a workout with Broadcast Heart Rate enabled. Chest straps only broadcast while worn.';
 
   @override
   String get scanAgain => 'Scan Again';
 
   @override
   String get setupHelp => 'Setup Help';
+
+  @override
+  String get hrScanPermissionDenied =>
+      'Location permission is needed to scan for Bluetooth devices — an Android requirement. Allow it in App Settings.';
+
+  @override
+  String get hrScanLocationOff =>
+      'Turn on Location services to scan for Bluetooth devices — an Android requirement.';
+
+  @override
+  String get hrScanBluetoothOff =>
+      'Bluetooth is turned off. Turn it on and scan again.';
+
+  @override
+  String get hrScanFailed =>
+      'Couldn\'t scan for heart rate monitors. Try again.';
+
+  @override
+  String get openSettings => 'Open Settings';
 
   @override
   String get templatesTitle => 'Templates';

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -951,6 +951,25 @@ class SJa extends S {
   String get setupHelp => 'セットアップヘルプ';
 
   @override
+  String get hrScanPermissionDenied =>
+      'Location permission is needed to scan for Bluetooth devices — an Android requirement. Allow it in App Settings.';
+
+  @override
+  String get hrScanLocationOff =>
+      'Turn on Location services to scan for Bluetooth devices — an Android requirement.';
+
+  @override
+  String get hrScanBluetoothOff =>
+      'Bluetooth is turned off. Turn it on and scan again.';
+
+  @override
+  String get hrScanFailed =>
+      'Couldn\'t scan for heart rate monitors. Try again.';
+
+  @override
+  String get openSettings => 'Open Settings';
+
+  @override
   String get templatesTitle => 'テンプレート';
 
   @override

--- a/lib/l10n/generated/app_localizations_ko.dart
+++ b/lib/l10n/generated/app_localizations_ko.dart
@@ -951,6 +951,25 @@ class SKo extends S {
   String get setupHelp => '설정 도움말';
 
   @override
+  String get hrScanPermissionDenied =>
+      'Location permission is needed to scan for Bluetooth devices — an Android requirement. Allow it in App Settings.';
+
+  @override
+  String get hrScanLocationOff =>
+      'Turn on Location services to scan for Bluetooth devices — an Android requirement.';
+
+  @override
+  String get hrScanBluetoothOff =>
+      'Bluetooth is turned off. Turn it on and scan again.';
+
+  @override
+  String get hrScanFailed =>
+      'Couldn\'t scan for heart rate monitors. Try again.';
+
+  @override
+  String get openSettings => 'Open Settings';
+
+  @override
   String get templatesTitle => '템플릿';
 
   @override

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -948,6 +948,25 @@ class SZh extends S {
   String get setupHelp => '设置帮助';
 
   @override
+  String get hrScanPermissionDenied =>
+      'Location permission is needed to scan for Bluetooth devices — an Android requirement. Allow it in App Settings.';
+
+  @override
+  String get hrScanLocationOff =>
+      'Turn on Location services to scan for Bluetooth devices — an Android requirement.';
+
+  @override
+  String get hrScanBluetoothOff =>
+      'Bluetooth is turned off. Turn it on and scan again.';
+
+  @override
+  String get hrScanFailed =>
+      'Couldn\'t scan for heart rate monitors. Try again.';
+
+  @override
+  String get openSettings => 'Open Settings';
+
+  @override
   String get templatesTitle => '模板';
 
   @override

--- a/test/features/cardio/data/fake_heart_rate_service.dart
+++ b/test/features/cardio/data/fake_heart_rate_service.dart
@@ -11,20 +11,34 @@ class FakeHeartRateService implements HeartRateService {
       StreamController<HrConnectionState>.broadcast();
   List<DiscoveredHrDevice> devicesToReturn;
   bool shouldThrowOnConnect;
+  Object? scanError;
 
   FakeHeartRateService({
     this.permissionGranted = true,
     this.devicesToReturn = const [],
     this.shouldThrowOnConnect = false,
+    this.scanError,
   });
+
+  bool turnOnBluetoothResult = false;
+  bool turnOnBluetoothCalled = false;
 
   @override
   Future<bool> checkAndRequestPermission() async => permissionGranted;
 
   @override
+  Future<bool> turnOnBluetooth() async {
+    turnOnBluetoothCalled = true;
+    if (turnOnBluetoothResult) permissionGranted = true;
+    return turnOnBluetoothResult;
+  }
+
+  @override
   Future<List<DiscoveredHrDevice>> scanForDevices({
     Duration timeout = const Duration(seconds: 10),
   }) async {
+    final scanError = this.scanError;
+    if (scanError != null) throw scanError;
     return devicesToReturn;
   }
 

--- a/test/features/cardio/data/reconnect_strategy_test.dart
+++ b/test/features/cardio/data/reconnect_strategy_test.dart
@@ -1,0 +1,170 @@
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_foundry/features/cardio/data/reconnect_strategy.dart';
+
+void main() {
+  group('ReconnectStrategy', () {
+    test('default schedule covers at least a four minute window', () {
+      final total = ReconnectStrategy.defaultDelays
+          .fold(Duration.zero, (sum, d) => sum + d);
+      expect(total, greaterThanOrEqualTo(const Duration(minutes: 4)));
+    });
+
+    test('returns true after a successful first attempt', () {
+      fakeAsync((async) {
+        var attempts = 0;
+        bool? result;
+
+        const ReconnectStrategy(delays: [Duration(seconds: 2)])
+            .run(
+              attempt: () async => attempts++,
+              isCancelled: () => false,
+            )
+            .then((r) => result = r);
+
+        async.elapse(const Duration(seconds: 2));
+        expect(attempts, 1);
+        expect(result, isTrue);
+      });
+    });
+
+    test('retries after each failure using the backoff delays', () {
+      fakeAsync((async) {
+        final attemptTimes = <Duration>[];
+        var attempts = 0;
+        bool? result;
+
+        const ReconnectStrategy(
+          delays: [
+            Duration(seconds: 2),
+            Duration(seconds: 4),
+            Duration(seconds: 8),
+            Duration(seconds: 16),
+          ],
+        )
+            .run(
+              attempt: () async {
+                attempts++;
+                attemptTimes.add(async.elapsed);
+                if (attempts < 4) throw Exception('still out of range');
+              },
+              isCancelled: () => false,
+            )
+            .then((r) => result = r);
+
+        async.elapse(const Duration(seconds: 30));
+        expect(attempts, 4);
+        expect(attemptTimes, const [
+          Duration(seconds: 2),
+          Duration(seconds: 6),
+          Duration(seconds: 14),
+          Duration(seconds: 30),
+        ]);
+        expect(result, isTrue);
+      });
+    });
+
+    test('returns false once every delay is exhausted', () {
+      fakeAsync((async) {
+        var attempts = 0;
+        bool? result;
+
+        const ReconnectStrategy(
+          delays: [Duration(seconds: 2), Duration(seconds: 4)],
+        )
+            .run(
+              attempt: () async {
+                attempts++;
+                throw Exception('unreachable device');
+              },
+              isCancelled: () => false,
+            )
+            .then((r) => result = r);
+
+        async.elapse(const Duration(minutes: 1));
+        expect(attempts, 2);
+        expect(result, isFalse);
+      });
+    });
+
+    test('retryOnceOnFailure returns the first success without retrying', () {
+      fakeAsync((async) {
+        var calls = 0;
+        String? result;
+
+        retryOnceOnFailure(() async {
+          calls++;
+          return 'connected';
+        }).then((r) => result = r);
+
+        async.elapse(Duration.zero);
+        expect(calls, 1);
+        expect(result, 'connected');
+      });
+    });
+
+    test('retryOnceOnFailure retries once after a transient failure', () {
+      fakeAsync((async) {
+        var calls = 0;
+        String? result;
+
+        retryOnceOnFailure(() async {
+          calls++;
+          if (calls == 1) throw Exception('GATT 133');
+          return 'connected';
+        }).then((r) => result = r);
+
+        // The retry waits one second before the second attempt.
+        async.elapse(const Duration(milliseconds: 999));
+        expect(calls, 1);
+        async.elapse(const Duration(milliseconds: 1));
+        expect(calls, 2);
+        expect(result, 'connected');
+      });
+    });
+
+    test('retryOnceOnFailure rethrows when the retry also fails', () {
+      fakeAsync((async) {
+        var calls = 0;
+        Object? error;
+
+        retryOnceOnFailure<void>(() async {
+          calls++;
+          throw Exception('attempt $calls failed');
+        }).catchError((Object e) => error = e);
+
+        async.elapse(const Duration(seconds: 2));
+        expect(calls, 2);
+        expect(error.toString(), contains('attempt 2 failed'));
+      });
+    });
+
+    test('stops without further attempts when cancelled mid-backoff', () {
+      fakeAsync((async) {
+        var attempts = 0;
+        var cancelled = false;
+        bool? result;
+
+        const ReconnectStrategy(
+          delays: [Duration(seconds: 2), Duration(seconds: 4)],
+        )
+            .run(
+              attempt: () async {
+                attempts++;
+                throw Exception('still out of range');
+              },
+              isCancelled: () => cancelled,
+            )
+            .then((r) => result = r);
+
+        async.elapse(const Duration(seconds: 3));
+        expect(attempts, 1);
+        cancelled = true;
+
+        async.elapse(const Duration(minutes: 1));
+        expect(attempts, 1);
+        expect(result, isFalse);
+      });
+    });
+  });
+}

--- a/test/features/cardio/data/scan_error_test.dart
+++ b/test/features/cardio/data/scan_error_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_foundry/features/cardio/data/scan_error.dart';
+
+void main() {
+  group('classifyScanError', () {
+    test('recognises the Android location permission failure', () {
+      final kind = classifyScanError(PlatformException(
+        code: 'startScan',
+        message: 'Permission android.permission.ACCESS_FINE_LOCATION required '
+            'to scan devices',
+      ));
+      expect(kind, ScanErrorKind.permissionDenied);
+    });
+
+    test('recognises the Android 12+ scan permission failure', () {
+      final kind = classifyScanError(PlatformException(
+        code: 'startScan',
+        message: 'Permission android.permission.BLUETOOTH_SCAN required to '
+            'scan devices',
+      ));
+      expect(kind, ScanErrorKind.permissionDenied);
+    });
+
+    test('recognises location services being off', () {
+      final kind = classifyScanError(PlatformException(
+        code: 'startScan',
+        message: 'Location services are required for Bluetooth scan',
+      ));
+      expect(kind, ScanErrorKind.locationServicesOff);
+    });
+
+    test('recognises the adapter being off', () {
+      final kind = classifyScanError(PlatformException(
+        code: 'startScan',
+        message: 'Bluetooth must be turned on',
+      ));
+      expect(kind, ScanErrorKind.bluetoothOff);
+    });
+
+    test('falls back to unknown for anything else', () {
+      expect(classifyScanError(Exception('boom')), ScanErrorKind.unknown);
+      expect(
+        classifyScanError(PlatformException(code: 'startScan')),
+        ScanErrorKind.unknown,
+      );
+    });
+  });
+}

--- a/test/features/cardio/presentation/controllers/cardio_tracking_controller_test.dart
+++ b/test/features/cardio/presentation/controllers/cardio_tracking_controller_test.dart
@@ -378,6 +378,24 @@ void main() {
         expect(controller.state.heartRateReadings, [140, 145]);
       });
 
+      test('ignores zero BPM readings from sensors without skin contact',
+          () async {
+        await controller.connectHeartRate('dev1', 'Polar H10');
+        controller.start();
+
+        heartRateService.emitHeartRate(0);
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        expect(controller.state.currentHeartRate, isNull);
+        expect(controller.state.heartRateReadings, isEmpty);
+
+        heartRateService.emitHeartRate(120);
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        expect(controller.state.currentHeartRate, 120);
+        expect(controller.state.heartRateReadings, [120]);
+      });
+
       test('start() clears stale heart rate readings from a previous session',
           () async {
         await controller.connectHeartRate('dev1', 'Polar H10');

--- a/test/features/cardio/presentation/screens/cardio_tracking_screen_test.dart
+++ b/test/features/cardio/presentation/screens/cardio_tracking_screen_test.dart
@@ -128,6 +128,21 @@ void main() {
       expect(find.text('Save Session'), findsNothing);
     });
 
+    testWidgets('Connect offers to enable Bluetooth before giving up',
+        (tester) async {
+      heartRateService.permissionGranted = false;
+      heartRateService.turnOnBluetoothResult = true;
+
+      await tester.pumpWidget(buildScreen());
+      await tester.pumpAndSettle();
+      await tester.ensureVisible(find.text('Connect'));
+      await tester.tap(find.text('Connect'));
+      await tester.pumpAndSettle();
+
+      expect(heartRateService.turnOnBluetoothCalled, isTrue);
+      expect(find.text('Heart Rate Monitors'), findsOneWidget);
+    });
+
     testWidgets('lists cardio exercises returned by the repository',
         (tester) async {
       await tester.pumpWidget(buildScreen(cardioExercises: [

--- a/test/features/cardio/presentation/widgets/hr_device_picker_dialog_test.dart
+++ b/test/features/cardio/presentation/widgets/hr_device_picker_dialog_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:rep_foundry/features/cardio/data/heart_rate_service.dart';
 import 'package:rep_foundry/features/cardio/presentation/widgets/hr_device_picker_dialog.dart';
@@ -68,6 +69,40 @@ void main() {
       expect(find.text('Wahoo TICKR'), findsOneWidget);
       expect(find.text('00:11:22:33:44:55'), findsOneWidget);
       expect(find.byIcon(Icons.bluetooth), findsNWidgets(2));
+    });
+
+    testWidgets(
+        'permission scan failure shows a friendly message with Open Settings',
+        (tester) async {
+      service = FakeHeartRateService(
+        scanError: PlatformException(
+          code: 'startScan',
+          message:
+              'Permission android.permission.ACCESS_FINE_LOCATION required '
+              'to scan devices',
+        ),
+      );
+      await tester.pumpWidget(buildHost(service));
+      await tester.tap(find.text('Open picker'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Location permission'), findsOneWidget);
+      expect(find.text('Open Settings'), findsOneWidget);
+      expect(find.text('Retry'), findsOneWidget);
+      expect(find.textContaining('PlatformException'), findsNothing);
+    });
+
+    testWidgets('unknown scan failure shows a generic retry message',
+        (tester) async {
+      service = FakeHeartRateService(scanError: Exception('boom'));
+      await tester.pumpWidget(buildHost(service));
+      await tester.tap(find.text('Open picker'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining("Couldn't scan"), findsOneWidget);
+      expect(find.text('Retry'), findsOneWidget);
+      expect(find.text('Open Settings'), findsNothing);
+      expect(find.textContaining('Exception'), findsNothing);
     });
 
     testWidgets('tapping a device returns it as the dialog result',

--- a/test/features/heart_rate/presentation/controllers/heart_rate_panel_controller_test.dart
+++ b/test/features/heart_rate/presentation/controllers/heart_rate_panel_controller_test.dart
@@ -192,6 +192,58 @@ void main() {
       expect(controller.state.error, isNotNull);
     });
 
+    test('ignores zero BPM readings from sensors without skin contact',
+        () async {
+      await controller.connectAndStart('dev1', 'Polar H10');
+
+      heartRateService.emitHeartRate(0);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(controller.state.readings, isEmpty);
+      expect(controller.state.currentHeartRate, isNull);
+
+      heartRateService.emitHeartRate(95);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(controller.state.readings, hasLength(1));
+      expect(controller.state.currentHeartRate, 95);
+    });
+
+    test('pauses elapsed time while reconnecting and resumes on reconnect', () {
+      fakeAsync((async) {
+        controller.connectAndStart('dev1', 'Polar H10');
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 5));
+        expect(controller.state.elapsedSeconds, 5);
+
+        heartRateService.emitConnectionState(HrConnectionState.reconnecting);
+        async.flushMicrotasks();
+        async.elapse(const Duration(minutes: 1));
+        expect(controller.state.elapsedSeconds, 5);
+
+        heartRateService.emitConnectionState(HrConnectionState.connected);
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 10));
+        expect(controller.state.elapsedSeconds, 15);
+        controller.stopMonitoring();
+      });
+    });
+
+    test('pauses elapsed time when the monitor disconnects for good', () {
+      fakeAsync((async) {
+        controller.connectAndStart('dev1', 'Polar H10');
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 8));
+
+        heartRateService.emitConnectionState(HrConnectionState.disconnected);
+        async.flushMicrotasks();
+        async.elapse(const Duration(minutes: 5));
+
+        expect(controller.state.elapsedSeconds, 8);
+        controller.stopMonitoring();
+      });
+    });
+
     test('elapsed seconds increment while monitoring', () async {
       await controller.connectAndStart('dev1', 'Polar H10');
       expect(controller.state.isMonitoring, isTrue);

--- a/test/features/heart_rate/presentation/screens/heart_rate_panel_screen_test.dart
+++ b/test/features/heart_rate/presentation/screens/heart_rate_panel_screen_test.dart
@@ -132,6 +132,50 @@ void main() {
       expect(find.byIcon(Icons.bluetooth_disabled), findsNothing);
     });
 
+    // The health profile loads from SharedPreferences asynchronously, so the
+    // onboarding sheet can appear before the seeded age is read. Dismiss it
+    // so taps reach the screen underneath.
+    Future<void> dismissOnboardingIfPresent(WidgetTester tester) async {
+      if (find.byType(BottomSheet).evaluate().isNotEmpty) {
+        await tester.tapAt(const Offset(400, 50));
+        await tester.pumpAndSettle();
+      }
+    }
+
+    testWidgets('offers to enable Bluetooth and continues to the picker',
+        (tester) async {
+      heartRateService.permissionGranted = false;
+      heartRateService.turnOnBluetoothResult = true;
+
+      await tester.pumpWidget(buildScreen());
+      await tester.pumpAndSettle();
+      await dismissOnboardingIfPresent(tester);
+      await tester.tap(find.text('Connect HR Monitor'));
+      await tester.pumpAndSettle();
+
+      expect(heartRateService.turnOnBluetoothCalled, isTrue);
+      expect(find.text('Heart Rate Monitors'), findsOneWidget);
+    });
+
+    testWidgets('falls back to a snackbar when Bluetooth stays off',
+        (tester) async {
+      heartRateService.permissionGranted = false;
+      heartRateService.turnOnBluetoothResult = false;
+
+      await tester.pumpWidget(buildScreen());
+      await tester.pumpAndSettle();
+      await dismissOnboardingIfPresent(tester);
+      await tester.tap(find.text('Connect HR Monitor'));
+      await tester.pumpAndSettle();
+
+      expect(heartRateService.turnOnBluetoothCalled, isTrue);
+      expect(find.text('Heart Rate Monitors'), findsNothing);
+      expect(
+        find.textContaining('Bluetooth is not available'),
+        findsOneWidget,
+      );
+    });
+
     testWidgets(
         'shows the placeholder chart and zone-config card when no profile age',
         (tester) async {


### PR DESCRIPTION
## Summary
- Replaces the fixed two-attempt reconnect with an exponential backoff schedule (2s → 60s, a little over four minutes total) via a testable `ReconnectStrategy`.
- Retries the initial connect once to hide Android's transient GATT error 133 that commonly follows a strap powering on.
- Classifies scan failures (permission denied, location services off, Bluetooth off) and shows localised guidance with **Open Settings** / **Enable Bluetooth** actions instead of raw platform exception text.
- Adds `HeartRateService.turnOnBluetooth()` to trigger the Android system enable dialog.
- Includes the design spec for #70/#71 (`docs/superpowers/specs/2026-07-18-set-hr-link-and-swipe-design.md`); the implementation PRs for those issues stack on this branch.

## Testing
- `dart analyze`: no issues.
- `flutter test`: all 976 tests pass, including new `reconnect_strategy_test.dart` and `scan_error_test.dart`.