### PR TITLE
ci: run analyse, format check, and tests on pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    name: Analyse & test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.44.6'
+          channel: 'stable'
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Verify formatting
+        run: dart format --set-exit-if-changed .
+
+      - name: Analyse
+        run: dart analyze
+
+      - name: Run tests
+        run: flutter test


### PR DESCRIPTION
Adds a `Tests` workflow that runs on every pull request and on pushes to `main`:

- `dart format --set-exit-if-changed .`
- `dart analyze`
- `flutter test`

Pinned to Flutter 3.44.6 (matches the version in local use) with pub caching enabled.

This commit was originally pushed to `feat/coach-client-roster` after PR #80 had already been squash-merged, so it never landed on `main`. Cherry-picked here so it isn't lost when that branch is deleted.

Verified locally: `flutter test` → 1099 passed; `dart analyze` → no issues; `dart format` → 0 changed.

