### PR TITLE
fix: stop the rest-timer chime cutting off the coach

### DIFF
--- a/lib/features/trainer/presentation/providers/coach_announcements.dart
+++ b/lib/features/trainer/presentation/providers/coach_announcements.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/entitlements/entitlement.dart';
+import '../../../../core/entitlements/entitlement_provider.dart';
+import 'trainer_settings_provider.dart';
+
+/// True when the coach will speak its own end-of-rest line.
+///
+/// The rest-timer chime is suppressed while this holds. On Android the chime
+/// takes exclusive audio focus (`AUDIOFOCUS_GAIN`) whereas the coach only asks
+/// to duck, so the two firing together cut the coach off mid-sentence. When
+/// the coach is speaking the chime is redundant anyway — the spoken line says
+/// rest is over.
+///
+/// The conditions mirror the ones [CoachBridge] applies before speaking, and
+/// `countdownsEnabled` is included because the end-of-rest cue carries
+/// countdown priority: switching countdowns off silences it, and the chime
+/// must come back.
+final coachAnnouncesRestEndProvider = Provider<bool>((ref) {
+  final settings = ref.watch(trainerSettingsProvider);
+  if (!settings.enabled || !settings.disclaimerAccepted) return false;
+  if (!settings.countdownsEnabled) return false;
+
+  return ref.watch(entitlementServiceProvider).has(Entitlement.virtualTrainer);
+});

--- a/lib/features/workout/presentation/widgets/rest_timer_widget.dart
+++ b/lib/features/workout/presentation/widgets/rest_timer_widget.dart
@@ -8,6 +8,7 @@ import 'package:rep_foundry/l10n/generated/app_localizations.dart';
 import '../../../../core/extensions/datetime_extensions.dart';
 import '../../../settings/presentation/providers/rest_timer_settings_provider.dart';
 import '../../../trainer/domain/trainer_event.dart';
+import '../../../trainer/presentation/providers/coach_announcements.dart';
 import '../../../trainer/presentation/providers/trainer_event_bus.dart';
 
 /// Provider that holds the current rest timer state in seconds remaining.
@@ -89,7 +90,10 @@ class _RestTimerWidgetState extends ConsumerState<RestTimerWidget> {
     if (settings.vibrationEnabled) {
       HapticFeedback.heavyImpact();
     }
-    if (settings.soundEnabled) {
+    // The chime takes exclusive audio focus and would cut the coach off
+    // mid-sentence, so it stands down whenever the coach announces rest end
+    // itself. Vibration is unaffected — it does not contend for audio.
+    if (settings.soundEnabled && !ref.read(coachAnnouncesRestEndProvider)) {
       _audioPlayer?.play(AssetSource('sounds/timer_complete.wav'));
     }
   }

--- a/test/features/trainer/presentation/coach_announces_rest_end_test.dart
+++ b/test/features/trainer/presentation/coach_announces_rest_end_test.dart
@@ -1,0 +1,100 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_foundry/core/entitlements/entitlement.dart';
+import 'package:rep_foundry/core/entitlements/entitlement_provider.dart';
+import 'package:rep_foundry/core/entitlements/entitlement_service.dart';
+import 'package:rep_foundry/features/trainer/presentation/providers/coach_announcements.dart';
+import 'package:rep_foundry/features/trainer/presentation/providers/trainer_settings_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _Entitled implements EntitlementService {
+  @override
+  bool has(Entitlement entitlement) => true;
+}
+
+class _NotEntitled implements EntitlementService {
+  @override
+  bool has(Entitlement entitlement) => false;
+}
+
+ProviderContainer _container({
+  bool entitled = true,
+  bool enabled = true,
+  bool disclaimerAccepted = true,
+  bool countdownsEnabled = true,
+}) {
+  final container = ProviderContainer(
+    overrides: [
+      entitlementServiceProvider
+          .overrideWithValue(entitled ? _Entitled() : _NotEntitled()),
+    ],
+  );
+  addTearDown(container.dispose);
+
+  // Seeded synchronously: the notifier's async load would otherwise land
+  // after the assertion and mask the state under test.
+  container.read(trainerSettingsProvider.notifier).state = TrainerSettings(
+    enabled: enabled,
+    disclaimerAccepted: disclaimerAccepted,
+    countdownsEnabled: countdownsEnabled,
+  );
+  return container;
+}
+
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  group('coachAnnouncesRestEndProvider', () {
+    test(
+        'true when the coach is entitled, enabled, consented, and counting '
+        'down', () {
+      expect(_container().read(coachAnnouncesRestEndProvider), isTrue);
+    });
+
+    test('false without the entitlement', () {
+      expect(
+        _container(entitled: false).read(coachAnnouncesRestEndProvider),
+        isFalse,
+      );
+    });
+
+    test('false when the coach is switched off', () {
+      expect(
+        _container(enabled: false).read(coachAnnouncesRestEndProvider),
+        isFalse,
+      );
+    });
+
+    test('false when the safety disclaimer has not been accepted', () {
+      expect(
+        _container(disclaimerAccepted: false)
+            .read(coachAnnouncesRestEndProvider),
+        isFalse,
+      );
+    });
+
+    test('false when rest countdowns are switched off', () {
+      // RestFinished is a countdown-priority cue, so this toggle silences it
+      // and the chime must come back.
+      expect(
+        _container(countdownsEnabled: false)
+            .read(coachAnnouncesRestEndProvider),
+        isFalse,
+      );
+    });
+
+    test('follows the settings as they change', () {
+      final container = _container();
+      expect(container.read(coachAnnouncesRestEndProvider), isTrue);
+
+      container.read(trainerSettingsProvider.notifier).state =
+          const TrainerSettings(
+        enabled: true,
+        disclaimerAccepted: true,
+        countdownsEnabled: false,
+      );
+
+      expect(container.read(coachAnnouncesRestEndProvider), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Fixes #97 — found during on-device verification of the trainer feature, not by any test.

## The problem

At the end of a rest period the coach speaks its end-of-rest line and the rest-timer chime plays. The coach asks only to *duck* other audio (`AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK`); the chime asks for *exclusive* focus (`AUDIOFOCUS_GAIN`) about 0.3 s later. Android then propagates focus loss to the coach, truncating a line that was 4.19 s of synthesised audio.

Both subsystems were individually correct and fully tested. The conflict existed only in the shared Android audio-focus stack, which is why it took a real device to see.

## The fix

A new `coachAnnouncesRestEndProvider` mirrors exactly the conditions `CoachBridge` applies before speaking — entitled, enabled, consent accepted, and countdowns on. The chime stands down only when all four hold, which is precisely when it is redundant: the spoken line already says rest is over.

The chime returns whenever the coach is unentitled, switched off, without consent, or has countdowns disabled, so nobody who has not unlocked the coach loses their timer sound. Vibration is untouched — haptics do not contend for audio focus.

`countdownsEnabled` is included deliberately: the end-of-rest cue carries *countdown* priority, so switching countdowns off silences the coach and the chime must come back.

## Verification

Same measurement that found the bug, on the same Galaxy S9+ — a genuine before/after rather than an impression.

Before:
```
07:15:28.883 requestAudioFocus() ... FlutterTtsPlugin ... req=3
07:15:29.202 requestAudioFocus() ... audioplayers.ModernFocusManager ... req=1
07:15:29.203 propagateFocusLossFromGain_syncMAF, 1     <- coach loses focus to the chime
```

After:
```
09:51:05.064 requestAudioFocus() ... FlutterTtsPlugin ... req=3
09:51:05.065 propagateFocusLossFromGain_syncMAF, 3     <- the coach's own duck request
09:51:06.644 abandonAudioFocus() ... FlutterTtsPlugin
audioplayers focus requests: 0
Samsung TTS syntheses: 2
```

The coach still speaks (2 syntheses), the chime no longer fires at all, and the only remaining `propagateFocusLossFromGain` is the coach's own `req=3` telling other players to duck — which is the intended behaviour, not focus theft.

Checking the coach still speaks was the point: "the chime no longer interrupts the coach" is trivially satisfiable by having no coach at all.

## Test coverage, honestly

Six unit tests cover the provider, including the `countdownsEnabled` case.

The widget wiring itself is **not** covered. `AudioPlayer` is constructed directly in `initState`, so there is no seam to assert "did not play" without refactoring pre-existing code — wider than this fix warrants. The logic is fully tested, the wiring is a single readable condition, and the device measurement above is what confirms the two are joined correctly.

1192 tests passing, `dart analyze` clean, `dart format` clean.
