### PR TITLE
fix: narrow-phone UI polish on cardio and heart rate onboarding

### DIFF
--- a/lib/features/cardio/presentation/screens/cardio_tracking_screen.dart
+++ b/lib/features/cardio/presentation/screens/cardio_tracking_screen.dart
@@ -330,53 +330,48 @@ class _CardioTrackingScreenState extends ConsumerState<CardioTrackingScreen> {
         borderRadius: BorderRadius.circular(22),
       ),
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
-      child: Row(
-        children: [
-          Container(
-            width: 42,
-            height: 42,
-            decoration: BoxDecoration(
-              color: cs.primary.withValues(alpha: 0.14),
-              borderRadius: BorderRadius.circular(13),
+      child: _HrConnectPrompt(
+        icon: Container(
+          width: 42,
+          height: 42,
+          decoration: BoxDecoration(
+            color: cs.primary.withValues(alpha: 0.14),
+            borderRadius: BorderRadius.circular(13),
+          ),
+          child: Icon(Icons.bluetooth, color: cs.primary, size: 22),
+        ),
+        label: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              s.heartRateMonitorCard,
+              style: KineticText.display(
+                size: 15,
+                letterSpacing: -0.2,
+                color: cs.onSurface,
+              ),
             ),
-            child: Icon(Icons.bluetooth, color: cs.primary, size: 22),
-          ),
-          const SizedBox(width: 14),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  s.heartRateMonitorCard,
-                  style: KineticText.display(
-                    size: 15,
-                    letterSpacing: -0.2,
-                    color: cs.onSurface,
-                  ),
-                ),
-                const SizedBox(height: 2),
-                Text(
-                  s.heartRateMonitorSubtitle,
-                  style: GoogleFonts.manrope(
-                    fontSize: 12,
-                    color: cs.onSurfaceVariant,
-                  ),
-                ),
-              ],
+            const SizedBox(height: 2),
+            Text(
+              s.heartRateMonitorSubtitle,
+              style: GoogleFonts.manrope(
+                fontSize: 12,
+                color: cs.onSurfaceVariant,
+              ),
             ),
-          ),
-          IconButton(
-            icon: Icon(Icons.help_outline, color: cs.onSurfaceVariant),
-            tooltip: s.setupGuide,
-            onPressed: () => showHrSetupGuide(context),
-          ),
-          FilledButton.tonal(
-            onPressed: cardioState.isSaving
-                ? null
-                : () => _showHrDevicePicker(controller),
-            child: Text(s.connect),
-          ),
-        ],
+          ],
+        ),
+        help: IconButton(
+          icon: Icon(Icons.help_outline, color: cs.onSurfaceVariant),
+          tooltip: s.setupGuide,
+          onPressed: () => showHrSetupGuide(context),
+        ),
+        action: FilledButton.tonal(
+          onPressed: cardioState.isSaving
+              ? null
+              : () => _showHrDevicePicker(controller),
+          child: Text(s.connect),
+        ),
       ),
     );
   }
@@ -604,6 +599,68 @@ class _HeroTimer extends StatelessWidget {
           ],
         ),
       ],
+    );
+  }
+}
+
+// ── Heart rate connect prompt ────────────────────────────────────────────────
+
+/// Lays out the BLE connect tile: icon + label with the help and Connect
+/// actions beside them. On a narrow phone the actions would squeeze the label
+/// column to about a third of the width, wrapping "Heart Rate Monitor" over
+/// several lines (issue #79 family), so below [_stackBelowWidth] the actions
+/// move onto their own line and the label gets the full width.
+class _HrConnectPrompt extends StatelessWidget {
+  const _HrConnectPrompt({
+    required this.icon,
+    required this.label,
+    required this.help,
+    required this.action,
+  });
+
+  final Widget icon;
+  final Widget label;
+  final Widget help;
+  final Widget action;
+
+  /// Below this the icon, label and both actions no longer fit on one line
+  /// without wrapping the label.
+  static const _stackBelowWidth = 420.0;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final labelRow = Row(
+          children: [
+            icon,
+            const SizedBox(width: 14),
+            Expanded(child: label),
+          ],
+        );
+
+        if (constraints.maxWidth >= _stackBelowWidth) {
+          return Row(
+            children: [
+              Expanded(child: labelRow),
+              help,
+              action,
+            ],
+          );
+        }
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            labelRow,
+            const SizedBox(height: 10),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [help, action],
+            ),
+          ],
+        );
+      },
     );
   }
 }

--- a/lib/features/heart_rate/presentation/widgets/health_profile_onboarding.dart
+++ b/lib/features/heart_rate/presentation/widgets/health_profile_onboarding.dart
@@ -61,38 +61,53 @@ class _HealthProfileOnboardingState
   @override
   Widget build(BuildContext context) {
     final s = S.of(context)!;
-    return Padding(
-      padding: EdgeInsets.only(
-        left: 24,
-        right: 24,
-        top: 24,
-        bottom: MediaQuery.of(context).viewInsets.bottom + 24,
+    final theme = Theme.of(context);
+    // The app theme draws fields as a fill with no enabled border, and that
+    // fill is nearly the same colour as this sheet — leaving an unfocused
+    // field looking like plain text. Give them a visible outline instead.
+    final outlined = theme.copyWith(
+      inputDecorationTheme: theme.inputDecorationTheme.copyWith(
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(16),
+          borderSide: BorderSide(color: theme.colorScheme.outlineVariant),
+        ),
       ),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          Row(
-            children: [
-              Expanded(
-                child: Text(
-                  s.onboardingTitle,
-                  style: Theme.of(context).textTheme.titleLarge,
+    );
+    return Theme(
+      data: outlined,
+      child: Padding(
+        padding: EdgeInsets.only(
+          left: 24,
+          right: 24,
+          top: 24,
+          bottom: MediaQuery.of(context).viewInsets.bottom + 24,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    s.onboardingTitle,
+                    style: Theme.of(context).textTheme.titleLarge,
+                  ),
                 ),
-              ),
-              Text(
-                s.onboardingStepOf(_step + 1, 4),
-                style: Theme.of(context).textTheme.bodySmall,
-              ),
-            ],
-          ),
-          const SizedBox(height: 4),
-          LinearProgressIndicator(value: (_step + 1) / 4),
-          const SizedBox(height: 20),
-          _buildStep(),
-          const SizedBox(height: 20),
-          _buildNav(),
-        ],
+                Text(
+                  s.onboardingStepOf(_step + 1, 4),
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+              ],
+            ),
+            const SizedBox(height: 4),
+            LinearProgressIndicator(value: (_step + 1) / 4),
+            const SizedBox(height: 20),
+            _buildStep(),
+            const SizedBox(height: 20),
+            _buildNav(),
+          ],
+        ),
       ),
     );
   }
@@ -126,7 +141,6 @@ class _HealthProfileOnboardingState
           controller: _ageController,
           keyboardType: TextInputType.number,
           inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-          autofocus: true,
           decoration: InputDecoration(
             labelText: s.ageLabel,
             hintText: s.ageHint,

--- a/test/features/cardio/presentation/screens/cardio_tracking_screen_test.dart
+++ b/test/features/cardio/presentation/screens/cardio_tracking_screen_test.dart
@@ -128,6 +128,54 @@ void main() {
       expect(find.text('Save Session'), findsNothing);
     });
 
+    testWidgets(
+        'heart rate tile stacks the Connect action below the label on a '
+        'narrow phone', (tester) async {
+      // On a ~411dp phone the icon, help button and Connect button squeezed
+      // the text column to ~140dp, wrapping "Heart Rate Monitor" onto two
+      // lines and the subtitle onto three. Same family as issue #79: the
+      // action moves below the label rather than beside it.
+      final binding = TestWidgetsFlutterBinding.ensureInitialized();
+      binding.platformDispatcher.views.first.physicalSize =
+          const Size(720, 1480);
+      binding.platformDispatcher.views.first.devicePixelRatio = 1.75;
+
+      await tester.pumpWidget(buildScreen());
+      await tester.pumpAndSettle();
+
+      final title = find.text('Heart Rate Monitor');
+      final connect = find.widgetWithText(FilledButton, 'Connect');
+      expect(title, findsOneWidget);
+      expect(connect, findsOneWidget);
+
+      // Stacked: the Connect button starts below the title, not beside it.
+      expect(
+        tester.getTopLeft(connect).dy,
+        greaterThan(tester.getBottomLeft(title).dy),
+        reason: 'Connect must sit below the label on a narrow phone',
+      );
+
+      // With the full width available the title no longer wraps.
+      expect(tester.getSize(title).height, lessThan(30));
+    });
+
+    testWidgets('heart rate tile keeps Connect beside the label when wide',
+        (tester) async {
+      // Default harness surface is 800dp wide — the side-by-side layout must
+      // be preserved there so tablets/desktop are unchanged.
+      await tester.pumpWidget(buildScreen());
+      await tester.pumpAndSettle();
+
+      final title = find.text('Heart Rate Monitor');
+      final connect = find.widgetWithText(FilledButton, 'Connect');
+
+      expect(
+        tester.getTopLeft(connect).dx,
+        greaterThan(tester.getBottomRight(title).dx),
+        reason: 'Connect stays beside the label on a wide surface',
+      );
+    });
+
     testWidgets('Connect offers to enable Bluetooth before giving up',
         (tester) async {
       heartRateService.permissionGranted = false;

--- a/test/features/heart_rate/presentation/widgets/health_profile_onboarding_test.dart
+++ b/test/features/heart_rate/presentation/widgets/health_profile_onboarding_test.dart
@@ -60,6 +60,46 @@ void main() {
       expect(find.text('Age'), findsOneWidget);
     });
 
+    testWidgets('does not open the keyboard over the sheet on step 1',
+        (tester) async {
+      // The age field used to autofocus, so arriving on the Heart Rate tab
+      // raised the numeric keyboard immediately and it covered the sheet
+      // including the Skip/Next buttons. The sheet must be readable first.
+      await tester.pumpWidget(buildApp());
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      final ageField = tester.widget<TextField>(find.byType(TextField));
+      expect(ageField.autofocus, isFalse);
+
+      final focus = ageField.focusNode;
+      expect(focus?.hasFocus ?? false, isFalse);
+    });
+
+    testWidgets('age field is visibly outlined when unfocused', (tester) async {
+      // The app theme uses enabledBorder: BorderSide.none with a filled
+      // background, and that fill is nearly identical to the bottom sheet's
+      // surface — so an unfocused field reads as plain text with no hint that
+      // it can be tapped. Autofocus used to mask this. The sheet must give its
+      // fields a visible outline in the enabled state.
+      await tester.pumpWidget(buildApp());
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      final decorator = tester.widget<InputDecorator>(
+        find.byType(InputDecorator).first,
+      );
+      final enabled = decorator.decoration.enabledBorder;
+
+      expect(enabled, isNotNull);
+      expect(
+        enabled!.borderSide.style,
+        BorderStyle.solid,
+        reason: 'unfocused field needs a visible outline',
+      );
+      expect(enabled.borderSide.width, greaterThan(0));
+    });
+
     testWidgets('navigates through all 4 steps', (tester) async {
       await tester.pumpWidget(buildApp());
       await tester.tap(find.text('Open'));

--- a/test/features/workout/presentation/screens/active_workout_screen_test.dart
+++ b/test/features/workout/presentation/screens/active_workout_screen_test.dart
@@ -190,6 +190,63 @@ void main() {
     );
 
     testWidgets(
+      'extended FAB clears the last ADD SET button at the end of the list',
+      (tester) async {
+        // On a 411dp phone the extended "Add Exercise" FAB floats over the
+        // list. That is expected mid-scroll, but once scrolled to the end the
+        // bottom padding must keep the last ADD SET button tappable rather
+        // than hidden beneath the FAB.
+        final binding = TestWidgetsFlutterBinding.ensureInitialized();
+        binding.platformDispatcher.views.first.physicalSize =
+            const Size(720, 1480);
+        binding.platformDispatcher.views.first.devicePixelRatio = 1.75;
+        addTearDown(() {
+          binding.platformDispatcher.views.first.resetPhysicalSize();
+          binding.platformDispatcher.views.first.resetDevicePixelRatio();
+        });
+
+        await tester.pumpWidget(buildScreen());
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Start Workout'));
+        await tester.pumpAndSettle();
+
+        final element = tester.element(find.byType(ActiveWorkoutScreen));
+        final container = ProviderScope.containerOf(element);
+        final notifier =
+            container.read(activeWorkoutControllerProvider.notifier);
+
+        for (var i = 0; i < 4; i++) {
+          await notifier.addExercise(makeExercise('ex-$i', 'Exercise $i'));
+        }
+        await tester.pumpAndSettle();
+
+        // Scroll to the very end of the list.
+        final state = tester.state<ActiveWorkoutScreenState>(
+          find.byType(ActiveWorkoutScreen),
+        );
+        state.scrollController
+            .jumpTo(state.scrollController.position.maxScrollExtent);
+        await tester.pumpAndSettle();
+
+        final fab = find.byType(FloatingActionButton);
+        expect(fab, findsOneWidget);
+
+        final addSetButtons = find.text('ADD SET');
+        expect(addSetButtons, findsWidgets);
+
+        // The last ADD SET button must not sit underneath the FAB.
+        final fabRect = tester.getRect(fab);
+        final lastAddSet = tester.getRect(addSetButtons.last);
+        expect(
+          fabRect.overlaps(lastAddSet),
+          isFalse,
+          reason: 'FAB $fabRect must not cover ADD SET $lastAddSet',
+        );
+      },
+    );
+
+    testWidgets(
       'handleAddExercise_scrollsNewExerciseToTop_afterAdd',
       (tester) async {
         await tester.pumpWidget(buildScreen());


### PR DESCRIPTION
Three narrow-phone issues found while testing on a Galaxy S9+ (411dp logical width), plus one regression test.

## Heart rate onboarding

- **Autofocus raised the keyboard over the sheet.** The onboarding sheet autofocused its Age field, so opening the Heart Rate tab brought up the numeric keyboard immediately and it covered the sheet — including the Skip and Next buttons. Autofocus removed.
- **The Age field was then effectively invisible.** The app theme draws fields with `enabledBorder: BorderSide.none` over a fill nearly identical to the bottom sheet surface, so an unfocused field read as plain text with no hint it could be tapped. The sheet now gives its fields a visible outline in the enabled state, scoped to the sheet rather than changing the global theme.

## Cardio tracking

- **"Heart Rate Monitor" tile wrapped badly.** The tile squeezed its text column to roughly 140dp, wrapping the title over four lines and the subtitle over three. `_HrConnectPrompt` now stacks the help and Connect actions below the label under 420dp — the same approach taken for #79 — and keeps the side-by-side layout above that width.

## Regression test

Adds a test asserting the extended "Add Exercise" FAB clears the last ADD SET button at the end of the list. That behaviour was already correct via the list's 104px bottom padding and is unchanged; the test locks it in.

## Test plan

- New widget tests in `cardio_tracking_screen_test.dart`, `health_profile_onboarding_test.dart`, and `active_workout_screen_test.dart`.
- Verified manually on a Galaxy S9+ (411dp).
