### PR TITLE
feat: land swipe navigation and per-set heart rate summary on main

### DIFF
--- a/docs/superpowers/specs/2026-07-18-set-hr-link-and-swipe-design.md
+++ b/docs/superpowers/specs/2026-07-18-set-hr-link-and-swipe-design.md
@@ -25,7 +25,7 @@ New `HrSessionRecorder` (Riverpod `Notifier`, non-autoDispose) in `lib/core/`, a
 - Subscribe to `heartRateService.heartRateStream` while connected; buffer `HrSample(bpm, DateTime timestampUtc)` — absolute UTC timestamps.
 - Expose the sample list, current BPM, connection state, session start, and `HrWindowSummary? summarise(DateTime from, DateTime to)` returning average and peak BPM for the window (null when no samples fall inside it).
 
-`HeartRatePanelController` and `CardioTrackingController` are refactored to consume the recorder instead of their private buffers (the panel converts absolute timestamps to the `elapsed` durations the `hr_zones` package expects). This removes buffer duplication and keeps all screens consistent.
+**Scope decision (made during implementation):** the panel and cardio controllers keep their existing private buffers. Their buffers carry session-scoped semantics the recorder deliberately does not have — the panel's readings use elapsed-time offsets that pause during reconnects, and cardio's readings reset on fresh sessions — and both behaviours are pinned by existing tests. Rewiring them through the recorder would rewrite tested behaviour without user-facing benefit. Because every screen already shares the single `heartRateServiceProvider`, the recorder still captures samples no matter which screen connected the strap, which is all issue 70 needs. Consolidating the three buffers remains a possible future refactor.
 
 ### Schema and sync
 

--- a/lib/core/database/app_database.dart
+++ b/lib/core/database/app_database.dart
@@ -38,7 +38,7 @@ class AppDatabase extends _$AppDatabase {
 
   /// Static accessor for the schema version, usable from non-database code
   /// (e.g. the sync serialiser) without an `AppDatabase` instance.
-  static const int schemaVersionConst = 11;
+  static const int schemaVersionConst = 12;
 
   @override
   int get schemaVersion => schemaVersionConst;
@@ -264,6 +264,16 @@ class AppDatabase extends _$AppDatabase {
             await m.createIndex(idxProgrammeDaysProgramme);
             await m.createIndex(idxTemplateExercisesTemplate);
             await m.createIndex(idxProgressionRulesProgramme);
+          }
+          if (from < 12) {
+            // Per-set heart rate summary captured while a monitor is
+            // connected during a strength workout (issue #70).
+            await customStatement(
+              'ALTER TABLE workout_sets ADD COLUMN avg_heart_rate INTEGER',
+            );
+            await customStatement(
+              'ALTER TABLE workout_sets ADD COLUMN peak_heart_rate INTEGER',
+            );
           }
         },
       );

--- a/lib/core/database/app_database.g.dart
+++ b/lib/core/database/app_database.g.dart
@@ -1333,6 +1333,18 @@ class $WorkoutSetsTable extends WorkoutSets
   late final GeneratedColumn<String> groupId = GeneratedColumn<String>(
       'group_id', aliasedName, true,
       type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _avgHeartRateMeta =
+      const VerificationMeta('avgHeartRate');
+  @override
+  late final GeneratedColumn<int> avgHeartRate = GeneratedColumn<int>(
+      'avg_heart_rate', aliasedName, true,
+      type: DriftSqlType.int, requiredDuringInsert: false);
+  static const VerificationMeta _peakHeartRateMeta =
+      const VerificationMeta('peakHeartRate');
+  @override
+  late final GeneratedColumn<int> peakHeartRate = GeneratedColumn<int>(
+      'peak_heart_rate', aliasedName, true,
+      type: DriftSqlType.int, requiredDuringInsert: false);
   static const VerificationMeta _updatedAtMeta =
       const VerificationMeta('updatedAt');
   @override
@@ -1359,6 +1371,8 @@ class $WorkoutSetsTable extends WorkoutSets
         timestamp,
         isWarmUp,
         groupId,
+        avgHeartRate,
+        peakHeartRate,
         updatedAt,
         deletedAt
       ];
@@ -1427,6 +1441,18 @@ class $WorkoutSetsTable extends WorkoutSets
       context.handle(_groupIdMeta,
           groupId.isAcceptableOrUnknown(data['group_id']!, _groupIdMeta));
     }
+    if (data.containsKey('avg_heart_rate')) {
+      context.handle(
+          _avgHeartRateMeta,
+          avgHeartRate.isAcceptableOrUnknown(
+              data['avg_heart_rate']!, _avgHeartRateMeta));
+    }
+    if (data.containsKey('peak_heart_rate')) {
+      context.handle(
+          _peakHeartRateMeta,
+          peakHeartRate.isAcceptableOrUnknown(
+              data['peak_heart_rate']!, _peakHeartRateMeta));
+    }
     if (data.containsKey('updated_at')) {
       context.handle(_updatedAtMeta,
           updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta));
@@ -1464,6 +1490,10 @@ class $WorkoutSetsTable extends WorkoutSets
           .read(DriftSqlType.bool, data['${effectivePrefix}is_warm_up'])!,
       groupId: attachedDatabase.typeMapping
           .read(DriftSqlType.string, data['${effectivePrefix}group_id']),
+      avgHeartRate: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}avg_heart_rate']),
+      peakHeartRate: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}peak_heart_rate']),
       updatedAt: attachedDatabase.typeMapping
           .read(DriftSqlType.int, data['${effectivePrefix}updated_at'])!,
       deletedAt: attachedDatabase.typeMapping
@@ -1488,6 +1518,8 @@ class WorkoutSet extends DataClass implements Insertable<WorkoutSet> {
   final int timestamp;
   final bool isWarmUp;
   final String? groupId;
+  final int? avgHeartRate;
+  final int? peakHeartRate;
   final int updatedAt;
   final int? deletedAt;
   const WorkoutSet(
@@ -1501,6 +1533,8 @@ class WorkoutSet extends DataClass implements Insertable<WorkoutSet> {
       required this.timestamp,
       required this.isWarmUp,
       this.groupId,
+      this.avgHeartRate,
+      this.peakHeartRate,
       required this.updatedAt,
       this.deletedAt});
   @override
@@ -1519,6 +1553,12 @@ class WorkoutSet extends DataClass implements Insertable<WorkoutSet> {
     map['is_warm_up'] = Variable<bool>(isWarmUp);
     if (!nullToAbsent || groupId != null) {
       map['group_id'] = Variable<String>(groupId);
+    }
+    if (!nullToAbsent || avgHeartRate != null) {
+      map['avg_heart_rate'] = Variable<int>(avgHeartRate);
+    }
+    if (!nullToAbsent || peakHeartRate != null) {
+      map['peak_heart_rate'] = Variable<int>(peakHeartRate);
     }
     map['updated_at'] = Variable<int>(updatedAt);
     if (!nullToAbsent || deletedAt != null) {
@@ -1541,6 +1581,12 @@ class WorkoutSet extends DataClass implements Insertable<WorkoutSet> {
       groupId: groupId == null && nullToAbsent
           ? const Value.absent()
           : Value(groupId),
+      avgHeartRate: avgHeartRate == null && nullToAbsent
+          ? const Value.absent()
+          : Value(avgHeartRate),
+      peakHeartRate: peakHeartRate == null && nullToAbsent
+          ? const Value.absent()
+          : Value(peakHeartRate),
       updatedAt: Value(updatedAt),
       deletedAt: deletedAt == null && nullToAbsent
           ? const Value.absent()
@@ -1562,6 +1608,8 @@ class WorkoutSet extends DataClass implements Insertable<WorkoutSet> {
       timestamp: serializer.fromJson<int>(json['timestamp']),
       isWarmUp: serializer.fromJson<bool>(json['isWarmUp']),
       groupId: serializer.fromJson<String?>(json['groupId']),
+      avgHeartRate: serializer.fromJson<int?>(json['avgHeartRate']),
+      peakHeartRate: serializer.fromJson<int?>(json['peakHeartRate']),
       updatedAt: serializer.fromJson<int>(json['updatedAt']),
       deletedAt: serializer.fromJson<int?>(json['deletedAt']),
     );
@@ -1580,6 +1628,8 @@ class WorkoutSet extends DataClass implements Insertable<WorkoutSet> {
       'timestamp': serializer.toJson<int>(timestamp),
       'isWarmUp': serializer.toJson<bool>(isWarmUp),
       'groupId': serializer.toJson<String?>(groupId),
+      'avgHeartRate': serializer.toJson<int?>(avgHeartRate),
+      'peakHeartRate': serializer.toJson<int?>(peakHeartRate),
       'updatedAt': serializer.toJson<int>(updatedAt),
       'deletedAt': serializer.toJson<int?>(deletedAt),
     };
@@ -1596,6 +1646,8 @@ class WorkoutSet extends DataClass implements Insertable<WorkoutSet> {
           int? timestamp,
           bool? isWarmUp,
           Value<String?> groupId = const Value.absent(),
+          Value<int?> avgHeartRate = const Value.absent(),
+          Value<int?> peakHeartRate = const Value.absent(),
           int? updatedAt,
           Value<int?> deletedAt = const Value.absent()}) =>
       WorkoutSet(
@@ -1609,6 +1661,10 @@ class WorkoutSet extends DataClass implements Insertable<WorkoutSet> {
         timestamp: timestamp ?? this.timestamp,
         isWarmUp: isWarmUp ?? this.isWarmUp,
         groupId: groupId.present ? groupId.value : this.groupId,
+        avgHeartRate:
+            avgHeartRate.present ? avgHeartRate.value : this.avgHeartRate,
+        peakHeartRate:
+            peakHeartRate.present ? peakHeartRate.value : this.peakHeartRate,
         updatedAt: updatedAt ?? this.updatedAt,
         deletedAt: deletedAt.present ? deletedAt.value : this.deletedAt,
       );
@@ -1625,6 +1681,12 @@ class WorkoutSet extends DataClass implements Insertable<WorkoutSet> {
       timestamp: data.timestamp.present ? data.timestamp.value : this.timestamp,
       isWarmUp: data.isWarmUp.present ? data.isWarmUp.value : this.isWarmUp,
       groupId: data.groupId.present ? data.groupId.value : this.groupId,
+      avgHeartRate: data.avgHeartRate.present
+          ? data.avgHeartRate.value
+          : this.avgHeartRate,
+      peakHeartRate: data.peakHeartRate.present
+          ? data.peakHeartRate.value
+          : this.peakHeartRate,
       updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
       deletedAt: data.deletedAt.present ? data.deletedAt.value : this.deletedAt,
     );
@@ -1643,6 +1705,8 @@ class WorkoutSet extends DataClass implements Insertable<WorkoutSet> {
           ..write('timestamp: $timestamp, ')
           ..write('isWarmUp: $isWarmUp, ')
           ..write('groupId: $groupId, ')
+          ..write('avgHeartRate: $avgHeartRate, ')
+          ..write('peakHeartRate: $peakHeartRate, ')
           ..write('updatedAt: $updatedAt, ')
           ..write('deletedAt: $deletedAt')
           ..write(')'))
@@ -1650,8 +1714,21 @@ class WorkoutSet extends DataClass implements Insertable<WorkoutSet> {
   }
 
   @override
-  int get hashCode => Object.hash(id, workoutId, exerciseId, setOrder, weight,
-      reps, rpe, timestamp, isWarmUp, groupId, updatedAt, deletedAt);
+  int get hashCode => Object.hash(
+      id,
+      workoutId,
+      exerciseId,
+      setOrder,
+      weight,
+      reps,
+      rpe,
+      timestamp,
+      isWarmUp,
+      groupId,
+      avgHeartRate,
+      peakHeartRate,
+      updatedAt,
+      deletedAt);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -1666,6 +1743,8 @@ class WorkoutSet extends DataClass implements Insertable<WorkoutSet> {
           other.timestamp == this.timestamp &&
           other.isWarmUp == this.isWarmUp &&
           other.groupId == this.groupId &&
+          other.avgHeartRate == this.avgHeartRate &&
+          other.peakHeartRate == this.peakHeartRate &&
           other.updatedAt == this.updatedAt &&
           other.deletedAt == this.deletedAt);
 }
@@ -1681,6 +1760,8 @@ class WorkoutSetsCompanion extends UpdateCompanion<WorkoutSet> {
   final Value<int> timestamp;
   final Value<bool> isWarmUp;
   final Value<String?> groupId;
+  final Value<int?> avgHeartRate;
+  final Value<int?> peakHeartRate;
   final Value<int> updatedAt;
   final Value<int?> deletedAt;
   final Value<int> rowid;
@@ -1695,6 +1776,8 @@ class WorkoutSetsCompanion extends UpdateCompanion<WorkoutSet> {
     this.timestamp = const Value.absent(),
     this.isWarmUp = const Value.absent(),
     this.groupId = const Value.absent(),
+    this.avgHeartRate = const Value.absent(),
+    this.peakHeartRate = const Value.absent(),
     this.updatedAt = const Value.absent(),
     this.deletedAt = const Value.absent(),
     this.rowid = const Value.absent(),
@@ -1710,6 +1793,8 @@ class WorkoutSetsCompanion extends UpdateCompanion<WorkoutSet> {
     required int timestamp,
     this.isWarmUp = const Value.absent(),
     this.groupId = const Value.absent(),
+    this.avgHeartRate = const Value.absent(),
+    this.peakHeartRate = const Value.absent(),
     this.updatedAt = const Value.absent(),
     this.deletedAt = const Value.absent(),
     this.rowid = const Value.absent(),
@@ -1731,6 +1816,8 @@ class WorkoutSetsCompanion extends UpdateCompanion<WorkoutSet> {
     Expression<int>? timestamp,
     Expression<bool>? isWarmUp,
     Expression<String>? groupId,
+    Expression<int>? avgHeartRate,
+    Expression<int>? peakHeartRate,
     Expression<int>? updatedAt,
     Expression<int>? deletedAt,
     Expression<int>? rowid,
@@ -1746,6 +1833,8 @@ class WorkoutSetsCompanion extends UpdateCompanion<WorkoutSet> {
       if (timestamp != null) 'timestamp': timestamp,
       if (isWarmUp != null) 'is_warm_up': isWarmUp,
       if (groupId != null) 'group_id': groupId,
+      if (avgHeartRate != null) 'avg_heart_rate': avgHeartRate,
+      if (peakHeartRate != null) 'peak_heart_rate': peakHeartRate,
       if (updatedAt != null) 'updated_at': updatedAt,
       if (deletedAt != null) 'deleted_at': deletedAt,
       if (rowid != null) 'rowid': rowid,
@@ -1763,6 +1852,8 @@ class WorkoutSetsCompanion extends UpdateCompanion<WorkoutSet> {
       Value<int>? timestamp,
       Value<bool>? isWarmUp,
       Value<String?>? groupId,
+      Value<int?>? avgHeartRate,
+      Value<int?>? peakHeartRate,
       Value<int>? updatedAt,
       Value<int?>? deletedAt,
       Value<int>? rowid}) {
@@ -1777,6 +1868,8 @@ class WorkoutSetsCompanion extends UpdateCompanion<WorkoutSet> {
       timestamp: timestamp ?? this.timestamp,
       isWarmUp: isWarmUp ?? this.isWarmUp,
       groupId: groupId ?? this.groupId,
+      avgHeartRate: avgHeartRate ?? this.avgHeartRate,
+      peakHeartRate: peakHeartRate ?? this.peakHeartRate,
       updatedAt: updatedAt ?? this.updatedAt,
       deletedAt: deletedAt ?? this.deletedAt,
       rowid: rowid ?? this.rowid,
@@ -1816,6 +1909,12 @@ class WorkoutSetsCompanion extends UpdateCompanion<WorkoutSet> {
     if (groupId.present) {
       map['group_id'] = Variable<String>(groupId.value);
     }
+    if (avgHeartRate.present) {
+      map['avg_heart_rate'] = Variable<int>(avgHeartRate.value);
+    }
+    if (peakHeartRate.present) {
+      map['peak_heart_rate'] = Variable<int>(peakHeartRate.value);
+    }
     if (updatedAt.present) {
       map['updated_at'] = Variable<int>(updatedAt.value);
     }
@@ -1841,6 +1940,8 @@ class WorkoutSetsCompanion extends UpdateCompanion<WorkoutSet> {
           ..write('timestamp: $timestamp, ')
           ..write('isWarmUp: $isWarmUp, ')
           ..write('groupId: $groupId, ')
+          ..write('avgHeartRate: $avgHeartRate, ')
+          ..write('peakHeartRate: $peakHeartRate, ')
           ..write('updatedAt: $updatedAt, ')
           ..write('deletedAt: $deletedAt, ')
           ..write('rowid: $rowid')
@@ -5840,10 +5941,9 @@ final class $$ExercisesTableReferences
   $$ExercisesTableReferences(super.$_db, super.$_table, super.$_typedResult);
 
   static MultiTypedResultKey<$WorkoutSetsTable, List<WorkoutSet>>
-      _workoutSetsRefsTable(_$AppDatabase db) => MultiTypedResultKey.fromTable(
-          db.workoutSets,
-          aliasName:
-              $_aliasNameGenerator(db.exercises.id, db.workoutSets.exerciseId));
+      _workoutSetsRefsTable(_$AppDatabase db) =>
+          MultiTypedResultKey.fromTable(db.workoutSets,
+              aliasName: 'exercises__id__workout_sets__exercise_id');
 
   $$WorkoutSetsTableProcessedTableManager get workoutSetsRefs {
     final manager = $$WorkoutSetsTableTableManager($_db, $_db.workoutSets)
@@ -5857,8 +5957,7 @@ final class $$ExercisesTableReferences
   static MultiTypedResultKey<$CardioSessionsTable, List<CardioSession>>
       _cardioSessionsRefsTable(_$AppDatabase db) =>
           MultiTypedResultKey.fromTable(db.cardioSessions,
-              aliasName: $_aliasNameGenerator(
-                  db.exercises.id, db.cardioSessions.exerciseId));
+              aliasName: 'exercises__id__cardio_sessions__exercise_id');
 
   $$CardioSessionsTableProcessedTableManager get cardioSessionsRefs {
     final manager = $$CardioSessionsTableTableManager($_db, $_db.cardioSessions)
@@ -5872,8 +5971,7 @@ final class $$ExercisesTableReferences
   static MultiTypedResultKey<$PersonalRecordsTable, List<PersonalRecord>>
       _personalRecordsRefsTable(_$AppDatabase db) =>
           MultiTypedResultKey.fromTable(db.personalRecords,
-              aliasName: $_aliasNameGenerator(
-                  db.exercises.id, db.personalRecords.exerciseId));
+              aliasName: 'exercises__id__personal_records__exercise_id');
 
   $$PersonalRecordsTableProcessedTableManager get personalRecordsRefs {
     final manager = $$PersonalRecordsTableTableManager(
@@ -5889,8 +5987,7 @@ final class $$ExercisesTableReferences
   static MultiTypedResultKey<$TemplateExercisesTable, List<TemplateExercise>>
       _templateExercisesRefsTable(_$AppDatabase db) =>
           MultiTypedResultKey.fromTable(db.templateExercises,
-              aliasName: $_aliasNameGenerator(
-                  db.exercises.id, db.templateExercises.exerciseId));
+              aliasName: 'exercises__id__template_exercises__exercise_id');
 
   $$TemplateExercisesTableProcessedTableManager get templateExercisesRefs {
     final manager = $$TemplateExercisesTableTableManager(
@@ -6382,10 +6479,9 @@ final class $$WorkoutsTableReferences
   $$WorkoutsTableReferences(super.$_db, super.$_table, super.$_typedResult);
 
   static MultiTypedResultKey<$WorkoutSetsTable, List<WorkoutSet>>
-      _workoutSetsRefsTable(_$AppDatabase db) => MultiTypedResultKey.fromTable(
-          db.workoutSets,
-          aliasName:
-              $_aliasNameGenerator(db.workouts.id, db.workoutSets.workoutId));
+      _workoutSetsRefsTable(_$AppDatabase db) =>
+          MultiTypedResultKey.fromTable(db.workoutSets,
+              aliasName: 'workouts__id__workout_sets__workout_id');
 
   $$WorkoutSetsTableProcessedTableManager get workoutSetsRefs {
     final manager = $$WorkoutSetsTableTableManager($_db, $_db.workoutSets)
@@ -6399,8 +6495,7 @@ final class $$WorkoutsTableReferences
   static MultiTypedResultKey<$CardioSessionsTable, List<CardioSession>>
       _cardioSessionsRefsTable(_$AppDatabase db) =>
           MultiTypedResultKey.fromTable(db.cardioSessions,
-              aliasName: $_aliasNameGenerator(
-                  db.workouts.id, db.cardioSessions.workoutId));
+              aliasName: 'workouts__id__cardio_sessions__workout_id');
 
   $$CardioSessionsTableProcessedTableManager get cardioSessionsRefs {
     final manager = $$CardioSessionsTableTableManager($_db, $_db.cardioSessions)
@@ -6414,8 +6509,7 @@ final class $$WorkoutsTableReferences
   static MultiTypedResultKey<$StretchingSessionsTable, List<StretchingSession>>
       _stretchingSessionsRefsTable(_$AppDatabase db) =>
           MultiTypedResultKey.fromTable(db.stretchingSessions,
-              aliasName: $_aliasNameGenerator(
-                  db.workouts.id, db.stretchingSessions.workoutId));
+              aliasName: 'workouts__id__stretching_sessions__workout_id');
 
   $$StretchingSessionsTableProcessedTableManager get stretchingSessionsRefs {
     final manager = $$StretchingSessionsTableTableManager(
@@ -6805,6 +6899,8 @@ typedef $$WorkoutSetsTableCreateCompanionBuilder = WorkoutSetsCompanion
   required int timestamp,
   Value<bool> isWarmUp,
   Value<String?> groupId,
+  Value<int?> avgHeartRate,
+  Value<int?> peakHeartRate,
   Value<int> updatedAt,
   Value<int?> deletedAt,
   Value<int> rowid,
@@ -6821,6 +6917,8 @@ typedef $$WorkoutSetsTableUpdateCompanionBuilder = WorkoutSetsCompanion
   Value<int> timestamp,
   Value<bool> isWarmUp,
   Value<String?> groupId,
+  Value<int?> avgHeartRate,
+  Value<int?> peakHeartRate,
   Value<int> updatedAt,
   Value<int?> deletedAt,
   Value<int> rowid,
@@ -6831,8 +6929,7 @@ final class $$WorkoutSetsTableReferences
   $$WorkoutSetsTableReferences(super.$_db, super.$_table, super.$_typedResult);
 
   static $WorkoutsTable _workoutIdTable(_$AppDatabase db) =>
-      db.workouts.createAlias(
-          $_aliasNameGenerator(db.workoutSets.workoutId, db.workouts.id));
+      db.workouts.createAlias('workout_sets__workout_id__workouts__id');
 
   $$WorkoutsTableProcessedTableManager get workoutId {
     final $_column = $_itemColumn<String>('workout_id')!;
@@ -6846,8 +6943,7 @@ final class $$WorkoutSetsTableReferences
   }
 
   static $ExercisesTable _exerciseIdTable(_$AppDatabase db) =>
-      db.exercises.createAlias(
-          $_aliasNameGenerator(db.workoutSets.exerciseId, db.exercises.id));
+      db.exercises.createAlias('workout_sets__exercise_id__exercises__id');
 
   $$ExercisesTableProcessedTableManager get exerciseId {
     final $_column = $_itemColumn<String>('exercise_id')!;
@@ -6863,8 +6959,7 @@ final class $$WorkoutSetsTableReferences
   static MultiTypedResultKey<$PersonalRecordsTable, List<PersonalRecord>>
       _personalRecordsRefsTable(_$AppDatabase db) =>
           MultiTypedResultKey.fromTable(db.personalRecords,
-              aliasName: $_aliasNameGenerator(
-                  db.workoutSets.id, db.personalRecords.workoutSetId));
+              aliasName: 'workout_sets__id__personal_records__workout_set_id');
 
   $$PersonalRecordsTableProcessedTableManager get personalRecordsRefs {
     final manager =
@@ -6910,6 +7005,12 @@ class $$WorkoutSetsTableFilterComposer
 
   ColumnFilters<String> get groupId => $composableBuilder(
       column: $table.groupId, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<int> get avgHeartRate => $composableBuilder(
+      column: $table.avgHeartRate, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<int> get peakHeartRate => $composableBuilder(
+      column: $table.peakHeartRate, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<int> get updatedAt => $composableBuilder(
       column: $table.updatedAt, builder: (column) => ColumnFilters(column));
@@ -7012,6 +7113,14 @@ class $$WorkoutSetsTableOrderingComposer
   ColumnOrderings<String> get groupId => $composableBuilder(
       column: $table.groupId, builder: (column) => ColumnOrderings(column));
 
+  ColumnOrderings<int> get avgHeartRate => $composableBuilder(
+      column: $table.avgHeartRate,
+      builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<int> get peakHeartRate => $composableBuilder(
+      column: $table.peakHeartRate,
+      builder: (column) => ColumnOrderings(column));
+
   ColumnOrderings<int> get updatedAt => $composableBuilder(
       column: $table.updatedAt, builder: (column) => ColumnOrderings(column));
 
@@ -7091,6 +7200,12 @@ class $$WorkoutSetsTableAnnotationComposer
 
   GeneratedColumn<String> get groupId =>
       $composableBuilder(column: $table.groupId, builder: (column) => column);
+
+  GeneratedColumn<int> get avgHeartRate => $composableBuilder(
+      column: $table.avgHeartRate, builder: (column) => column);
+
+  GeneratedColumn<int> get peakHeartRate => $composableBuilder(
+      column: $table.peakHeartRate, builder: (column) => column);
 
   GeneratedColumn<int> get updatedAt =>
       $composableBuilder(column: $table.updatedAt, builder: (column) => column);
@@ -7194,6 +7309,8 @@ class $$WorkoutSetsTableTableManager extends RootTableManager<
             Value<int> timestamp = const Value.absent(),
             Value<bool> isWarmUp = const Value.absent(),
             Value<String?> groupId = const Value.absent(),
+            Value<int?> avgHeartRate = const Value.absent(),
+            Value<int?> peakHeartRate = const Value.absent(),
             Value<int> updatedAt = const Value.absent(),
             Value<int?> deletedAt = const Value.absent(),
             Value<int> rowid = const Value.absent(),
@@ -7209,6 +7326,8 @@ class $$WorkoutSetsTableTableManager extends RootTableManager<
             timestamp: timestamp,
             isWarmUp: isWarmUp,
             groupId: groupId,
+            avgHeartRate: avgHeartRate,
+            peakHeartRate: peakHeartRate,
             updatedAt: updatedAt,
             deletedAt: deletedAt,
             rowid: rowid,
@@ -7224,6 +7343,8 @@ class $$WorkoutSetsTableTableManager extends RootTableManager<
             required int timestamp,
             Value<bool> isWarmUp = const Value.absent(),
             Value<String?> groupId = const Value.absent(),
+            Value<int?> avgHeartRate = const Value.absent(),
+            Value<int?> peakHeartRate = const Value.absent(),
             Value<int> updatedAt = const Value.absent(),
             Value<int?> deletedAt = const Value.absent(),
             Value<int> rowid = const Value.absent(),
@@ -7239,6 +7360,8 @@ class $$WorkoutSetsTableTableManager extends RootTableManager<
             timestamp: timestamp,
             isWarmUp: isWarmUp,
             groupId: groupId,
+            avgHeartRate: avgHeartRate,
+            peakHeartRate: peakHeartRate,
             updatedAt: updatedAt,
             deletedAt: deletedAt,
             rowid: rowid,
@@ -7362,8 +7485,7 @@ final class $$CardioSessionsTableReferences
       super.$_db, super.$_table, super.$_typedResult);
 
   static $WorkoutsTable _workoutIdTable(_$AppDatabase db) =>
-      db.workouts.createAlias(
-          $_aliasNameGenerator(db.cardioSessions.workoutId, db.workouts.id));
+      db.workouts.createAlias('cardio_sessions__workout_id__workouts__id');
 
   $$WorkoutsTableProcessedTableManager get workoutId {
     final $_column = $_itemColumn<String>('workout_id')!;
@@ -7377,8 +7499,7 @@ final class $$CardioSessionsTableReferences
   }
 
   static $ExercisesTable _exerciseIdTable(_$AppDatabase db) =>
-      db.exercises.createAlias(
-          $_aliasNameGenerator(db.cardioSessions.exerciseId, db.exercises.id));
+      db.exercises.createAlias('cardio_sessions__exercise_id__exercises__id');
 
   $$ExercisesTableProcessedTableManager get exerciseId {
     final $_column = $_itemColumn<String>('exercise_id')!;
@@ -7778,8 +7899,7 @@ final class $$PersonalRecordsTableReferences extends BaseReferences<
       super.$_db, super.$_table, super.$_typedResult);
 
   static $ExercisesTable _exerciseIdTable(_$AppDatabase db) =>
-      db.exercises.createAlias(
-          $_aliasNameGenerator(db.personalRecords.exerciseId, db.exercises.id));
+      db.exercises.createAlias('personal_records__exercise_id__exercises__id');
 
   $$ExercisesTableProcessedTableManager get exerciseId {
     final $_column = $_itemColumn<String>('exercise_id')!;
@@ -7793,8 +7913,8 @@ final class $$PersonalRecordsTableReferences extends BaseReferences<
   }
 
   static $WorkoutSetsTable _workoutSetIdTable(_$AppDatabase db) =>
-      db.workoutSets.createAlias($_aliasNameGenerator(
-          db.personalRecords.workoutSetId, db.workoutSets.id));
+      db.workoutSets
+          .createAlias('personal_records__workout_set_id__workout_sets__id');
 
   $$WorkoutSetsTableProcessedTableManager? get workoutSetId {
     final $_column = $_itemColumn<String>('workout_set_id');
@@ -8174,8 +8294,8 @@ final class $$WorkoutTemplatesTableReferences extends BaseReferences<
   static MultiTypedResultKey<$TemplateExercisesTable, List<TemplateExercise>>
       _templateExercisesRefsTable(_$AppDatabase db) =>
           MultiTypedResultKey.fromTable(db.templateExercises,
-              aliasName: $_aliasNameGenerator(
-                  db.workoutTemplates.id, db.templateExercises.templateId));
+              aliasName:
+                  'workout_templates__id__template_exercises__template_id');
 
   $$TemplateExercisesTableProcessedTableManager get templateExercisesRefs {
     final manager = $$TemplateExercisesTableTableManager(
@@ -8441,9 +8561,9 @@ final class $$TemplateExercisesTableReferences extends BaseReferences<
   $$TemplateExercisesTableReferences(
       super.$_db, super.$_table, super.$_typedResult);
 
-  static $WorkoutTemplatesTable _templateIdTable(_$AppDatabase db) =>
-      db.workoutTemplates.createAlias($_aliasNameGenerator(
-          db.templateExercises.templateId, db.workoutTemplates.id));
+  static $WorkoutTemplatesTable _templateIdTable(_$AppDatabase db) => db
+      .workoutTemplates
+      .createAlias('template_exercises__template_id__workout_templates__id');
 
   $$WorkoutTemplatesTableProcessedTableManager get templateId {
     final $_column = $_itemColumn<String>('template_id')!;
@@ -8457,9 +8577,8 @@ final class $$TemplateExercisesTableReferences extends BaseReferences<
         manager.$state.copyWith(prefetchedData: [item]));
   }
 
-  static $ExercisesTable _exerciseIdTable(_$AppDatabase db) =>
-      db.exercises.createAlias($_aliasNameGenerator(
-          db.templateExercises.exerciseId, db.exercises.id));
+  static $ExercisesTable _exerciseIdTable(_$AppDatabase db) => db.exercises
+      .createAlias('template_exercises__exercise_id__exercises__id');
 
   $$ExercisesTableProcessedTableManager get exerciseId {
     final $_column = $_itemColumn<String>('exercise_id')!;
@@ -9504,8 +9623,7 @@ final class $$StretchingSessionsTableReferences extends BaseReferences<
       super.$_db, super.$_table, super.$_typedResult);
 
   static $WorkoutsTable _workoutIdTable(_$AppDatabase db) =>
-      db.workouts.createAlias($_aliasNameGenerator(
-          db.stretchingSessions.workoutId, db.workouts.id));
+      db.workouts.createAlias('stretching_sessions__workout_id__workouts__id');
 
   $$WorkoutsTableProcessedTableManager get workoutId {
     final $_column = $_itemColumn<String>('workout_id')!;

--- a/lib/core/database/tables/workout_sets_table.dart
+++ b/lib/core/database/tables/workout_sets_table.dart
@@ -18,6 +18,8 @@ class WorkoutSets extends Table {
   IntColumn get timestamp => integer()();
   BoolColumn get isWarmUp => boolean().withDefault(const Constant(false))();
   TextColumn get groupId => text().nullable()();
+  IntColumn get avgHeartRate => integer().nullable()();
+  IntColumn get peakHeartRate => integer().nullable()();
   IntColumn get updatedAt => integer().withDefault(const Constant(0))();
   IntColumn get deletedAt => integer().nullable()();
 

--- a/lib/core/heart_rate/hr_session_recorder.dart
+++ b/lib/core/heart_rate/hr_session_recorder.dart
@@ -1,0 +1,89 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../providers.dart';
+
+/// A single heart-rate reading with the absolute time it arrived, so it can
+/// be correlated with other absolutely-timestamped events (e.g. logged sets).
+class HrSample {
+  final int bpm;
+  final DateTime timestamp;
+
+  const HrSample({required this.bpm, required this.timestamp});
+}
+
+/// Average and peak BPM over a time window.
+class HrWindowSummary {
+  final int avgBpm;
+  final int peakBpm;
+
+  const HrWindowSummary({required this.avgBpm, required this.peakBpm});
+}
+
+/// Summarises the samples that fall inside `(from, to]`.
+///
+/// `from` is exclusive so a sample stamped exactly at the previous window's
+/// end is not counted twice. Returns null when the window holds no samples.
+HrWindowSummary? summariseSamples(
+  List<HrSample> samples, {
+  required DateTime from,
+  required DateTime to,
+}) {
+  final inWindow = samples
+      .where((s) => s.timestamp.isAfter(from) && !s.timestamp.isAfter(to))
+      .toList();
+  if (inWindow.isEmpty) return null;
+
+  var sum = 0;
+  var peak = 0;
+  for (final s in inWindow) {
+    sum += s.bpm;
+    if (s.bpm > peak) peak = s.bpm;
+  }
+  return HrWindowSummary(
+    avgBpm: (sum / inWindow.length).round(),
+    peakBpm: peak,
+  );
+}
+
+/// Buffers timestamped heart-rate samples from the shared [HeartRateService]
+/// for as long as a monitor is connected, regardless of which screen started
+/// the connection. Consumers ask for a window summary via [summarise].
+class HrSessionRecorder extends Notifier<List<HrSample>> {
+  StreamSubscription<int>? _subscription;
+
+  /// Samples older than this are pruned as new ones arrive, keeping the
+  /// buffer bounded across very long sessions.
+  static const _retention = Duration(hours: 6);
+
+  @override
+  List<HrSample> build() {
+    final service = ref.watch(heartRateServiceProvider);
+    _subscription?.cancel();
+    _subscription = service.heartRateStream.listen(_onReading);
+    ref.onDispose(() => _subscription?.cancel());
+    return const [];
+  }
+
+  void _onReading(int bpm) {
+    if (bpm <= 0) return;
+    final now = DateTime.now().toUtc();
+    final cutoff = now.subtract(_retention);
+    state = [
+      ...state.where((s) => s.timestamp.isAfter(cutoff)),
+      HrSample(bpm: bpm, timestamp: now),
+    ];
+  }
+
+  HrWindowSummary? summarise({required DateTime from, required DateTime to}) {
+    return summariseSamples(state, from: from, to: to);
+  }
+
+  void clear() {
+    state = const [];
+  }
+}
+
+final hrSessionRecorderProvider =
+    NotifierProvider<HrSessionRecorder, List<HrSample>>(HrSessionRecorder.new);

--- a/lib/core/widgets/horizontal_swipe_navigator.dart
+++ b/lib/core/widgets/horizontal_swipe_navigator.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+/// Detects horizontal fling gestures over [child] and invokes the matching
+/// callback, so two screens can offer a swipe shortcut to one another
+/// without a PageView.
+///
+/// Vertical scrolling inside [child] is unaffected: only the horizontal
+/// drag gesture is claimed, and a fling must exceed [velocityThreshold]
+/// (logical pixels per second) to count as a swipe.
+class HorizontalSwipeNavigator extends StatelessWidget {
+  const HorizontalSwipeNavigator({
+    super.key,
+    required this.child,
+    this.onSwipeLeft,
+    this.onSwipeRight,
+    this.velocityThreshold = 400,
+  });
+
+  final Widget child;
+
+  /// Called on a leftward fling (finger moves right to left).
+  final VoidCallback? onSwipeLeft;
+
+  /// Called on a rightward fling (finger moves left to right).
+  final VoidCallback? onSwipeRight;
+
+  final double velocityThreshold;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      behavior: HitTestBehavior.translucent,
+      onHorizontalDragEnd: (details) {
+        final velocity = details.primaryVelocity ?? 0;
+        if (velocity <= -velocityThreshold) {
+          onSwipeLeft?.call();
+        } else if (velocity >= velocityThreshold) {
+          onSwipeRight?.call();
+        }
+      },
+      child: child,
+    );
+  }
+}

--- a/lib/features/heart_rate/presentation/screens/heart_rate_panel_screen.dart
+++ b/lib/features/heart_rate/presentation/screens/heart_rate_panel_screen.dart
@@ -2,11 +2,13 @@ import 'package:audioplayers/audioplayers.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:rep_foundry/l10n/generated/app_localizations.dart';
 
 import '../../../../core/extensions/datetime_extensions.dart';
 import '../../../../core/providers.dart';
+import '../../../../core/widgets/horizontal_swipe_navigator.dart';
 import '../../../../core/widgets/kinetic.dart';
 import '../../../../core/widgets/sparkline_widget.dart';
 import '../../../cardio/presentation/controllers/cardio_tracking_controller.dart';
@@ -160,113 +162,117 @@ class _HeartRatePanelScreenState extends ConsumerState<HeartRatePanelScreen> {
           ),
         ],
       ),
-      body: ListView(
-        padding: const EdgeInsets.fromLTRB(22, 8, 22, 96),
-        children: [
-          // Kinetic app header.
-          const KineticAppHeader(),
+      // Swipe right to jump back to the active workout (issue #71).
+      body: HorizontalSwipeNavigator(
+        onSwipeRight: () => context.go('/workout'),
+        child: ListView(
+          padding: const EdgeInsets.fromLTRB(22, 8, 22, 96),
+          children: [
+            // Kinetic app header.
+            const KineticAppHeader(),
 
-          // Caution badge.
-          if (profile.isCautionMode) ...[
-            CautionBadge(profile: profile),
-            const SizedBox(height: 12),
-          ],
+            // Caution badge.
+            if (profile.isCautionMode) ...[
+              CautionBadge(profile: profile),
+              const SizedBox(height: 12),
+            ],
 
-          // ── Hero BPM section ──────────────────────────────────────
-          _HeroBpmSection(
-            panelState: panelState,
-            activeZone: activeZone,
-            peakZoneColor: peakZoneColor,
-          ),
-          const SizedBox(height: 16),
-
-          // Controls.
-          _buildControls(context, panelState, controller),
-          const SizedBox(height: 24),
-
-          // ── EKG trace sparkline ───────────────────────────────────
-          if (panelState.readings.isNotEmpty) ...[
-            _EkgTrace(
-              readings: panelState.readings,
+            // ── Hero BPM section ──────────────────────────────────────
+            _HeroBpmSection(
+              panelState: panelState,
+              activeZone: activeZone,
               peakZoneColor: peakZoneColor,
             ),
-            const SizedBox(height: 20),
-          ],
+            const SizedBox(height: 16),
 
-          // ── Vitals bento grid ─────────────────────────────────────
-          if (panelState.readings.isNotEmpty) ...[
-            _MetricBentoGrid(
-              avgBpm: bpmStats.avg,
-              maxBpm: bpmStats.max,
-              minBpm: bpmStats.min,
-              readingCount: panelState.readings.length,
-              profile: profile,
-            ),
+            // Controls.
+            _buildControls(context, panelState, controller),
             const SizedBox(height: 24),
-          ],
 
-          // ── Workout Intensity Zones ───────────────────────────────
-          if (zoneConfig != null && panelState.readings.isNotEmpty) ...[
-            _ZonesSection(
-              panelState: panelState,
-              zoneConfig: zoneConfig,
-            ),
-            const SizedBox(height: 24),
-          ],
-
-          // ── HR Trend card with SparklineWidget ────────────────────
-          if (panelState.readings.isNotEmpty) ...[
-            _TrendChartSection(
-              panelState: panelState,
-              zoneConfig: zoneConfig,
-              chartWindow: chartWindow,
-              showZoneBands: showZoneBands,
-              peakZoneColor: peakZoneColor,
-              onWindowChanged: (v) =>
-                  ref.read(chartWindowProvider.notifier).setWindow(v),
-            ),
-            const SizedBox(height: 16),
-          ] else ...[
-            HeartRateChart(
-              readings: panelState.readings,
-              zoneConfig: zoneConfig,
-              showZoneBands: showZoneBands,
-            ),
-            const SizedBox(height: 16),
-          ],
-
-          // Symptom report button during active monitoring.
-          if (panelState.isMonitoring) ...[
-            SymptomReportButton(
-              onStopRequested: controller.stopMonitoring,
-              analytics: ref.read(hrAnalyticsReporterProvider),
-            ),
-            const SizedBox(height: 16),
-          ],
-
-          // ── Full Weekly Heart Report row (.srow style) ────────────
-          if (panelState.readings.isNotEmpty) ...[
-            _WeeklyReportRow(peakZoneColor: peakZoneColor),
-            const SizedBox(height: 16),
-          ],
-
-          // Zone legend / no-profile prompt.
-          if (zoneConfig != null) ...[
-            HeartRateZoneLegend(
-              config: zoneConfig,
-              currentBpm: panelState.currentHeartRate,
-            ),
-          ] else ...[
-            Card(
-              child: ListTile(
-                leading: const Icon(Icons.info_outline),
-                title: Text(s.setAgeInSettings),
-                subtitle: Text(s.setAgeInSettingsSubtitle),
-                onTap: () => showHealthProfileOnboarding(context),
+            // ── EKG trace sparkline ───────────────────────────────────
+            if (panelState.readings.isNotEmpty) ...[
+              _EkgTrace(
+                readings: panelState.readings,
+                peakZoneColor: peakZoneColor,
               ),
-            ),
+              const SizedBox(height: 20),
+            ],
+
+            // ── Vitals bento grid ─────────────────────────────────────
+            if (panelState.readings.isNotEmpty) ...[
+              _MetricBentoGrid(
+                avgBpm: bpmStats.avg,
+                maxBpm: bpmStats.max,
+                minBpm: bpmStats.min,
+                readingCount: panelState.readings.length,
+                profile: profile,
+              ),
+              const SizedBox(height: 24),
+            ],
+
+            // ── Workout Intensity Zones ───────────────────────────────
+            if (zoneConfig != null && panelState.readings.isNotEmpty) ...[
+              _ZonesSection(
+                panelState: panelState,
+                zoneConfig: zoneConfig,
+              ),
+              const SizedBox(height: 24),
+            ],
+
+            // ── HR Trend card with SparklineWidget ────────────────────
+            if (panelState.readings.isNotEmpty) ...[
+              _TrendChartSection(
+                panelState: panelState,
+                zoneConfig: zoneConfig,
+                chartWindow: chartWindow,
+                showZoneBands: showZoneBands,
+                peakZoneColor: peakZoneColor,
+                onWindowChanged: (v) =>
+                    ref.read(chartWindowProvider.notifier).setWindow(v),
+              ),
+              const SizedBox(height: 16),
+            ] else ...[
+              HeartRateChart(
+                readings: panelState.readings,
+                zoneConfig: zoneConfig,
+                showZoneBands: showZoneBands,
+              ),
+              const SizedBox(height: 16),
+            ],
+
+            // Symptom report button during active monitoring.
+            if (panelState.isMonitoring) ...[
+              SymptomReportButton(
+                onStopRequested: controller.stopMonitoring,
+                analytics: ref.read(hrAnalyticsReporterProvider),
+              ),
+              const SizedBox(height: 16),
+            ],
+
+            // ── Full Weekly Heart Report row (.srow style) ────────────
+            if (panelState.readings.isNotEmpty) ...[
+              _WeeklyReportRow(peakZoneColor: peakZoneColor),
+              const SizedBox(height: 16),
+            ],
+
+            // Zone legend / no-profile prompt.
+            if (zoneConfig != null) ...[
+              HeartRateZoneLegend(
+                config: zoneConfig,
+                currentBpm: panelState.currentHeartRate,
+              ),
+            ] else ...[
+              Card(
+                child: ListTile(
+                  leading: const Icon(Icons.info_outline),
+                  title: Text(s.setAgeInSettings),
+                  subtitle: Text(s.setAgeInSettingsSubtitle),
+                  onTap: () => showHealthProfileOnboarding(context),
+                ),
+              ),
+            ],
           ],
-        ],
+        ),
       ),
     );
   }

--- a/lib/features/history/presentation/screens/workout_detail_screen.dart
+++ b/lib/features/history/presentation/screens/workout_detail_screen.dart
@@ -437,40 +437,53 @@ class _ExerciseSetsCard extends ConsumerWidget {
               ],
             ),
             const SizedBox(height: 8),
-            Table(
-              columnWidths: const {
-                0: FixedColumnWidth(32),
-                1: FlexColumnWidth(),
-                2: FlexColumnWidth(),
-                3: FlexColumnWidth(),
-              },
-              children: [
-                TableRow(
-                  children: [
-                    _tableHeader(context, s.tableHeaderHash),
-                    _tableHeader(context, s.tableHeaderWeight),
-                    _tableHeader(context, s.tableHeaderReps),
-                    _tableHeader(context, s.tableHeaderE1rm),
-                  ],
-                ),
-                for (int i = 0; i < sets.length; i++)
+            Builder(builder: (context) {
+              // Only show the HR column when at least one set captured a
+              // heart rate summary.
+              final hasHr = sets.any((set) => set.avgHeartRate != null);
+              return Table(
+                columnWidths: {
+                  0: const FixedColumnWidth(32),
+                  for (var c = 1; c < (hasHr ? 5 : 4); c++)
+                    c: const FlexColumnWidth(),
+                },
+                children: [
                   TableRow(
                     children: [
-                      _tableCell(context, '${i + 1}', isHeader: true),
-                      _tableCell(context,
-                          '${unit.formatFromKg(sets[i].weight)} ${unit.label(s)}'),
-                      _tableCell(context, '${sets[i].reps}'),
-                      _tableCell(
-                        context,
-                        unit
-                            .fromKg(sets[i].estimatedOneRepMax)
-                            .toStringAsFixed(1),
-                        color: Theme.of(context).colorScheme.primary,
-                      ),
+                      _tableHeader(context, s.tableHeaderHash),
+                      _tableHeader(context, s.tableHeaderWeight),
+                      _tableHeader(context, s.tableHeaderReps),
+                      _tableHeader(context, s.tableHeaderE1rm),
+                      if (hasHr) _tableHeader(context, s.tableHeaderHr),
                     ],
                   ),
-              ],
-            ),
+                  for (int i = 0; i < sets.length; i++)
+                    TableRow(
+                      children: [
+                        _tableCell(context, '${i + 1}', isHeader: true),
+                        _tableCell(context,
+                            '${unit.formatFromKg(sets[i].weight)} ${unit.label(s)}'),
+                        _tableCell(context, '${sets[i].reps}'),
+                        _tableCell(
+                          context,
+                          unit
+                              .fromKg(sets[i].estimatedOneRepMax)
+                              .toStringAsFixed(1),
+                          color: Theme.of(context).colorScheme.primary,
+                        ),
+                        if (hasHr)
+                          _tableCell(
+                            context,
+                            sets[i].avgHeartRate == null
+                                ? '—'
+                                : '${sets[i].avgHeartRate}'
+                                    '${sets[i].peakHeartRate != null ? '/${sets[i].peakHeartRate}' : ''}',
+                          ),
+                      ],
+                    ),
+                ],
+              );
+            }),
           ],
         ),
       ),

--- a/lib/features/sync/data/sync_snapshot_serialiser.dart
+++ b/lib/features/sync/data/sync_snapshot_serialiser.dart
@@ -230,6 +230,8 @@ class SyncSnapshotSerialiser {
             timestamp: dateTimeToEpochMs(s.timestamp),
             isWarmUp: Value(s.isWarmUp),
             groupId: Value(s.groupId),
+            avgHeartRate: Value(s.avgHeartRate),
+            peakHeartRate: Value(s.peakHeartRate),
             updatedAt: Value(dateTimeToEpochMs(s.updatedAt)),
             deletedAt: Value(nullableDateTimeToEpochMs(s.deletedAt)),
           ),
@@ -436,6 +438,8 @@ class SyncSnapshotSerialiser {
         timestamp: dateTimeFromEpochMs(row.timestamp),
         isWarmUp: row.isWarmUp,
         groupId: row.groupId,
+        avgHeartRate: row.avgHeartRate,
+        peakHeartRate: row.peakHeartRate,
         updatedAt: dateTimeFromEpochMs(row.updatedAt),
         deletedAt: nullableDateTimeFromEpochMs(row.deletedAt),
       );
@@ -564,6 +568,8 @@ class SyncSnapshotSerialiser {
         'timestamp': s.timestamp.toIso8601String(),
         'isWarmUp': s.isWarmUp,
         'groupId': s.groupId,
+        'avgHeartRate': s.avgHeartRate,
+        'peakHeartRate': s.peakHeartRate,
         'updatedAt': s.updatedAt.toIso8601String(),
         'deletedAt': s.deletedAt?.toIso8601String(),
       };
@@ -711,6 +717,8 @@ class SyncSnapshotSerialiser {
         timestamp: DateTime.parse(m['timestamp'] as String),
         isWarmUp: m['isWarmUp'] as bool? ?? false,
         groupId: m['groupId'] as String?,
+        avgHeartRate: m['avgHeartRate'] as int?,
+        peakHeartRate: m['peakHeartRate'] as int?,
         updatedAt: DateTime.parse(m['updatedAt'] as String),
         deletedAt: _parseNullableDate(m['deletedAt']),
       );

--- a/lib/features/workout/application/log_set_use_case.dart
+++ b/lib/features/workout/application/log_set_use_case.dart
@@ -18,6 +18,8 @@ class LogSetInput {
   final int reps;
   final double? rpe;
   final bool isWarmUp;
+  final int? avgHeartRate;
+  final int? peakHeartRate;
 
   const LogSetInput({
     required this.workoutId,
@@ -27,6 +29,8 @@ class LogSetInput {
     required this.reps,
     this.rpe,
     this.isWarmUp = false,
+    this.avgHeartRate,
+    this.peakHeartRate,
   });
 }
 
@@ -59,6 +63,8 @@ class LogSetUseCase {
       reps: input.reps,
       rpe: input.rpe,
       isWarmUp: input.isWarmUp,
+      avgHeartRate: input.avgHeartRate,
+      peakHeartRate: input.peakHeartRate,
     );
 
     final savedSet = await _workoutRepository.addSet(set);

--- a/lib/features/workout/data/drift_workout_repository.dart
+++ b/lib/features/workout/data/drift_workout_repository.dart
@@ -112,6 +112,8 @@ class DriftWorkoutRepository implements WorkoutRepository {
             timestamp: dateTimeToEpochMs(set.timestamp),
             isWarmUp: Value(set.isWarmUp),
             groupId: Value(set.groupId),
+            avgHeartRate: Value(set.avgHeartRate),
+            peakHeartRate: Value(set.peakHeartRate),
             updatedAt: Value(dateTimeToEpochMs(set.updatedAt)),
           ),
         );
@@ -180,6 +182,8 @@ class DriftWorkoutRepository implements WorkoutRepository {
         timestamp: Value(dateTimeToEpochMs(set.timestamp)),
         isWarmUp: Value(set.isWarmUp),
         groupId: Value(set.groupId),
+        avgHeartRate: Value(set.avgHeartRate),
+        peakHeartRate: Value(set.peakHeartRate),
         updatedAt: Value(dateTimeToEpochMs(set.updatedAt)),
         deletedAt: Value(nullableDateTimeToEpochMs(set.deletedAt)),
       ),
@@ -274,6 +278,8 @@ class DriftWorkoutRepository implements WorkoutRepository {
       timestamp: dateTimeFromEpochMs(row.timestamp),
       isWarmUp: row.isWarmUp,
       groupId: row.groupId,
+      avgHeartRate: row.avgHeartRate,
+      peakHeartRate: row.peakHeartRate,
       updatedAt: dateTimeFromEpochMs(row.updatedAt),
       deletedAt: nullableDateTimeFromEpochMs(row.deletedAt),
     );

--- a/lib/features/workout/domain/models/workout_set.dart
+++ b/lib/features/workout/domain/models/workout_set.dart
@@ -11,6 +11,13 @@ class WorkoutSet {
   final DateTime timestamp;
   final bool isWarmUp;
   final String? groupId;
+
+  /// Average BPM over the effort-and-rest window leading up to this set,
+  /// captured automatically when a heart-rate monitor was connected.
+  final int? avgHeartRate;
+
+  /// Peak BPM over the same window.
+  final int? peakHeartRate;
   final DateTime updatedAt;
   final DateTime? deletedAt;
 
@@ -25,6 +32,8 @@ class WorkoutSet {
     required this.timestamp,
     this.isWarmUp = false,
     this.groupId,
+    this.avgHeartRate,
+    this.peakHeartRate,
     required this.updatedAt,
     this.deletedAt,
   });
@@ -51,6 +60,8 @@ class WorkoutSet {
     bool? isWarmUp,
     String? groupId,
     bool clearGroupId = false,
+    int? avgHeartRate,
+    int? peakHeartRate,
     DateTime? updatedAt,
     DateTime? deletedAt,
   }) {
@@ -65,6 +76,8 @@ class WorkoutSet {
       timestamp: timestamp ?? this.timestamp,
       isWarmUp: isWarmUp ?? this.isWarmUp,
       groupId: clearGroupId ? null : (groupId ?? this.groupId),
+      avgHeartRate: avgHeartRate ?? this.avgHeartRate,
+      peakHeartRate: peakHeartRate ?? this.peakHeartRate,
       updatedAt: updatedAt ?? this.updatedAt,
       deletedAt: deletedAt ?? this.deletedAt,
     );
@@ -79,6 +92,8 @@ class WorkoutSet {
     double? rpe,
     bool isWarmUp = false,
     String? groupId,
+    int? avgHeartRate,
+    int? peakHeartRate,
   }) {
     final now = DateTime.now().toUtc();
     return WorkoutSet(
@@ -92,6 +107,8 @@ class WorkoutSet {
       timestamp: now,
       isWarmUp: isWarmUp,
       groupId: groupId,
+      avgHeartRate: avgHeartRate,
+      peakHeartRate: peakHeartRate,
       updatedAt: now,
     );
   }

--- a/lib/features/workout/presentation/controllers/active_workout_controller.dart
+++ b/lib/features/workout/presentation/controllers/active_workout_controller.dart
@@ -12,6 +12,7 @@ import '../../../history/domain/models/personal_record.dart';
 import '../../../programmes/domain/models/programme.dart';
 import '../../../templates/domain/models/workout_template.dart';
 import '../models/ghost_set.dart';
+import '../../../../core/heart_rate/hr_session_recorder.dart';
 import '../../../../core/providers.dart';
 import '../../../sync/presentation/providers/sync_settings_provider.dart';
 
@@ -472,6 +473,7 @@ class ActiveWorkoutController extends Notifier<ActiveWorkoutState> {
 
     try {
       final existingSets = state.setsByExercise[exerciseId] ?? [];
+      final hrSummary = _heartRateSummaryForNewSet(workout);
       final useCase = ref.read(logSetUseCaseProvider);
       final result = await useCase.execute(
         LogSetInput(
@@ -486,6 +488,8 @@ class ActiveWorkoutController extends Notifier<ActiveWorkoutState> {
           reps: reps,
           rpe: rpe,
           isWarmUp: isWarmUp,
+          avgHeartRate: hrSummary?.avgBpm,
+          peakHeartRate: hrSummary?.peakBpm,
         ),
       );
 
@@ -514,6 +518,29 @@ class ActiveWorkoutController extends Notifier<ActiveWorkoutState> {
       state = state.copyWith(
         error: e is LogSetException ? e.message : e.toString(),
       );
+    }
+  }
+
+  /// Best-effort heart-rate summary for a set being logged now: the window
+  /// runs from the previously logged set (or the workout start), capped at
+  /// five minutes, up to this moment. Null when no monitor readings exist.
+  HrWindowSummary? _heartRateSummaryForNewSet(Workout workout) {
+    try {
+      final now = DateTime.now().toUtc();
+      var from = workout.startedAt;
+      for (final sets in state.setsByExercise.values) {
+        for (final set in sets) {
+          if (set.timestamp.isAfter(from)) from = set.timestamp;
+        }
+      }
+      final cap = now.subtract(const Duration(minutes: 5));
+      if (cap.isAfter(from)) from = cap;
+      return ref
+          .read(hrSessionRecorderProvider.notifier)
+          .summarise(from: from, to: now);
+    } catch (_) {
+      // HR capture must never block set logging.
+      return null;
     }
   }
 

--- a/lib/features/workout/presentation/screens/active_workout_screen.dart
+++ b/lib/features/workout/presentation/screens/active_workout_screen.dart
@@ -1707,6 +1707,17 @@ class _SetCard extends ConsumerWidget {
                 color: cs.onSurfaceVariant,
               ),
             ),
+            if (set.avgHeartRate != null) ...[
+              const SizedBox(height: 4),
+              Text(
+                '♥ ${set.avgHeartRate}'
+                '${set.peakHeartRate != null ? '/${set.peakHeartRate}' : ''}',
+                style: KineticText.mono(
+                  size: 9,
+                  color: cs.error,
+                ),
+              ),
+            ],
           ],
         ),
       ),

--- a/lib/features/workout/presentation/screens/active_workout_screen.dart
+++ b/lib/features/workout/presentation/screens/active_workout_screen.dart
@@ -19,6 +19,7 @@ import '../../../../core/extensions/datetime_extensions.dart';
 import '../../../../core/providers.dart';
 import '../../../../core/units/weight_unit.dart';
 import '../../../../core/units/weight_unit_provider.dart';
+import '../../../../core/widgets/horizontal_swipe_navigator.dart';
 import '../../../../core/widgets/kinetic.dart';
 import '../../../../core/widgets/loading_widget.dart';
 import '../../../../core/widgets/sparkline_widget.dart';
@@ -200,11 +201,15 @@ class ActiveWorkoutScreenState extends ConsumerState<ActiveWorkoutScreen>
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.surface,
       body: SafeArea(
-        child: state.isLoading
-            ? LoadingWidget(message: s.loadingWorkout)
-            : state.hasActiveWorkout
-                ? _buildActiveWorkout(context, ref, state, controller)
-                : _buildNoWorkout(context, ref, controller),
+        // Swipe left to jump to the heart rate panel (issue #71).
+        child: HorizontalSwipeNavigator(
+          onSwipeLeft: () => context.go('/heart-rate'),
+          child: state.isLoading
+              ? LoadingWidget(message: s.loadingWorkout)
+              : state.hasActiveWorkout
+                  ? _buildActiveWorkout(context, ref, state, controller)
+                  : _buildNoWorkout(context, ref, controller),
+        ),
       ),
       floatingActionButton: state.hasActiveWorkout && !_keyboardVisible
           ? FloatingActionButton.extended(

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -347,6 +347,7 @@
   "tableHeaderWeight": "Weight",
   "tableHeaderReps": "Reps",
   "tableHeaderE1rm": "e1RM",
+  "tableHeaderHr": "HR",
 
   "weightFieldLabel": "Weight ({unit})",
   "@weightFieldLabel": {

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -254,6 +254,7 @@
   "tableHeaderWeight": "重量",
   "tableHeaderReps": "レップ数",
   "tableHeaderE1rm": "e1RM",
+  "tableHeaderHr": "心拍数",
 
   "weightFieldLabel": "重量（{unit}）",
   "percentSuffix": "%",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -254,6 +254,7 @@
   "tableHeaderWeight": "무게",
   "tableHeaderReps": "횟수",
   "tableHeaderE1rm": "e1RM",
+  "tableHeaderHr": "심박수",
 
   "weightFieldLabel": "무게 ({unit})",
   "percentSuffix": "%",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -237,6 +237,7 @@
   "tableHeaderWeight": "重量",
   "tableHeaderReps": "次数",
   "tableHeaderE1rm": "估算1RM",
+  "tableHeaderHr": "心率",
 
   "weightFieldLabel": "重量（{unit}）",
   "percentSuffix": "%",

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -237,6 +237,7 @@
   "tableHeaderWeight": "重量",
   "tableHeaderReps": "次数",
   "tableHeaderE1rm": "估算1RM",
+  "tableHeaderHr": "心率",
 
   "weightFieldLabel": "重量（{unit}）",
   "percentSuffix": "%",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -1320,6 +1320,12 @@ abstract class S {
   /// **'e1RM'**
   String get tableHeaderE1rm;
 
+  /// No description provided for @tableHeaderHr.
+  ///
+  /// In en, this message translates to:
+  /// **'HR'**
+  String get tableHeaderHr;
+
   /// No description provided for @weightFieldLabel.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -677,6 +677,9 @@ class SEn extends S {
   String get tableHeaderE1rm => 'e1RM';
 
   @override
+  String get tableHeaderHr => 'HR';
+
+  @override
   String weightFieldLabel(String unit) {
     return 'Weight ($unit)';
   }

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -659,6 +659,9 @@ class SJa extends S {
   String get tableHeaderE1rm => 'e1RM';
 
   @override
+  String get tableHeaderHr => '心拍数';
+
+  @override
   String weightFieldLabel(String unit) {
     return '重量（$unit）';
   }

--- a/lib/l10n/generated/app_localizations_ko.dart
+++ b/lib/l10n/generated/app_localizations_ko.dart
@@ -657,6 +657,9 @@ class SKo extends S {
   String get tableHeaderE1rm => 'e1RM';
 
   @override
+  String get tableHeaderHr => '심박수';
+
+  @override
   String weightFieldLabel(String unit) {
     return '무게 ($unit)';
   }

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -656,6 +656,9 @@ class SZh extends S {
   String get tableHeaderE1rm => '估算1RM';
 
   @override
+  String get tableHeaderHr => '心率';
+
+  @override
   String weightFieldLabel(String unit) {
     return '重量（$unit）';
   }
@@ -2514,6 +2517,9 @@ class SZhHans extends SZh {
 
   @override
   String get tableHeaderE1rm => '估算1RM';
+
+  @override
+  String get tableHeaderHr => '心率';
 
   @override
   String weightFieldLabel(String unit) {

--- a/test/core/heart_rate/hr_session_recorder_test.dart
+++ b/test/core/heart_rate/hr_session_recorder_test.dart
@@ -1,0 +1,127 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_foundry/core/heart_rate/hr_session_recorder.dart';
+import 'package:rep_foundry/core/providers.dart';
+
+import '../../features/cardio/data/fake_heart_rate_service.dart';
+
+void main() {
+  group('summariseSamples', () {
+    final base = DateTime.utc(2026, 7, 18, 10, 0, 0);
+
+    HrSample sample(int bpm, int secondsAfterBase) => HrSample(
+        bpm: bpm, timestamp: base.add(Duration(seconds: secondsAfterBase)));
+
+    test('returns null when there are no samples in the window', () {
+      final samples = [sample(120, 0), sample(130, 300)];
+      final summary = summariseSamples(
+        samples,
+        from: base.add(const Duration(seconds: 60)),
+        to: base.add(const Duration(seconds: 120)),
+      );
+      expect(summary, isNull);
+    });
+
+    test('returns null for an empty sample list', () {
+      final summary = summariseSamples(
+        const [],
+        from: base,
+        to: base.add(const Duration(minutes: 5)),
+      );
+      expect(summary, isNull);
+    });
+
+    test('computes average and peak over samples inside the window', () {
+      final samples = [
+        sample(100, 0), // at `from` — excluded (belongs to previous window)
+        sample(120, 10),
+        sample(140, 20),
+        sample(160, 30), // at `to` — included
+        sample(180, 40), // after `to` — excluded
+      ];
+      final summary = summariseSamples(
+        samples,
+        from: base,
+        to: base.add(const Duration(seconds: 30)),
+      );
+      expect(summary, isNotNull);
+      expect(summary!.avgBpm, 140);
+      expect(summary.peakBpm, 160);
+    });
+
+    test('rounds the average to the nearest whole bpm', () {
+      final samples = [sample(100, 10), sample(101, 20)];
+      final summary = summariseSamples(
+        samples,
+        from: base,
+        to: base.add(const Duration(minutes: 1)),
+      )!;
+      expect(summary.avgBpm, 101); // 100.5 rounds up
+      expect(summary.peakBpm, 101);
+    });
+  });
+
+  group('HrSessionRecorder', () {
+    late FakeHeartRateService service;
+    late ProviderContainer container;
+
+    setUp(() {
+      service = FakeHeartRateService();
+      container = ProviderContainer(overrides: [
+        heartRateServiceProvider.overrideWithValue(service),
+      ]);
+      addTearDown(container.dispose);
+      addTearDown(service.dispose);
+    });
+
+    test('buffers timestamped samples from the heart rate stream', () async {
+      final recorder = container.read(hrSessionRecorderProvider.notifier);
+      final before = DateTime.now().toUtc();
+
+      service.emitHeartRate(120);
+      service.emitHeartRate(135);
+      await Future<void>.delayed(Duration.zero);
+
+      final after = DateTime.now().toUtc();
+      final samples = container.read(hrSessionRecorderProvider);
+      expect(samples, hasLength(2));
+      expect(samples.map((s) => s.bpm), [120, 135]);
+      for (final s in samples) {
+        expect(
+          s.timestamp.isBefore(before) || s.timestamp.isAfter(after),
+          isFalse,
+        );
+      }
+
+      final summary = recorder.summarise(
+        from: before.subtract(const Duration(seconds: 1)),
+        to: after.add(const Duration(seconds: 1)),
+      );
+      expect(summary!.avgBpm, 128);
+      expect(summary.peakBpm, 135);
+    });
+
+    test('drops non-positive readings', () async {
+      container.read(hrSessionRecorderProvider.notifier);
+
+      service.emitHeartRate(0);
+      service.emitHeartRate(-3);
+      service.emitHeartRate(90);
+      await Future<void>.delayed(Duration.zero);
+
+      final samples = container.read(hrSessionRecorderProvider);
+      expect(samples.map((s) => s.bpm), [90]);
+    });
+
+    test('clear() empties the buffer', () async {
+      final recorder = container.read(hrSessionRecorderProvider.notifier);
+
+      service.emitHeartRate(110);
+      await Future<void>.delayed(Duration.zero);
+      expect(container.read(hrSessionRecorderProvider), isNotEmpty);
+
+      recorder.clear();
+      expect(container.read(hrSessionRecorderProvider), isEmpty);
+    });
+  });
+}

--- a/test/core/widgets/horizontal_swipe_navigator_test.dart
+++ b/test/core/widgets/horizontal_swipe_navigator_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_foundry/core/widgets/horizontal_swipe_navigator.dart';
+
+void main() {
+  Widget build({
+    VoidCallback? onSwipeLeft,
+    VoidCallback? onSwipeRight,
+    Widget? child,
+  }) {
+    return MaterialApp(
+      home: Scaffold(
+        body: HorizontalSwipeNavigator(
+          onSwipeLeft: onSwipeLeft,
+          onSwipeRight: onSwipeRight,
+          child: child ?? const SizedBox.expand(),
+        ),
+      ),
+    );
+  }
+
+  group('HorizontalSwipeNavigator', () {
+    testWidgets('leftward fling calls onSwipeLeft', (tester) async {
+      var leftCalls = 0;
+      var rightCalls = 0;
+      await tester.pumpWidget(build(
+        onSwipeLeft: () => leftCalls++,
+        onSwipeRight: () => rightCalls++,
+      ));
+
+      await tester.fling(
+        find.byType(HorizontalSwipeNavigator),
+        const Offset(-300, 0),
+        1200,
+      );
+      await tester.pumpAndSettle();
+
+      expect(leftCalls, 1);
+      expect(rightCalls, 0);
+    });
+
+    testWidgets('rightward fling calls onSwipeRight', (tester) async {
+      var leftCalls = 0;
+      var rightCalls = 0;
+      await tester.pumpWidget(build(
+        onSwipeLeft: () => leftCalls++,
+        onSwipeRight: () => rightCalls++,
+      ));
+
+      await tester.fling(
+        find.byType(HorizontalSwipeNavigator),
+        const Offset(300, 0),
+        1200,
+      );
+      await tester.pumpAndSettle();
+
+      expect(leftCalls, 0);
+      expect(rightCalls, 1);
+    });
+
+    testWidgets('slow horizontal drag below the fling threshold is ignored',
+        (tester) async {
+      var leftCalls = 0;
+      var rightCalls = 0;
+      await tester.pumpWidget(build(
+        onSwipeLeft: () => leftCalls++,
+        onSwipeRight: () => rightCalls++,
+      ));
+
+      await tester.timedDrag(
+        find.byType(HorizontalSwipeNavigator),
+        const Offset(-100, 0),
+        const Duration(seconds: 1),
+      );
+      await tester.pumpAndSettle();
+
+      expect(leftCalls, 0);
+      expect(rightCalls, 0);
+    });
+
+    testWidgets('vertical scrolling inside the child still works',
+        (tester) async {
+      var leftCalls = 0;
+      var rightCalls = 0;
+      await tester.pumpWidget(build(
+        onSwipeLeft: () => leftCalls++,
+        onSwipeRight: () => rightCalls++,
+        child: ListView(
+          children: [
+            for (var i = 0; i < 40; i++)
+              SizedBox(height: 50, child: Text('row $i')),
+          ],
+        ),
+      ));
+
+      expect(find.text('row 0'), findsOneWidget);
+      await tester.fling(find.byType(ListView), const Offset(0, -400), 1200);
+      await tester.pumpAndSettle();
+
+      expect(find.text('row 0'), findsNothing);
+      expect(leftCalls, 0);
+      expect(rightCalls, 0);
+    });
+
+    testWidgets('missing callbacks are a no-op rather than an error',
+        (tester) async {
+      await tester.pumpWidget(build());
+
+      await tester.fling(
+        find.byType(HorizontalSwipeNavigator),
+        const Offset(-300, 0),
+        1200,
+      );
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+    });
+  });
+}

--- a/test/features/heart_rate/presentation/screens/heart_rate_panel_screen_test.dart
+++ b/test/features/heart_rate/presentation/screens/heart_rate_panel_screen_test.dart
@@ -2,13 +2,16 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:rep_foundry/core/providers.dart';
 import 'package:rep_foundry/features/cardio/application/save_cardio_session_use_case.dart';
 import 'package:rep_foundry/features/cardio/data/cardio_session_repository_impl.dart';
 import 'package:rep_foundry/features/health_sync/data/health_sync_service.dart';
 import 'package:rep_foundry/features/health_sync/presentation/providers/health_sync_settings_provider.dart';
+import 'package:hr_zones/hr_zones.dart';
 import 'package:rep_foundry/features/heart_rate/presentation/controllers/heart_rate_panel_controller.dart';
 import 'package:rep_foundry/features/heart_rate/presentation/controllers/heart_rate_panel_state.dart';
+import 'package:rep_foundry/features/heart_rate/presentation/providers/health_profile_provider.dart';
 import 'package:rep_foundry/features/heart_rate/presentation/screens/heart_rate_panel_screen.dart';
 import 'package:rep_foundry/features/workout/data/workout_repository_impl.dart';
 import 'package:rep_foundry/l10n/generated/app_localizations.dart';
@@ -16,6 +19,13 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../../cardio/data/fake_heart_rate_service.dart';
 import '../../../cardio/data/fake_location_service.dart';
+
+/// Health profile override with a synchronously seeded age, so the
+/// first-visit onboarding sheet never opens during a test.
+class _SeededHealthProfileNotifier extends HealthProfileNotifier {
+  @override
+  HealthProfile build() => const HealthProfile(age: 35);
+}
 
 /// Notifier override that seeds the panel with a specific initial state so
 /// tests can render branches that normally depend on live BLE readings.
@@ -473,6 +483,84 @@ void main() {
       // controller's disconnectHeartRate() flow itself is unit-tested in
       // heart_rate_panel_controller_test.dart.
       expect(find.byTooltip('Disconnect'), findsOneWidget);
+    });
+  });
+
+  group('swipe navigation', () {
+    Widget buildRouterScreen() {
+      // The real notifier loads the profile from SharedPreferences
+      // asynchronously, which races the first-visit onboarding check; a
+      // seeded profile keeps the onboarding sheet (and its modal barrier,
+      // which would swallow the fling) out of this test.
+      final seededProfile = healthProfileProvider.overrideWith(
+        _SeededHealthProfileNotifier.new,
+      );
+      final router = GoRouter(
+        initialLocation: '/heart-rate',
+        routes: [
+          GoRoute(
+            path: '/heart-rate',
+            builder: (context, state) => const HeartRatePanelScreen(),
+          ),
+          GoRoute(
+            path: '/workout',
+            builder: (context, state) =>
+                const Scaffold(body: Text('workout destination')),
+          ),
+        ],
+      );
+      return ProviderScope(
+        overrides: [
+          cardioSessionRepositoryProvider.overrideWithValue(cardioRepo),
+          saveCardioSessionUseCaseProvider.overrideWithValue(
+            SaveCardioSessionUseCase(
+              cardioRepository: cardioRepo,
+              workoutRepository: workoutRepo,
+            ),
+          ),
+          locationServiceProvider.overrideWithValue(locationService),
+          heartRateServiceProvider.overrideWithValue(heartRateService),
+          healthSyncServiceProvider.overrideWithValue(HealthSyncService()),
+          healthSyncSettingsProvider
+              .overrideWith(() => HealthSyncSettingsNotifier()),
+          seededProfile,
+        ],
+        child: MaterialApp.router(
+          localizationsDelegates: S.localizationsDelegates,
+          supportedLocales: S.supportedLocales,
+          routerConfig: router,
+        ),
+      );
+    }
+
+    testWidgets('rightward fling navigates to the active workout screen',
+        (tester) async {
+      await tester.pumpWidget(buildRouterScreen());
+      await tester.pumpAndSettle();
+
+      await tester.fling(
+        find.byType(HeartRatePanelScreen),
+        const Offset(300, 0),
+        1200,
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('workout destination'), findsOneWidget);
+    });
+
+    testWidgets('leftward fling stays on the heart rate panel', (tester) async {
+      await tester.pumpWidget(buildRouterScreen());
+      await tester.pumpAndSettle();
+
+      await tester.fling(
+        find.byType(HeartRatePanelScreen),
+        const Offset(-300, 0),
+        1200,
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('workout destination'), findsNothing);
+      expect(find.byType(HeartRatePanelScreen), findsOneWidget);
     });
   });
 }

--- a/test/features/history/presentation/screens/workout_detail_screen_test.dart
+++ b/test/features/history/presentation/screens/workout_detail_screen_test.dart
@@ -117,4 +117,66 @@ void main() {
     expect(templates.single.name, 'My Template');
     expect(templates.single.exercises.single.exerciseName, 'Bench Press');
   });
+
+  testWidgets('shows a heart rate column when sets carry HR summaries',
+      (tester) async {
+    final repo = InMemoryWorkoutRepository();
+    final now = DateTime.utc(2026, 6, 1, 9);
+    await repo.createWorkout(
+      Workout(
+        id: 'w1',
+        startedAt: now,
+        completedAt: now.add(const Duration(minutes: 45)),
+        updatedAt: now,
+      ),
+    );
+    await repo.addSet(WorkoutSet.create(
+      workoutId: 'w1',
+      exerciseId: '1',
+      setOrder: 1,
+      weight: 60,
+      reps: 5,
+      avgHeartRate: 142,
+      peakHeartRate: 168,
+    ));
+    await repo.addSet(WorkoutSet.create(
+      workoutId: 'w1',
+      exerciseId: '1',
+      setOrder: 2,
+      weight: 60,
+      reps: 5,
+    ));
+
+    await tester.pumpWidget(buildScreen(repo, 'w1'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('HR'), findsOneWidget);
+    expect(find.text('142/168'), findsOneWidget);
+  });
+
+  testWidgets('hides the heart rate column when no set carries HR data',
+      (tester) async {
+    final repo = InMemoryWorkoutRepository();
+    final now = DateTime.utc(2026, 6, 1, 9);
+    await repo.createWorkout(
+      Workout(
+        id: 'w1',
+        startedAt: now,
+        completedAt: now.add(const Duration(minutes: 45)),
+        updatedAt: now,
+      ),
+    );
+    await repo.addSet(WorkoutSet.create(
+      workoutId: 'w1',
+      exerciseId: '1',
+      setOrder: 1,
+      weight: 60,
+      reps: 5,
+    ));
+
+    await tester.pumpWidget(buildScreen(repo, 'w1'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('HR'), findsNothing);
+  });
 }

--- a/test/features/sync/data/sync_snapshot_serialiser_test.dart
+++ b/test/features/sync/data/sync_snapshot_serialiser_test.dart
@@ -187,6 +187,46 @@ void main() {
       expect(round.stretchingSessions.single.deletedAt, equals(tombstone));
     });
 
+    test('workout set heart rate summary survives a JSON round-trip', () {
+      final ts = DateTime.utc(2025, 6, 1, 12);
+      final snapshot = SyncSnapshot(
+        snapshotAt: ts,
+        deviceId: 'device-a',
+        schemaVersion: AppDatabase.schemaVersionConst,
+        workoutSets: [
+          WorkoutSet(
+            id: 'set-hr',
+            workoutId: 'wo-1',
+            exerciseId: 'ex-1',
+            setOrder: 1,
+            weight: 80,
+            reps: 8,
+            timestamp: ts,
+            avgHeartRate: 142,
+            peakHeartRate: 168,
+            updatedAt: ts,
+          ),
+          WorkoutSet(
+            id: 'set-no-hr',
+            workoutId: 'wo-1',
+            exerciseId: 'ex-1',
+            setOrder: 2,
+            weight: 80,
+            reps: 8,
+            timestamp: ts,
+            updatedAt: ts,
+          ),
+        ],
+      );
+
+      final restored = serialiser.fromJson(serialiser.toJson(snapshot));
+
+      expect(restored.workoutSets.first.avgHeartRate, 142);
+      expect(restored.workoutSets.first.peakHeartRate, 168);
+      expect(restored.workoutSets.last.avgHeartRate, isNull);
+      expect(restored.workoutSets.last.peakHeartRate, isNull);
+    });
+
     test('stretching sessions survive a full JSON round-trip', () {
       final original = makeFullSnapshot();
 

--- a/test/features/workout/application/log_set_use_case_test.dart
+++ b/test/features/workout/application/log_set_use_case_test.dart
@@ -99,6 +99,27 @@ void main() {
     expect(result.set.reps, 5);
   });
 
+  test('execute() stores heart rate summary fields when provided', () async {
+    const input = LogSetInput(
+      workoutId: 'w1',
+      exerciseId: 'e1',
+      setOrder: 1,
+      weight: 100.0,
+      reps: 5,
+      avgHeartRate: 138,
+      peakHeartRate: 171,
+    );
+    final result = await useCase.execute(input);
+    expect(result.set.avgHeartRate, 138);
+    expect(result.set.peakHeartRate, 171);
+  });
+
+  test('execute() leaves heart rate fields null when not provided', () async {
+    final result = await useCase.execute(validInput);
+    expect(result.set.avgHeartRate, isNull);
+    expect(result.set.peakHeartRate, isNull);
+  });
+
   test('execute() detects all PR types on first set', () async {
     final result = await useCase.execute(validInput);
     expect(result.newPersonalRecords, isNotEmpty);

--- a/test/features/workout/data/drift_workout_repository_test.dart
+++ b/test/features/workout/data/drift_workout_repository_test.dart
@@ -203,6 +203,30 @@ void main() {
         expect(sets.first.setOrder, 1);
         expect(sets.last.setOrder, 2);
       });
+
+      test('round-trips heart rate summary fields', () async {
+        final workout = newWorkout();
+        await repo.createWorkout(workout);
+
+        final withHr = WorkoutSet.create(
+          workoutId: workout.id,
+          exerciseId: '1',
+          setOrder: 1,
+          weight: 80.0,
+          reps: 8,
+          avgHeartRate: 142,
+          peakHeartRate: 168,
+        );
+        final withoutHr = newSet(workoutId: workout.id, setOrder: 2);
+        await repo.addSet(withHr);
+        await repo.addSet(withoutHr);
+
+        final sets = await repo.getSetsForWorkout(workout.id);
+        expect(sets.first.avgHeartRate, 142);
+        expect(sets.first.peakHeartRate, 168);
+        expect(sets.last.avgHeartRate, isNull);
+        expect(sets.last.peakHeartRate, isNull);
+      });
     });
 
     group('getSetsForWorkouts', () {

--- a/test/features/workout/presentation/controllers/active_workout_controller_test.dart
+++ b/test/features/workout/presentation/controllers/active_workout_controller_test.dart
@@ -6,6 +6,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:drift/native.dart';
 import 'package:rep_foundry/core/database/app_database.dart' show AppDatabase;
+import 'package:rep_foundry/core/heart_rate/hr_session_recorder.dart';
 import 'package:rep_foundry/core/providers.dart';
 import 'package:rep_foundry/features/exercises/data/exercise_repository_impl.dart';
 import 'package:rep_foundry/features/health_sync/data/health_sync_service.dart';
@@ -21,6 +22,8 @@ import 'package:rep_foundry/features/workout/data/workout_repository_impl.dart';
 import 'package:rep_foundry/features/workout/domain/models/workout.dart';
 import 'package:rep_foundry/features/workout/domain/models/workout_set.dart';
 import 'package:rep_foundry/features/workout/presentation/controllers/active_workout_controller.dart';
+
+import '../../../cardio/data/fake_heart_rate_service.dart';
 
 class _FakeCloudSyncService implements CloudSyncService {
   @override
@@ -199,6 +202,75 @@ void main() {
         expect(sets, hasLength(1));
         expect(sets.first.weight, 100);
         expect(sets.first.reps, 5);
+      });
+
+      test('stamps the set with avg/peak heart rate from the recorder',
+          () async {
+        final hrService = FakeHeartRateService();
+        addTearDown(hrService.dispose);
+        container.dispose();
+        container = ProviderContainer(
+          overrides: [
+            workoutRepositoryProvider.overrideWithValue(workoutRepo),
+            exerciseRepositoryProvider.overrideWithValue(exerciseRepo),
+            personalRecordRepositoryProvider.overrideWithValue(prRepo),
+            workoutTemplateRepositoryProvider.overrideWithValue(templateRepo),
+            healthSyncServiceProvider.overrideWithValue(HealthSyncService()),
+            healthSyncSettingsProvider
+                .overrideWith(() => _NoOpHealthSyncSettingsNotifier()),
+            syncSettingsProvider.overrideWith(() => SyncSettingsNotifier()),
+            syncOrchestratorProvider.overrideWithValue(syncOrchestrator),
+            heartRateServiceProvider.overrideWithValue(hrService),
+          ],
+        );
+        // Start the recorder buffering before any readings arrive.
+        container.read(hrSessionRecorderProvider.notifier);
+
+        await waitForInit();
+        final controller = readController();
+        await controller.startWorkout();
+        final exercises = await exerciseRepo.getAllExercises();
+        final exercise = exercises.first;
+        await controller.addExercise(exercise);
+
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+        hrService.emitHeartRate(130);
+        hrService.emitHeartRate(150);
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+
+        await controller.logSet(exerciseId: exercise.id, weight: 100, reps: 5);
+
+        final firstSet = readState().setsByExercise[exercise.id]!.single;
+        expect(firstSet.avgHeartRate, 140);
+        expect(firstSet.peakHeartRate, 150);
+
+        // The second set's window starts at the first set's timestamp, so it
+        // must only see the readings emitted after it.
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+        hrService.emitHeartRate(170);
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+
+        await controller.logSet(exerciseId: exercise.id, weight: 100, reps: 5);
+
+        final secondSet = readState().setsByExercise[exercise.id]!.last;
+        expect(secondSet.avgHeartRate, 170);
+        expect(secondSet.peakHeartRate, 170);
+      });
+
+      test('leaves heart rate fields null when no monitor readings exist',
+          () async {
+        await waitForInit();
+        final controller = readController();
+        await controller.startWorkout();
+        final exercises = await exerciseRepo.getAllExercises();
+        final exercise = exercises.first;
+        await controller.addExercise(exercise);
+
+        await controller.logSet(exerciseId: exercise.id, weight: 100, reps: 5);
+
+        final set = readState().setsByExercise[exercise.id]!.single;
+        expect(set.avgHeartRate, isNull);
+        expect(set.peakHeartRate, isNull);
       });
 
       test(

--- a/test/features/workout/presentation/screens/active_workout_screen_test.dart
+++ b/test/features/workout/presentation/screens/active_workout_screen_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'package:rep_foundry/core/heart_rate/hr_session_recorder.dart';
 import 'package:rep_foundry/core/providers.dart';
 import 'package:rep_foundry/features/exercises/data/exercise_repository_impl.dart';
 import 'package:rep_foundry/features/exercises/domain/models/exercise.dart';
@@ -18,6 +19,8 @@ import 'package:rep_foundry/features/workout/presentation/controllers/active_wor
 import 'package:rep_foundry/core/widgets/loading_widget.dart';
 import 'package:rep_foundry/features/workout/presentation/screens/active_workout_screen.dart';
 import 'package:rep_foundry/l10n/generated/app_localizations.dart';
+
+import '../../../cardio/data/fake_heart_rate_service.dart';
 
 void main() {
   setUp(() {
@@ -422,6 +425,82 @@ void main() {
         expect(state.scrollController.offset, 0.0);
       },
     );
+  });
+
+  group('heart rate chip', () {
+    testWidgets('logged set shows avg/peak BPM captured from the monitor',
+        (tester) async {
+      final hrService = FakeHeartRateService();
+      addTearDown(hrService.dispose);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            workoutRepositoryProvider
+                .overrideWithValue(InMemoryWorkoutRepository()),
+            exerciseRepositoryProvider.overrideWithValue(
+              InMemoryExerciseRepository(),
+            ),
+            personalRecordRepositoryProvider.overrideWithValue(
+              InMemoryPersonalRecordRepository(),
+            ),
+            workoutTemplateRepositoryProvider.overrideWithValue(
+              InMemoryWorkoutTemplateRepository(),
+            ),
+            healthSyncServiceProvider.overrideWithValue(HealthSyncService()),
+            healthSyncSettingsProvider.overrideWith(
+              () => HealthSyncSettingsNotifier(),
+            ),
+            syncSettingsProvider.overrideWith(() => SyncSettingsNotifier()),
+            heartRateServiceProvider.overrideWithValue(hrService),
+          ],
+          child: const MaterialApp(
+            localizationsDelegates: S.localizationsDelegates,
+            supportedLocales: S.supportedLocales,
+            home: ActiveWorkoutScreen(),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final element = tester.element(find.byType(ActiveWorkoutScreen));
+      final container = ProviderScope.containerOf(element);
+      // Start the recorder buffering before readings arrive.
+      container.read(hrSessionRecorderProvider.notifier);
+      final notifier = container.read(activeWorkoutControllerProvider.notifier);
+
+      await notifier.startWorkout();
+      await notifier.addExercise(makeExercise('ex-1', 'Bench Press'));
+      await tester.pumpAndSettle();
+
+      await tester.runAsync(() async {
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+        hrService.emitHeartRate(130);
+        hrService.emitHeartRate(150);
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+        await notifier.logSet(exerciseId: 'ex-1', weight: 100, reps: 5);
+      });
+      await tester.pumpAndSettle();
+
+      expect(find.text('♥ 140/150'), findsOneWidget);
+    });
+
+    testWidgets('logged set without HR data shows no heart chip',
+        (tester) async {
+      await tester.pumpWidget(buildScreen());
+      await tester.pumpAndSettle();
+
+      final element = tester.element(find.byType(ActiveWorkoutScreen));
+      final container = ProviderScope.containerOf(element);
+      final notifier = container.read(activeWorkoutControllerProvider.notifier);
+
+      await notifier.startWorkout();
+      await notifier.addExercise(makeExercise('ex-1', 'Bench Press'));
+      await notifier.logSet(exerciseId: 'ex-1', weight: 100, reps: 5);
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('♥'), findsNothing);
+    });
   });
 
   group('swipe navigation', () {

--- a/test/features/workout/presentation/screens/active_workout_screen_test.dart
+++ b/test/features/workout/presentation/screens/active_workout_screen_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:rep_foundry/core/providers.dart';
@@ -421,5 +422,79 @@ void main() {
         expect(state.scrollController.offset, 0.0);
       },
     );
+  });
+
+  group('swipe navigation', () {
+    Widget buildRouterScreen() {
+      final router = GoRouter(
+        initialLocation: '/workout',
+        routes: [
+          GoRoute(
+            path: '/workout',
+            builder: (context, state) => const ActiveWorkoutScreen(),
+          ),
+          GoRoute(
+            path: '/heart-rate',
+            builder: (context, state) =>
+                const Scaffold(body: Text('heart-rate destination')),
+          ),
+        ],
+      );
+      return ProviderScope(
+        overrides: [
+          workoutRepositoryProvider
+              .overrideWithValue(InMemoryWorkoutRepository()),
+          exerciseRepositoryProvider.overrideWithValue(
+            InMemoryExerciseRepository(),
+          ),
+          personalRecordRepositoryProvider.overrideWithValue(
+            InMemoryPersonalRecordRepository(),
+          ),
+          workoutTemplateRepositoryProvider.overrideWithValue(
+            InMemoryWorkoutTemplateRepository(),
+          ),
+          healthSyncServiceProvider.overrideWithValue(HealthSyncService()),
+          healthSyncSettingsProvider.overrideWith(
+            () => HealthSyncSettingsNotifier(),
+          ),
+          syncSettingsProvider.overrideWith(() => SyncSettingsNotifier()),
+        ],
+        child: MaterialApp.router(
+          localizationsDelegates: S.localizationsDelegates,
+          supportedLocales: S.supportedLocales,
+          routerConfig: router,
+        ),
+      );
+    }
+
+    testWidgets('leftward fling navigates to the heart rate panel',
+        (tester) async {
+      await tester.pumpWidget(buildRouterScreen());
+      await tester.pumpAndSettle();
+
+      await tester.fling(
+        find.byType(ActiveWorkoutScreen),
+        const Offset(-300, 0),
+        1200,
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('heart-rate destination'), findsOneWidget);
+    });
+
+    testWidgets('rightward fling stays on the workout screen', (tester) async {
+      await tester.pumpWidget(buildRouterScreen());
+      await tester.pumpAndSettle();
+
+      await tester.fling(
+        find.byType(ActiveWorkoutScreen),
+        const Offset(300, 0),
+        1200,
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('heart-rate destination'), findsNothing);
+      expect(find.byType(ActiveWorkoutScreen), findsOneWidget);
+    });
   });
 }


### PR DESCRIPTION
## Summary
Recovery PR: #73 and #74 were squash-merged **into each other's stacked branches**, not into `main` — all three merges happened within ~25 seconds, before GitHub retargeted the stacked bases after #72 landed. As a result `main` only received the BLE hardening from #72; the swipe feature and the per-set HR summary were stranded on the feature branches.

This PR cherry-picks the two squash commits onto `main` unchanged:
- `8708b09` feat: swipe between active workout and heart rate panel (#73)
- `9e49b52` feat: stamp logged sets with heart rate summary from a connected monitor (#74)

The resulting tree is **byte-identical** to the fully verified stack tip (`feat/set-hr-summary`) — the exact build that was tested on the iPhone 16 Pro simulator and the Galaxy S9+.

## Testing
- `dart analyze`: no issues.
- `flutter test`: all 1002 tests pass on this branch.

Closes #70
Closes #71