### PR TITLE
feat: swipe between active workout and heart rate panel

### DIFF
--- a/lib/core/widgets/horizontal_swipe_navigator.dart
+++ b/lib/core/widgets/horizontal_swipe_navigator.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+/// Detects horizontal fling gestures over [child] and invokes the matching
+/// callback, so two screens can offer a swipe shortcut to one another
+/// without a PageView.
+///
+/// Vertical scrolling inside [child] is unaffected: only the horizontal
+/// drag gesture is claimed, and a fling must exceed [velocityThreshold]
+/// (logical pixels per second) to count as a swipe.
+class HorizontalSwipeNavigator extends StatelessWidget {
+  const HorizontalSwipeNavigator({
+    super.key,
+    required this.child,
+    this.onSwipeLeft,
+    this.onSwipeRight,
+    this.velocityThreshold = 400,
+  });
+
+  final Widget child;
+
+  /// Called on a leftward fling (finger moves right to left).
+  final VoidCallback? onSwipeLeft;
+
+  /// Called on a rightward fling (finger moves left to right).
+  final VoidCallback? onSwipeRight;
+
+  final double velocityThreshold;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      behavior: HitTestBehavior.translucent,
+      onHorizontalDragEnd: (details) {
+        final velocity = details.primaryVelocity ?? 0;
+        if (velocity <= -velocityThreshold) {
+          onSwipeLeft?.call();
+        } else if (velocity >= velocityThreshold) {
+          onSwipeRight?.call();
+        }
+      },
+      child: child,
+    );
+  }
+}

--- a/lib/features/heart_rate/presentation/screens/heart_rate_panel_screen.dart
+++ b/lib/features/heart_rate/presentation/screens/heart_rate_panel_screen.dart
@@ -2,11 +2,13 @@ import 'package:audioplayers/audioplayers.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:rep_foundry/l10n/generated/app_localizations.dart';
 
 import '../../../../core/extensions/datetime_extensions.dart';
 import '../../../../core/providers.dart';
+import '../../../../core/widgets/horizontal_swipe_navigator.dart';
 import '../../../../core/widgets/kinetic.dart';
 import '../../../../core/widgets/sparkline_widget.dart';
 import '../../../cardio/presentation/controllers/cardio_tracking_controller.dart';
@@ -160,113 +162,117 @@ class _HeartRatePanelScreenState extends ConsumerState<HeartRatePanelScreen> {
           ),
         ],
       ),
-      body: ListView(
-        padding: const EdgeInsets.fromLTRB(22, 8, 22, 96),
-        children: [
-          // Kinetic app header.
-          const KineticAppHeader(),
+      // Swipe right to jump back to the active workout (issue #71).
+      body: HorizontalSwipeNavigator(
+        onSwipeRight: () => context.go('/workout'),
+        child: ListView(
+          padding: const EdgeInsets.fromLTRB(22, 8, 22, 96),
+          children: [
+            // Kinetic app header.
+            const KineticAppHeader(),
 
-          // Caution badge.
-          if (profile.isCautionMode) ...[
-            CautionBadge(profile: profile),
-            const SizedBox(height: 12),
-          ],
+            // Caution badge.
+            if (profile.isCautionMode) ...[
+              CautionBadge(profile: profile),
+              const SizedBox(height: 12),
+            ],
 
-          // ── Hero BPM section ──────────────────────────────────────
-          _HeroBpmSection(
-            panelState: panelState,
-            activeZone: activeZone,
-            peakZoneColor: peakZoneColor,
-          ),
-          const SizedBox(height: 16),
-
-          // Controls.
-          _buildControls(context, panelState, controller),
-          const SizedBox(height: 24),
-
-          // ── EKG trace sparkline ───────────────────────────────────
-          if (panelState.readings.isNotEmpty) ...[
-            _EkgTrace(
-              readings: panelState.readings,
+            // ── Hero BPM section ──────────────────────────────────────
+            _HeroBpmSection(
+              panelState: panelState,
+              activeZone: activeZone,
               peakZoneColor: peakZoneColor,
             ),
-            const SizedBox(height: 20),
-          ],
+            const SizedBox(height: 16),
 
-          // ── Vitals bento grid ─────────────────────────────────────
-          if (panelState.readings.isNotEmpty) ...[
-            _MetricBentoGrid(
-              avgBpm: bpmStats.avg,
-              maxBpm: bpmStats.max,
-              minBpm: bpmStats.min,
-              readingCount: panelState.readings.length,
-              profile: profile,
-            ),
+            // Controls.
+            _buildControls(context, panelState, controller),
             const SizedBox(height: 24),
-          ],
 
-          // ── Workout Intensity Zones ───────────────────────────────
-          if (zoneConfig != null && panelState.readings.isNotEmpty) ...[
-            _ZonesSection(
-              panelState: panelState,
-              zoneConfig: zoneConfig,
-            ),
-            const SizedBox(height: 24),
-          ],
-
-          // ── HR Trend card with SparklineWidget ────────────────────
-          if (panelState.readings.isNotEmpty) ...[
-            _TrendChartSection(
-              panelState: panelState,
-              zoneConfig: zoneConfig,
-              chartWindow: chartWindow,
-              showZoneBands: showZoneBands,
-              peakZoneColor: peakZoneColor,
-              onWindowChanged: (v) =>
-                  ref.read(chartWindowProvider.notifier).setWindow(v),
-            ),
-            const SizedBox(height: 16),
-          ] else ...[
-            HeartRateChart(
-              readings: panelState.readings,
-              zoneConfig: zoneConfig,
-              showZoneBands: showZoneBands,
-            ),
-            const SizedBox(height: 16),
-          ],
-
-          // Symptom report button during active monitoring.
-          if (panelState.isMonitoring) ...[
-            SymptomReportButton(
-              onStopRequested: controller.stopMonitoring,
-              analytics: ref.read(hrAnalyticsReporterProvider),
-            ),
-            const SizedBox(height: 16),
-          ],
-
-          // ── Full Weekly Heart Report row (.srow style) ────────────
-          if (panelState.readings.isNotEmpty) ...[
-            _WeeklyReportRow(peakZoneColor: peakZoneColor),
-            const SizedBox(height: 16),
-          ],
-
-          // Zone legend / no-profile prompt.
-          if (zoneConfig != null) ...[
-            HeartRateZoneLegend(
-              config: zoneConfig,
-              currentBpm: panelState.currentHeartRate,
-            ),
-          ] else ...[
-            Card(
-              child: ListTile(
-                leading: const Icon(Icons.info_outline),
-                title: Text(s.setAgeInSettings),
-                subtitle: Text(s.setAgeInSettingsSubtitle),
-                onTap: () => showHealthProfileOnboarding(context),
+            // ── EKG trace sparkline ───────────────────────────────────
+            if (panelState.readings.isNotEmpty) ...[
+              _EkgTrace(
+                readings: panelState.readings,
+                peakZoneColor: peakZoneColor,
               ),
-            ),
+              const SizedBox(height: 20),
+            ],
+
+            // ── Vitals bento grid ─────────────────────────────────────
+            if (panelState.readings.isNotEmpty) ...[
+              _MetricBentoGrid(
+                avgBpm: bpmStats.avg,
+                maxBpm: bpmStats.max,
+                minBpm: bpmStats.min,
+                readingCount: panelState.readings.length,
+                profile: profile,
+              ),
+              const SizedBox(height: 24),
+            ],
+
+            // ── Workout Intensity Zones ───────────────────────────────
+            if (zoneConfig != null && panelState.readings.isNotEmpty) ...[
+              _ZonesSection(
+                panelState: panelState,
+                zoneConfig: zoneConfig,
+              ),
+              const SizedBox(height: 24),
+            ],
+
+            // ── HR Trend card with SparklineWidget ────────────────────
+            if (panelState.readings.isNotEmpty) ...[
+              _TrendChartSection(
+                panelState: panelState,
+                zoneConfig: zoneConfig,
+                chartWindow: chartWindow,
+                showZoneBands: showZoneBands,
+                peakZoneColor: peakZoneColor,
+                onWindowChanged: (v) =>
+                    ref.read(chartWindowProvider.notifier).setWindow(v),
+              ),
+              const SizedBox(height: 16),
+            ] else ...[
+              HeartRateChart(
+                readings: panelState.readings,
+                zoneConfig: zoneConfig,
+                showZoneBands: showZoneBands,
+              ),
+              const SizedBox(height: 16),
+            ],
+
+            // Symptom report button during active monitoring.
+            if (panelState.isMonitoring) ...[
+              SymptomReportButton(
+                onStopRequested: controller.stopMonitoring,
+                analytics: ref.read(hrAnalyticsReporterProvider),
+              ),
+              const SizedBox(height: 16),
+            ],
+
+            // ── Full Weekly Heart Report row (.srow style) ────────────
+            if (panelState.readings.isNotEmpty) ...[
+              _WeeklyReportRow(peakZoneColor: peakZoneColor),
+              const SizedBox(height: 16),
+            ],
+
+            // Zone legend / no-profile prompt.
+            if (zoneConfig != null) ...[
+              HeartRateZoneLegend(
+                config: zoneConfig,
+                currentBpm: panelState.currentHeartRate,
+              ),
+            ] else ...[
+              Card(
+                child: ListTile(
+                  leading: const Icon(Icons.info_outline),
+                  title: Text(s.setAgeInSettings),
+                  subtitle: Text(s.setAgeInSettingsSubtitle),
+                  onTap: () => showHealthProfileOnboarding(context),
+                ),
+              ),
+            ],
           ],
-        ],
+        ),
       ),
     );
   }

--- a/lib/features/workout/presentation/screens/active_workout_screen.dart
+++ b/lib/features/workout/presentation/screens/active_workout_screen.dart
@@ -19,6 +19,7 @@ import '../../../../core/extensions/datetime_extensions.dart';
 import '../../../../core/providers.dart';
 import '../../../../core/units/weight_unit.dart';
 import '../../../../core/units/weight_unit_provider.dart';
+import '../../../../core/widgets/horizontal_swipe_navigator.dart';
 import '../../../../core/widgets/kinetic.dart';
 import '../../../../core/widgets/loading_widget.dart';
 import '../../../../core/widgets/sparkline_widget.dart';
@@ -200,11 +201,15 @@ class ActiveWorkoutScreenState extends ConsumerState<ActiveWorkoutScreen>
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.surface,
       body: SafeArea(
-        child: state.isLoading
-            ? LoadingWidget(message: s.loadingWorkout)
-            : state.hasActiveWorkout
-                ? _buildActiveWorkout(context, ref, state, controller)
-                : _buildNoWorkout(context, ref, controller),
+        // Swipe left to jump to the heart rate panel (issue #71).
+        child: HorizontalSwipeNavigator(
+          onSwipeLeft: () => context.go('/heart-rate'),
+          child: state.isLoading
+              ? LoadingWidget(message: s.loadingWorkout)
+              : state.hasActiveWorkout
+                  ? _buildActiveWorkout(context, ref, state, controller)
+                  : _buildNoWorkout(context, ref, controller),
+        ),
       ),
       floatingActionButton: state.hasActiveWorkout && !_keyboardVisible
           ? FloatingActionButton.extended(

--- a/test/core/widgets/horizontal_swipe_navigator_test.dart
+++ b/test/core/widgets/horizontal_swipe_navigator_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_foundry/core/widgets/horizontal_swipe_navigator.dart';
+
+void main() {
+  Widget build({
+    VoidCallback? onSwipeLeft,
+    VoidCallback? onSwipeRight,
+    Widget? child,
+  }) {
+    return MaterialApp(
+      home: Scaffold(
+        body: HorizontalSwipeNavigator(
+          onSwipeLeft: onSwipeLeft,
+          onSwipeRight: onSwipeRight,
+          child: child ?? const SizedBox.expand(),
+        ),
+      ),
+    );
+  }
+
+  group('HorizontalSwipeNavigator', () {
+    testWidgets('leftward fling calls onSwipeLeft', (tester) async {
+      var leftCalls = 0;
+      var rightCalls = 0;
+      await tester.pumpWidget(build(
+        onSwipeLeft: () => leftCalls++,
+        onSwipeRight: () => rightCalls++,
+      ));
+
+      await tester.fling(
+        find.byType(HorizontalSwipeNavigator),
+        const Offset(-300, 0),
+        1200,
+      );
+      await tester.pumpAndSettle();
+
+      expect(leftCalls, 1);
+      expect(rightCalls, 0);
+    });
+
+    testWidgets('rightward fling calls onSwipeRight', (tester) async {
+      var leftCalls = 0;
+      var rightCalls = 0;
+      await tester.pumpWidget(build(
+        onSwipeLeft: () => leftCalls++,
+        onSwipeRight: () => rightCalls++,
+      ));
+
+      await tester.fling(
+        find.byType(HorizontalSwipeNavigator),
+        const Offset(300, 0),
+        1200,
+      );
+      await tester.pumpAndSettle();
+
+      expect(leftCalls, 0);
+      expect(rightCalls, 1);
+    });
+
+    testWidgets('slow horizontal drag below the fling threshold is ignored',
+        (tester) async {
+      var leftCalls = 0;
+      var rightCalls = 0;
+      await tester.pumpWidget(build(
+        onSwipeLeft: () => leftCalls++,
+        onSwipeRight: () => rightCalls++,
+      ));
+
+      await tester.timedDrag(
+        find.byType(HorizontalSwipeNavigator),
+        const Offset(-100, 0),
+        const Duration(seconds: 1),
+      );
+      await tester.pumpAndSettle();
+
+      expect(leftCalls, 0);
+      expect(rightCalls, 0);
+    });
+
+    testWidgets('vertical scrolling inside the child still works',
+        (tester) async {
+      var leftCalls = 0;
+      var rightCalls = 0;
+      await tester.pumpWidget(build(
+        onSwipeLeft: () => leftCalls++,
+        onSwipeRight: () => rightCalls++,
+        child: ListView(
+          children: [
+            for (var i = 0; i < 40; i++)
+              SizedBox(height: 50, child: Text('row $i')),
+          ],
+        ),
+      ));
+
+      expect(find.text('row 0'), findsOneWidget);
+      await tester.fling(find.byType(ListView), const Offset(0, -400), 1200);
+      await tester.pumpAndSettle();
+
+      expect(find.text('row 0'), findsNothing);
+      expect(leftCalls, 0);
+      expect(rightCalls, 0);
+    });
+
+    testWidgets('missing callbacks are a no-op rather than an error',
+        (tester) async {
+      await tester.pumpWidget(build());
+
+      await tester.fling(
+        find.byType(HorizontalSwipeNavigator),
+        const Offset(-300, 0),
+        1200,
+      );
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+    });
+  });
+}

--- a/test/features/heart_rate/presentation/screens/heart_rate_panel_screen_test.dart
+++ b/test/features/heart_rate/presentation/screens/heart_rate_panel_screen_test.dart
@@ -2,13 +2,16 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:rep_foundry/core/providers.dart';
 import 'package:rep_foundry/features/cardio/application/save_cardio_session_use_case.dart';
 import 'package:rep_foundry/features/cardio/data/cardio_session_repository_impl.dart';
 import 'package:rep_foundry/features/health_sync/data/health_sync_service.dart';
 import 'package:rep_foundry/features/health_sync/presentation/providers/health_sync_settings_provider.dart';
+import 'package:hr_zones/hr_zones.dart';
 import 'package:rep_foundry/features/heart_rate/presentation/controllers/heart_rate_panel_controller.dart';
 import 'package:rep_foundry/features/heart_rate/presentation/controllers/heart_rate_panel_state.dart';
+import 'package:rep_foundry/features/heart_rate/presentation/providers/health_profile_provider.dart';
 import 'package:rep_foundry/features/heart_rate/presentation/screens/heart_rate_panel_screen.dart';
 import 'package:rep_foundry/features/workout/data/workout_repository_impl.dart';
 import 'package:rep_foundry/l10n/generated/app_localizations.dart';
@@ -16,6 +19,13 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../../cardio/data/fake_heart_rate_service.dart';
 import '../../../cardio/data/fake_location_service.dart';
+
+/// Health profile override with a synchronously seeded age, so the
+/// first-visit onboarding sheet never opens during a test.
+class _SeededHealthProfileNotifier extends HealthProfileNotifier {
+  @override
+  HealthProfile build() => const HealthProfile(age: 35);
+}
 
 /// Notifier override that seeds the panel with a specific initial state so
 /// tests can render branches that normally depend on live BLE readings.
@@ -473,6 +483,84 @@ void main() {
       // controller's disconnectHeartRate() flow itself is unit-tested in
       // heart_rate_panel_controller_test.dart.
       expect(find.byTooltip('Disconnect'), findsOneWidget);
+    });
+  });
+
+  group('swipe navigation', () {
+    Widget buildRouterScreen() {
+      // The real notifier loads the profile from SharedPreferences
+      // asynchronously, which races the first-visit onboarding check; a
+      // seeded profile keeps the onboarding sheet (and its modal barrier,
+      // which would swallow the fling) out of this test.
+      final seededProfile = healthProfileProvider.overrideWith(
+        _SeededHealthProfileNotifier.new,
+      );
+      final router = GoRouter(
+        initialLocation: '/heart-rate',
+        routes: [
+          GoRoute(
+            path: '/heart-rate',
+            builder: (context, state) => const HeartRatePanelScreen(),
+          ),
+          GoRoute(
+            path: '/workout',
+            builder: (context, state) =>
+                const Scaffold(body: Text('workout destination')),
+          ),
+        ],
+      );
+      return ProviderScope(
+        overrides: [
+          cardioSessionRepositoryProvider.overrideWithValue(cardioRepo),
+          saveCardioSessionUseCaseProvider.overrideWithValue(
+            SaveCardioSessionUseCase(
+              cardioRepository: cardioRepo,
+              workoutRepository: workoutRepo,
+            ),
+          ),
+          locationServiceProvider.overrideWithValue(locationService),
+          heartRateServiceProvider.overrideWithValue(heartRateService),
+          healthSyncServiceProvider.overrideWithValue(HealthSyncService()),
+          healthSyncSettingsProvider
+              .overrideWith(() => HealthSyncSettingsNotifier()),
+          seededProfile,
+        ],
+        child: MaterialApp.router(
+          localizationsDelegates: S.localizationsDelegates,
+          supportedLocales: S.supportedLocales,
+          routerConfig: router,
+        ),
+      );
+    }
+
+    testWidgets('rightward fling navigates to the active workout screen',
+        (tester) async {
+      await tester.pumpWidget(buildRouterScreen());
+      await tester.pumpAndSettle();
+
+      await tester.fling(
+        find.byType(HeartRatePanelScreen),
+        const Offset(300, 0),
+        1200,
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('workout destination'), findsOneWidget);
+    });
+
+    testWidgets('leftward fling stays on the heart rate panel', (tester) async {
+      await tester.pumpWidget(buildRouterScreen());
+      await tester.pumpAndSettle();
+
+      await tester.fling(
+        find.byType(HeartRatePanelScreen),
+        const Offset(-300, 0),
+        1200,
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('workout destination'), findsNothing);
+      expect(find.byType(HeartRatePanelScreen), findsOneWidget);
     });
   });
 }

--- a/test/features/workout/presentation/screens/active_workout_screen_test.dart
+++ b/test/features/workout/presentation/screens/active_workout_screen_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:rep_foundry/core/providers.dart';
@@ -421,5 +422,79 @@ void main() {
         expect(state.scrollController.offset, 0.0);
       },
     );
+  });
+
+  group('swipe navigation', () {
+    Widget buildRouterScreen() {
+      final router = GoRouter(
+        initialLocation: '/workout',
+        routes: [
+          GoRoute(
+            path: '/workout',
+            builder: (context, state) => const ActiveWorkoutScreen(),
+          ),
+          GoRoute(
+            path: '/heart-rate',
+            builder: (context, state) =>
+                const Scaffold(body: Text('heart-rate destination')),
+          ),
+        ],
+      );
+      return ProviderScope(
+        overrides: [
+          workoutRepositoryProvider
+              .overrideWithValue(InMemoryWorkoutRepository()),
+          exerciseRepositoryProvider.overrideWithValue(
+            InMemoryExerciseRepository(),
+          ),
+          personalRecordRepositoryProvider.overrideWithValue(
+            InMemoryPersonalRecordRepository(),
+          ),
+          workoutTemplateRepositoryProvider.overrideWithValue(
+            InMemoryWorkoutTemplateRepository(),
+          ),
+          healthSyncServiceProvider.overrideWithValue(HealthSyncService()),
+          healthSyncSettingsProvider.overrideWith(
+            () => HealthSyncSettingsNotifier(),
+          ),
+          syncSettingsProvider.overrideWith(() => SyncSettingsNotifier()),
+        ],
+        child: MaterialApp.router(
+          localizationsDelegates: S.localizationsDelegates,
+          supportedLocales: S.supportedLocales,
+          routerConfig: router,
+        ),
+      );
+    }
+
+    testWidgets('leftward fling navigates to the heart rate panel',
+        (tester) async {
+      await tester.pumpWidget(buildRouterScreen());
+      await tester.pumpAndSettle();
+
+      await tester.fling(
+        find.byType(ActiveWorkoutScreen),
+        const Offset(-300, 0),
+        1200,
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('heart-rate destination'), findsOneWidget);
+    });
+
+    testWidgets('rightward fling stays on the workout screen', (tester) async {
+      await tester.pumpWidget(buildRouterScreen());
+      await tester.pumpAndSettle();
+
+      await tester.fling(
+        find.byType(ActiveWorkoutScreen),
+        const Offset(300, 0),
+        1200,
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('heart-rate destination'), findsNothing);
+      expect(find.byType(ActiveWorkoutScreen), findsOneWidget);
+    });
   });
 }


### PR DESCRIPTION
## Summary
Implements #71 per the design commented on the issue and the spec in `docs/superpowers/specs/2026-07-18-set-hr-link-and-swipe-design.md`.

- New reusable `HorizontalSwipeNavigator` in `lib/core/widgets/` — a fling-threshold horizontal gesture wrapper (velocity ≥ 400 px/s), no PageView, no router restructuring.
- Active Workout screen: swipe **left** → `/heart-rate`.
- Heart Rate panel: swipe **right** → `/workout`.
- Tab order and all other screens untouched; vertical scrolling and taps unaffected.

Stacked on #72 (BLE hardening) — merge that first.

## Testing (TDD)
- 5 new widget tests for the wrapper (fling left/right, sub-threshold drag ignored, vertical scroll unaffected, missing callbacks are a no-op).
- 4 new screen tests using a GoRouter harness (each direction navigates; the opposite direction stays put).
- Full suite: 985 tests pass; `dart analyze` clean; `dart format` clean.

Closes #71