### PR TITLE
feat: heart-rate-aware coaching (phase 2a)

### DIFF
--- a/docs/superpowers/plans/2026-08-02-virtual-trainer-phase-2a-hr-coaching.md
+++ b/docs/superpowers/plans/2026-08-02-virtual-trainer-phase-2a-hr-coaching.md
@@ -1,0 +1,517 @@
+# Virtual Trainer Phase 2a — HR-Aware Coaching Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the coach heart-rate aware — announcing training-zone changes, warning when the user exceeds their safe maximum, and falling silent on encouragement whenever doing so could push someone at risk harder.
+
+**Architecture:** A new event source watches the existing BLE heart-rate stream, maps each reading to a zone via `zoneConfigurationProvider`, and emits typed `TrainerEvent`s onto the existing bus. The `CoachingEngine` gains safety-priority handling for those events plus suppression rules that override its ordinary behaviour. Nothing about the transport, speech service, or bridge changes shape — this is a new event producer plus new engine rules.
+
+**Tech Stack:** Flutter, Riverpod, `hr_zones` 0.0.2, existing `HeartRateService` (BLE), `flutter_tts`, `flutter_test`.
+
+**Spec:** `docs/superpowers/specs/2026-08-01-virtual-personal-trainer-design.md` §6
+**Issue:** #91. Content work (Hype/Sergeant personas, quote bank) is #99 and explicitly **out of scope here**.
+
+## Global Constraints
+
+- Use `gradle21w` in place of `./gradlew`. Use `python3` in place of `python`.
+- **British spelling** in all code, comments, strings, and commit messages ("behaviour", "colour"). Flutter API names keep their spelling.
+- Author is **Paul Snow**. No AI-assistant references anywhere.
+- Domain and application layers are **pure Dart** — no `package:flutter`, no `dart:ui`.
+- All user-facing strings in `lib/l10n/app_en.arb` via `S.of(context)!`; run `flutter gen-l10n` and commit generated output.
+- Widget tests need `localizationsDelegates: S.localizationsDelegates` and `supportedLocales: S.supportedLocales`, plus `SharedPreferences.setMockInitialValues({})` in `setUp`.
+- Strict lints: `always_declare_return_types`, `prefer_const_constructors`, `prefer_final_fields`, `prefer_final_locals`. `dart analyze` must report zero issues.
+- `dart format --set-exit-if-changed .` must pass before every commit.
+- Full `flutter test` suite (currently 1192) must pass; pre-existing tests must not be weakened.
+- **Content rules for every spoken phrase:** never urge load increases, never "push through pain", no ego-lifting, no body-shaming, no guilt framing. Safety phrases must be calm and directive, never alarming.
+- Every new phrase key needs a `phraseResolvers` entry (`phrase_resolver.dart`) **and** must be added to the persona-pack tests' loops — those iterate `steadyPersona` only, and a missing resolver means the coach silently says nothing.
+- Commit per task on one branch, `feat/91-hr-aware-coaching`. Do not open per-task branches.
+
+## Existing code this builds on — read before starting
+
+- `lib/features/trainer/domain/trainer_event.dart` — `sealed class TrainerEvent`, `TrainerEventKind`.
+- `lib/features/trainer/domain/coaching_cue.dart` — `SpeechPriority { encouragement, milestone, countdown, safety }`. **`safety` is currently unreachable; this plan is what makes it real.**
+- `lib/features/trainer/application/coaching_engine.dart` — `onEvent(event, {required now, countdownsEnabled, encouragementEnabled})`.
+- `lib/features/trainer/presentation/providers/coach_bridge.dart` — subscribes to the bus, resolves phrase keys, speaks.
+- `lib/features/trainer/presentation/providers/trainer_event_bus.dart` — `emit` applies the entitlement gate internally.
+- `lib/features/heart_rate/presentation/providers/zone_configuration_provider.dart` — `zoneConfigurationProvider` (`ZoneConfiguration?`) and `cautionModeProvider` (`bool`).
+- `lib/features/cardio/data/heart_rate_service.dart` — `Stream<int> get heartRateStream`.
+- `hr_zones` 0.0.2: `ZoneConfiguration { List<CalculatedZone> zones; int maxHr; ZoneMethod method; ZoneReliability reliability; }`, `CalculatedZone { int zoneNumber; String label; String effortLabel; String descriptiveLabel; int lowerBound; int? upperBound; }`. There is **no** built-in "zone for a given bpm" lookup — Task 1 adds one.
+- `lib/features/heart_rate/presentation/providers/max_hr_alert_provider.dart` — the **existing** max-HR alert (sound + haptic + cooldown), fired from `heart_rate_panel_screen.dart`.
+
+## Two decisions already taken — do not revisit
+
+1. **The existing max-HR alert stays as the attention-getter.** A chime cuts through instantly; a spoken line takes ~2 s. The coach speaks its guidance *after* the alert, never over it. This is the #97 lesson: exactly one owner of a given audio moment.
+2. **The existing alert only fires while the HR panel screen is mounted.** During a workout with the panel closed, nothing warns the user today. The coach's bridge is app-wide, so this plan closes that gap — Task 4 tests it explicitly.
+
+---
+
+### Task 1: Zone lookup and HR trainer events
+
+Pure Dart. No streams, no Flutter.
+
+**Files:**
+- Create: `lib/features/trainer/domain/hr_zone_lookup.dart`
+- Modify: `lib/features/trainer/domain/trainer_event.dart`
+- Test: `test/features/trainer/domain/hr_zone_lookup_test.dart`
+
+**Interfaces:**
+- Produces:
+  - `int? zoneNumberFor(ZoneConfiguration config, int bpm)` — the zone containing `bpm`, or null below zone 1. Top zone has a null `upperBound` and extends to `config.maxHr` and beyond.
+  - New `TrainerEvent` subclasses: `HeartRateZoneChanged({required int zoneNumber, required String effortLabel, required String descriptiveLabel})`, `HeartRateAboveCap({required int bpm, required int cap})`, `HeartRateBackBelowCap()`.
+  - New `TrainerEventKind` values: `hrZoneChanged`, `hrAboveCap`, `hrBackBelowCap`.
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hr_zones/hr_zones.dart';
+import 'package:rep_foundry/features/trainer/domain/hr_zone_lookup.dart';
+
+ZoneConfiguration _config() => calculateZones(
+      const HealthProfile(age: 40),
+    )!;
+
+void main() {
+  group('zoneNumberFor', () {
+    test('returns null below the bottom of zone 1', () {
+      final config = _config();
+      final belowZone1 = config.zones.first.lowerBound - 1;
+
+      expect(zoneNumberFor(config, belowZone1), isNull);
+    });
+
+    test('returns the zone containing the reading', () {
+      final config = _config();
+      for (final zone in config.zones) {
+        expect(zoneNumberFor(config, zone.lowerBound), zone.zoneNumber,
+            reason: 'lower bound of zone ${zone.zoneNumber} is inclusive');
+      }
+    });
+
+    test('an upper bound belongs to the next zone up, not its own', () {
+      final config = _config();
+      final zone1 = config.zones.first;
+
+      expect(zoneNumberFor(config, zone1.upperBound!), 2);
+    });
+
+    test('readings above the top zone stay in the top zone', () {
+      final config = _config();
+
+      expect(zoneNumberFor(config, config.maxHr + 40),
+          config.zones.last.zoneNumber);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `flutter test test/features/trainer/domain/hr_zone_lookup_test.dart`
+Expected: FAIL — `hr_zone_lookup.dart` does not exist.
+
+- [ ] **Step 3: Implement the lookup**
+
+Create `lib/features/trainer/domain/hr_zone_lookup.dart`:
+
+```dart
+import 'package:hr_zones/hr_zones.dart';
+
+/// The zone containing [bpm], or null when the reading sits below zone 1.
+///
+/// Bounds follow the package's convention: `lowerBound` inclusive,
+/// `upperBound` exclusive. The top zone has a null `upperBound` and absorbs
+/// everything above it — a reading past the configured maximum is still "in"
+/// the top zone, and the above-cap warning is what handles that case.
+int? zoneNumberFor(ZoneConfiguration config, int bpm) {
+  for (final zone in config.zones) {
+    if (bpm < zone.lowerBound) continue;
+    final upper = zone.upperBound;
+    if (upper == null || bpm < upper) return zone.zoneNumber;
+  }
+  return bpm >= config.zones.first.lowerBound
+      ? config.zones.last.zoneNumber
+      : null;
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `flutter test test/features/trainer/domain/hr_zone_lookup_test.dart`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Add the three events**
+
+In `lib/features/trainer/domain/trainer_event.dart`, add `hrZoneChanged`, `hrAboveCap`, `hrBackBelowCap` to `TrainerEventKind`, then:
+
+```dart
+/// The user has settled into a different training zone.
+class HeartRateZoneChanged extends TrainerEvent {
+  const HeartRateZoneChanged({
+    required this.zoneNumber,
+    required this.effortLabel,
+    required this.descriptiveLabel,
+  });
+
+  final int zoneNumber;
+  final String effortLabel;
+  final String descriptiveLabel;
+
+  @override
+  TrainerEventKind get kind => TrainerEventKind.hrZoneChanged;
+}
+
+/// The heart rate has crossed the user's safe maximum. Re-emitted while it
+/// stays there so the coach can repeat its warning.
+class HeartRateAboveCap extends TrainerEvent {
+  const HeartRateAboveCap({required this.bpm, required this.cap});
+
+  final int bpm;
+  final int cap;
+
+  @override
+  TrainerEventKind get kind => TrainerEventKind.hrAboveCap;
+}
+
+class HeartRateBackBelowCap extends TrainerEvent {
+  const HeartRateBackBelowCap();
+
+  @override
+  TrainerEventKind get kind => TrainerEventKind.hrBackBelowCap;
+}
+```
+
+Adding to a `sealed` hierarchy makes the engine's `switch` non-exhaustive — that is intentional and Task 2 fixes it. The analyser error between steps is expected.
+
+- [ ] **Step 6: Full suite, analyse, format, commit**
+
+Run: `flutter test && dart analyze && dart format --set-exit-if-changed .`
+
+```bash
+git checkout -b feat/91-hr-aware-coaching
+git add lib/features/trainer/domain test/features/trainer/domain
+git commit -m "feat: heart rate zone lookup and trainer events
+
+Adds a zone-for-bpm lookup over the hr_zones configuration and the three
+heart-rate events the coach reacts to: settling into a new zone, crossing
+the safe maximum, and returning below it.
+
+Refs #91"
+```
+
+---
+
+### Task 2: Engine safety rules
+
+The heart of this issue. Pure Dart, TDD, and the first use of `SpeechPriority.safety`.
+
+**Files:**
+- Modify: `lib/features/trainer/application/coaching_engine.dart`
+- Test: `test/features/trainer/application/coaching_engine_hr_test.dart`
+
+**Interfaces:**
+- Consumes: Task 1's events and kinds.
+- Produces: `onEvent` gains two named parameters — `bool hrCalloutsEnabled = true`, `bool cautionMode = false` — and the engine gains `bool get isAboveCap`.
+
+**The rules, from spec §6. Every one needs a test that fails without it.**
+
+1. Above cap, the engine returns a **safety** cue for `HeartRateAboveCap`, and repeats it no more often than every 30 s while it stays above.
+2. While above cap, **all encouragement is suppressed** — `SetLogged`, zone callouts, everything except safety and countdown cues. Returning below cap lifts the suppression.
+3. In **caution mode**, zone callouts remain but are informational; no encouragement is produced at any intensity.
+4. Encouragement never fires when the current zone is **5** — the Zone 4 ceiling from the spec.
+5. `hrCalloutsEnabled == false` silences zone callouts but **never** silences cap warnings.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/features/trainer/application/coaching_engine_hr_test.dart`. Cover, one test each:
+
+```dart
+// Sketch of the shape; write all nine, each asserting one rule.
+test('above cap produces a safety-priority cue', () {
+  final engine = _engine();
+  final cue = engine.onEvent(
+    const HeartRateAboveCap(bpm: 180, cap: 170),
+    now: t0,
+  );
+
+  expect(cue, isNotNull);
+  expect(cue!.priority, SpeechPriority.safety);
+  expect(cue.args['bpm'], 180);
+});
+
+test('the cap warning repeats no more than every 30 seconds', () {
+  final engine = _engine();
+  engine.onEvent(const HeartRateAboveCap(bpm: 180, cap: 170), now: t0);
+
+  final tooSoon = engine.onEvent(
+    const HeartRateAboveCap(bpm: 182, cap: 170),
+    now: t0.add(const Duration(seconds: 10)),
+  );
+  final later = engine.onEvent(
+    const HeartRateAboveCap(bpm: 182, cap: 170),
+    now: t0.add(const Duration(seconds: 31)),
+  );
+
+  expect(tooSoon, isNull);
+  expect(later, isNotNull);
+});
+
+test('encouragement is suppressed entirely while above cap', () {
+  final engine = _engine(encouragementEverySets: 1, cooldown: Duration.zero);
+  engine.onEvent(const HeartRateAboveCap(bpm: 180, cap: 170), now: t0);
+
+  final cue = engine.onEvent(
+    const SetLogged(setNumber: 1, isPersonalRecord: false),
+    now: t0.add(const Duration(seconds: 5)),
+  );
+
+  expect(cue, isNull);
+});
+
+test('dropping back below the cap lifts the suppression', () {
+  final engine = _engine(encouragementEverySets: 1, cooldown: Duration.zero);
+  engine.onEvent(const HeartRateAboveCap(bpm: 180, cap: 170), now: t0);
+  engine.onEvent(const HeartRateBackBelowCap(),
+      now: t0.add(const Duration(seconds: 20)));
+
+  final cue = engine.onEvent(
+    const SetLogged(setNumber: 1, isPersonalRecord: false),
+    now: t0.add(const Duration(seconds: 25)),
+  );
+
+  expect(cue, isNotNull);
+});
+
+test('a personal record is still suppressed above cap', () {
+  // PRs are milestone priority and normally bypass the cooldown, so they are
+  // the most likely cue to escape the safety suppression.
+  final engine = _engine();
+  engine.onEvent(const HeartRateAboveCap(bpm: 180, cap: 170), now: t0);
+
+  final cue = engine.onEvent(
+    const SetLogged(setNumber: 1, isPersonalRecord: true),
+    now: t0.add(const Duration(seconds: 5)),
+  );
+
+  expect(cue, isNull);
+});
+
+test('caution mode produces zone callouts but no encouragement', () {
+  final engine = _engine(encouragementEverySets: 1, cooldown: Duration.zero);
+
+  final zone = engine.onEvent(
+    const HeartRateZoneChanged(
+        zoneNumber: 3, effortLabel: 'Moderate', descriptiveLabel: 'Aerobic'),
+    now: t0,
+    cautionMode: true,
+  );
+  final encouragement = engine.onEvent(
+    const SetLogged(setNumber: 1, isPersonalRecord: false),
+    now: t0.add(const Duration(minutes: 1)),
+    cautionMode: true,
+  );
+
+  expect(zone, isNotNull);
+  expect(encouragement, isNull);
+});
+
+test('encouragement never fires in zone 5', () {
+  final engine = _engine(encouragementEverySets: 1, cooldown: Duration.zero);
+  engine.onEvent(
+    const HeartRateZoneChanged(
+        zoneNumber: 5, effortLabel: 'Maximum', descriptiveLabel: 'VO₂ Max'),
+    now: t0,
+  );
+
+  final cue = engine.onEvent(
+    const SetLogged(setNumber: 1, isPersonalRecord: false),
+    now: t0.add(const Duration(minutes: 1)),
+  );
+
+  expect(cue, isNull);
+});
+
+test('hrCalloutsEnabled false silences zone callouts', () {
+  final engine = _engine();
+
+  final cue = engine.onEvent(
+    const HeartRateZoneChanged(
+        zoneNumber: 3, effortLabel: 'Moderate', descriptiveLabel: 'Aerobic'),
+    now: t0,
+    hrCalloutsEnabled: false,
+  );
+
+  expect(cue, isNull);
+});
+
+test('hrCalloutsEnabled false still allows cap warnings', () {
+  // The safety path must not be switchable off by a convenience toggle.
+  final engine = _engine();
+
+  final cue = engine.onEvent(
+    const HeartRateAboveCap(bpm: 180, cap: 170),
+    now: t0,
+    hrCalloutsEnabled: false,
+  );
+
+  expect(cue, isNotNull);
+  expect(cue!.priority, SpeechPriority.safety);
+});
+```
+
+Each must fail against the current engine before you implement. Verify that, do not assume it.
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `flutter test test/features/trainer/application/coaching_engine_hr_test.dart`
+Expected: FAIL on every test.
+
+- [ ] **Step 3: Implement the rules**
+
+In `coaching_engine.dart`: track `bool _aboveCap = false` and `DateTime? _lastCapWarningAt`, plus `int? _currentZone`, all cleared by `reset()`. Add the two named parameters. Extend the `switch` with the three new events, and gate every encouragement-producing branch behind `!_aboveCap && !cautionMode && _currentZone != 5`.
+
+Put the suppression check in **one** place that all encouragement paths pass through rather than repeating it per branch — a scattered rule is how a future persona or event kind quietly escapes it.
+
+Keep the existing decision-before-recording property: a suppressed cue must not consume a phrase from the variety bank nor move the cooldown. That was a review finding in phase 1; do not regress it.
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `flutter test test/features/trainer/application/coaching_engine_hr_test.dart` then the full suite.
+Expected: all pass, including every pre-existing engine test unchanged.
+
+- [ ] **Step 5: Check coverage**
+
+Run: `flutter test --coverage test/features/trainer/`
+Expected: `coaching_engine.dart` still ≥80% (it was 100%). Add tests for uncovered branches rather than lowering the bar.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/features/trainer/application test/features/trainer/application
+git commit -m "feat: heart rate safety rules in the coaching engine
+
+Above the user's safe maximum the coach stops encouraging entirely and
+repeats a calm ease-off warning at most every thirty seconds. Caution mode
+reduces zone callouts to information only, and encouragement never fires in
+zone five.
+
+Refs #91"
+```
+
+---
+
+### Task 3: HR event source
+
+Turns the BLE stream into trainer events, with the hysteresis that stops the coach chattering at a zone boundary.
+
+**Files:**
+- Create: `lib/features/trainer/presentation/providers/hr_event_source.dart`
+- Test: `test/features/trainer/presentation/hr_event_source_test.dart`
+
+**Interfaces:**
+- Consumes: `heartRateServiceProvider`'s `heartRateStream`, `zoneConfigurationProvider`, `cautionModeProvider`, `trainerEventBusProvider`, Task 1's lookup and events.
+- Produces: `hrEventSourceProvider` — a `Provider<HrEventSource>` mounted alongside the bridge; `class HrEventSource { HrEventSource(this._ref, {Duration zoneDwell = const Duration(seconds: 10), Duration capRepeat = const Duration(seconds: 30)}); void dispose(); }`.
+
+**Behaviour:**
+- A zone change is emitted only after the reading has **stayed** in the new zone for `zoneDwell` (default 10 s). Without this the coach announces a zone change on every boundary flicker — the single most likely way this feature becomes intolerable.
+- `HeartRateAboveCap` is emitted on the first reading above `config.maxHr`, then re-emitted every `capRepeat` while it stays above. The engine also rate-limits; belt and braces is deliberate for a safety path.
+- `HeartRateBackBelowCap` on the first reading back below, once.
+- Nothing is emitted when `zoneConfigurationProvider` is null (no usable profile).
+- Emission goes through `trainerEventBusProvider.emit`, which already applies the entitlement gate.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create the test with a controllable stream and `fake_async`. Cover: no emission before dwell elapses; one emission after; no repeat while the zone holds; cap crossing emits immediately; cap repeat at 30 s not before; back-below emits once; null zone config emits nothing; `dispose()` cancels the subscription.
+
+Use a fake `HeartRateService` exposing a `StreamController<int>` you drive directly — do not touch BLE.
+
+- [ ] **Step 2: Run to verify they fail**
+
+Expected: FAIL — `hr_event_source.dart` does not exist.
+
+- [ ] **Step 3: Implement**
+
+Subscribe to `heartRateStream`; on each reading resolve the zone via `zoneNumberFor`; track a candidate zone and the time it was first seen, promoting it to `_currentZone` and emitting only once `zoneDwell` has passed. Track above/below cap separately from zones — a reading can be above the cap while still nominally in the top zone.
+
+Use `clock.now()` from `package:clock` (already a dependency) rather than `DateTime.now()`, so `fake_async` controls time in tests.
+
+- [ ] **Step 4: Run to verify they pass**, then the full suite.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/trainer/presentation/providers/hr_event_source.dart test/features/trainer/presentation
+git commit -m "feat: heart rate event source feeding the coach
+
+Maps the BLE heart rate stream onto trainer events, requiring a ten second
+dwell before announcing a zone change so boundary flicker cannot make the
+coach chatter, and re-emitting the above-cap event every thirty seconds
+while the reading stays high.
+
+Refs #91"
+```
+
+---
+
+### Task 4: Wire it up, settings, and phrases
+
+**Files:**
+- Modify: `lib/features/trainer/presentation/providers/coach_bridge.dart` (pass the new engine parameters)
+- Modify: `lib/features/trainer/presentation/providers/trainer_settings_provider.dart` (two new settings)
+- Modify: `lib/features/trainer/presentation/screens/trainer_settings_screen.dart`
+- Modify: `lib/features/trainer/data/persona_packs.dart`, `lib/features/trainer/presentation/providers/phrase_resolver.dart`, `lib/l10n/app_en.arb`
+- Modify: `lib/app/router.dart` (mount the HR event source beside the bridge)
+- Modify: `lib/features/heart_rate/presentation/screens/heart_rate_panel_screen.dart` (sequencing with the existing alert)
+- Test: `test/features/trainer/presentation/hr_coaching_integration_test.dart`, plus additions to the persona-pack and settings tests
+
+**Settings:** `hrCalloutsEnabled` (default true) and `hrSafetyWarningsEnabled` (**default true**, listed last, with copy explaining why leaving it on is recommended). Preference keys `trainer_hr_callouts` and `trainer_hr_safety`. `hrSafetyWarningsEnabled == false` must still be honoured — the user may switch it off — but the setting is presented as the one to leave alone.
+
+**Phrases** — add to the Steady pack and `phraseResolvers`, and **add every new key to the persona-pack test loops**:
+
+```json
+  "coachSteadyZone": "Zone {zoneNumber} — {effortLabel}.",
+  "coachSteadyAboveCap1": "Your heart rate is above your maximum. Ease off and bring it down.",
+  "coachSteadyAboveCap2": "Still above your maximum. Slow down, breathe.",
+  "coachSteadyBackBelowCap": "Good — you're back under your maximum.",
+```
+
+Calm and directive, never alarming. `coachSteadyAboveCap*` must never suggest continuing.
+
+**Sequencing with the existing alert (decision 1):** in `heart_rate_panel_screen.dart`, the alert keeps firing exactly as it does today. The coach's warning must land *after* it, not with it. Implement by having the HR event source delay the first `HeartRateAboveCap` emission by the alert's duration (~1.5 s) when `maxHrAlertProvider.soundEnabled` is true and the panel is mounted. Do not suppress the alert — that is the opposite of the #97 fix here, because the chime is the faster signal.
+
+- [ ] **Step 1: Settings + phrases + resolver, TDD as in phase 1.**
+- [ ] **Step 2: Bridge passes `hrCalloutsEnabled` and `cautionMode` into `onEvent`;** read `cautionModeProvider` for the latter. Cap warnings pass through when `hrSafetyWarningsEnabled` is true.
+- [ ] **Step 3: Mount `hrEventSourceProvider`** beside `coachBridgeProvider` in the router shell, disposed the same way. **Verify exactly one instance exists** — this is the defect that shipped in phase 1 (`Provider.family` is not `autoDispose`), so write the test that would catch a duplicate.
+- [ ] **Step 4: Integration test** — pump readings through a fake HR service into a real container with `SilentSpeechService`, and assert the full path: zone change after dwell speaks; cap crossing speaks a safety line; encouragement goes silent above cap and returns below it.
+- [ ] **Step 5: Test the gap closure from decision 2** — with the HR panel *not* mounted, a cap crossing still produces a spoken warning. This is the user-visible benefit of the issue and it must not regress.
+- [ ] **Step 6:** `flutter gen-l10n`, full suite, analyse, format, commit.
+
+---
+
+### Task 5: Device verification (Polar H9 + Galaxy S9+)
+
+Not automatable. Phase 1 shipped a defect that every test and six reviews missed because it lived in a shared platform resource; this task exists so that does not repeat.
+
+- [ ] **Step 1:** Build and install on the S9+ (`flutter run -d <id> --debug --flavor dev`). Pair the Polar H9.
+- [ ] **Step 2:** Confirm zone callouts fire on real readings, and that boundary flicker does **not** produce repeated announcements — wear the strap through a zone boundary deliberately.
+- [ ] **Step 3:** Provoke a cap crossing (lower the clinician cap in the health profile to just above resting HR to make this safe and repeatable — do **not** ask anyone to exercise to their real maximum). Confirm the alert fires first and the coach's line follows it intact, not clipped.
+- [ ] **Step 4:** Capture `adb logcat | grep MediaFocusControl` across the crossing. Success: the coach's `req=3` request, no `propagateFocusLossFromGain` against it while it holds focus, and a clean `abandonAudioFocus`. This is the same measurement that found and verified #97.
+- [ ] **Step 5:** Confirm the coach warns with the HR panel closed (decision 2's gap).
+- [ ] **Step 6:** Record all findings on #91 — including anything that fails.
+
+---
+
+## Verification checklist
+
+- [ ] `flutter test` green; `dart analyze` zero issues; `dart format` clean
+- [ ] `coaching_engine.dart` coverage ≥80%
+- [ ] Every new phrase key has a resolver entry AND appears in the persona-pack test loops
+- [ ] Encouragement provably silent above cap, in caution mode, and in zone 5
+- [ ] Cap warnings survive `hrCalloutsEnabled == false`
+- [ ] Exactly one `HrEventSource` instance, with a test proving it
+- [ ] Device matrix recorded on #91
+- [ ] With no entitlement, nothing changes: no HR subscription, no events, no audio
+
+## Out of scope
+
+Hype and Sergeant personas and the quote bank are #99. Exercise auto-detection is #92. Background operation is #93.

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -22,6 +22,7 @@ import '../features/clients/presentation/screens/client_roster_screen.dart';
 import '../features/clients/presentation/widgets/client_switcher.dart';
 import '../features/clients/presentation/screens/client_detail_screen.dart';
 import '../features/trainer/presentation/providers/coach_bridge.dart';
+import '../features/trainer/presentation/providers/hr_event_source.dart';
 import '../features/trainer/presentation/screens/trainer_settings_screen.dart';
 import '../core/entitlements/entitlement.dart';
 import '../core/entitlements/entitlement_provider.dart';
@@ -46,6 +47,14 @@ final routerProvider = Provider<GoRouter>((ref) {
             // updates the existing subscription instead of leaking a second,
             // still-listening bridge.
             ref.read(coachBridgeProvider).strings = S.of(context)!;
+            // Mounted alongside the bridge, for the same reason and with
+            // the same non-family Provider shape: it turns heart-rate
+            // readings into trainer events for the life of the app shell,
+            // regardless of which tab is active, and reading it again on
+            // rebuild returns the same instance rather than leaking a
+            // second, still-subscribed source (see hrEventSourceProvider's
+            // lifecycle tests).
+            ref.read(hrEventSourceProvider);
             return ScaffoldWithNavBar(
               railFooter: const ClientSwitcher(),
               child: child,

--- a/lib/features/heart_rate/presentation/providers/heart_rate_panel_visibility_provider.dart
+++ b/lib/features/heart_rate/presentation/providers/heart_rate_panel_visibility_provider.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Whether the heart rate panel screen is currently mounted.
+///
+/// In-memory only, no `SharedPreferences` — this is a widget-lifecycle
+/// signal, not a persisted setting. `HrEventSource` reads it to decide
+/// whether the panel's own max-HR alert chime is about to sound, so the
+/// coach's cap warning can be delayed to land after it rather than talking
+/// over it (see the sequencing decision in the phase 2a HR coaching spec).
+class HeartRatePanelVisibilityNotifier extends Notifier<bool> {
+  @override
+  bool build() => false;
+
+  void setVisible(bool value) => state = value;
+}
+
+final heartRatePanelVisibleProvider =
+    NotifierProvider<HeartRatePanelVisibilityNotifier, bool>(
+  HeartRatePanelVisibilityNotifier.new,
+);

--- a/lib/features/heart_rate/presentation/screens/heart_rate_panel_screen.dart
+++ b/lib/features/heart_rate/presentation/screens/heart_rate_panel_screen.dart
@@ -19,6 +19,7 @@ import '../controllers/heart_rate_panel_controller.dart';
 import '../controllers/heart_rate_panel_state.dart';
 import '../providers/chart_window_provider.dart';
 import '../providers/health_profile_provider.dart';
+import '../providers/heart_rate_panel_visibility_provider.dart';
 import '../providers/max_hr_alert_provider.dart';
 import '../providers/zone_bands_provider.dart';
 import '../providers/zone_configuration_provider.dart';
@@ -43,11 +44,23 @@ class _HeartRatePanelScreenState extends ConsumerState<HeartRatePanelScreen> {
   AudioPlayer? _alertPlayer;
   DateTime? _lastMaxHrAlert;
 
+  /// Captured in [initState] because `ref`/`context` are no longer usable
+  /// once this widget has disposed, and [dispose] needs to reach the
+  /// container to clear [heartRatePanelVisibleProvider].
+  late final ProviderContainer _providerContainer;
+
   @override
   void initState() {
     super.initState();
     _alertPlayer = AudioPlayer();
+    _providerContainer = ProviderScope.containerOf(context, listen: false);
     WidgetsBinding.instance.addPostFrameCallback((_) {
+      // Lets HrEventSource know the panel's own max-HR alert chime may
+      // sound, so it can sequence the coach's cap warning to land after it
+      // rather than talking over it. Deferred to the post-frame callback,
+      // like the rest of this method — Riverpod disallows modifying a
+      // provider synchronously during initState/build.
+      ref.read(heartRatePanelVisibleProvider.notifier).setVisible(true);
       _onFirstVisit();
 
       // If cardio already has HR connected, sync it.
@@ -80,6 +93,22 @@ class _HeartRatePanelScreenState extends ConsumerState<HeartRatePanelScreen> {
 
   @override
   void dispose() {
+    // Deferred to a microtask: Riverpod disallows modifying a provider
+    // synchronously during dispose, since element unmounting happens inside
+    // Flutter's own build/frame pipeline. Guarded against StateError because
+    // the container itself (e.g. the whole app, or a test's ProviderScope)
+    // can finish tearing down before this microtask runs — `disposed` is an
+    // `@internal` test-only getter, so a disposed read is caught instead of
+    // checked for up front.
+    Future.microtask(() {
+      try {
+        _providerContainer
+            .read(heartRatePanelVisibleProvider.notifier)
+            .setVisible(false);
+      } on StateError {
+        // Container already disposed; nothing left to clear.
+      }
+    });
     _alertPlayer?.dispose();
     super.dispose();
   }

--- a/lib/features/trainer/application/coaching_engine.dart
+++ b/lib/features/trainer/application/coaching_engine.dart
@@ -34,10 +34,20 @@ class CoachingEngine {
   final int encouragementMinSets;
   final int encouragementMaxSets;
 
+  /// Minimum gap between repeats of the above-cap warning while it holds.
+  static const Duration _capWarningRepeat = Duration(seconds: 30);
+
   final Set<String> _spokenPhrases = {};
   DateTime? _lastSpokenAt;
   int _setsSinceEncouragement = 0;
   late int _encouragementQuota;
+  bool _aboveCap = false;
+  DateTime? _lastCapWarningAt;
+  int? _currentZone;
+
+  /// Whether the last `HeartRateAboveCap`/`HeartRateBackBelowCap` event left
+  /// the reading above the user's safe maximum.
+  bool get isAboveCap => _aboveCap;
 
   /// Clears per-session state. Call when a workout starts or finishes.
   void reset() {
@@ -45,6 +55,9 @@ class CoachingEngine {
     _lastSpokenAt = null;
     _setsSinceEncouragement = 0;
     _encouragementQuota = _pickEncouragementQuota();
+    _aboveCap = false;
+    _lastCapWarningAt = null;
+    _currentZone = null;
   }
 
   /// Decides whether and what to say.
@@ -58,6 +71,8 @@ class CoachingEngine {
     required DateTime now,
     bool countdownsEnabled = true,
     bool encouragementEnabled = true,
+    bool hrCalloutsEnabled = true,
+    bool cautionMode = false,
   }) {
     return switch (event) {
       WorkoutStarted() => _speak(event.kind, SpeechPriority.milestone, now),
@@ -67,10 +82,13 @@ class CoachingEngine {
           now,
           args: {'totalSets': totalSets},
         ),
-      SetLogged(isPersonalRecord: true) =>
-        _speak(event.kind, SpeechPriority.milestone, now),
+      SetLogged(isPersonalRecord: true) => _encouragementBlocked(cautionMode)
+          ? null
+          : _speak(event.kind, SpeechPriority.milestone, now),
       SetLogged(isPersonalRecord: false) =>
-        encouragementEnabled ? _onSetLogged(now) : null,
+        (encouragementEnabled && !_encouragementBlocked(cautionMode))
+            ? _onSetLogged(now)
+            : null,
       RestCountdown(:final secondsLeft) => countdownsEnabled
           ? _speak(
               event.kind,
@@ -83,7 +101,70 @@ class CoachingEngine {
           ? _speak(event.kind, SpeechPriority.countdown, now)
           : null,
       RestStarted() => null,
+      HeartRateZoneChanged(:final zoneNumber, :final effortLabel) =>
+        _onZoneChanged(zoneNumber, effortLabel, hrCalloutsEnabled, now),
+      HeartRateAboveCap(:final bpm, :final cap) => _onAboveCap(bpm, cap, now),
+      HeartRateBackBelowCap() => _onBackBelowCap(now),
     };
+  }
+
+  /// True while no encouragement-type cue — motivational chatter or a
+  /// personal record — may be spoken: above the safety cap, in caution mode,
+  /// or once the user has reached zone 5.
+  ///
+  /// Every encouragement-producing branch in [onEvent] routes through this
+  /// single check so a future event kind cannot quietly bypass the rule.
+  bool _encouragementBlocked(bool cautionMode) =>
+      _aboveCap || cautionMode || _currentZone == 5;
+
+  /// Records the new zone unconditionally — zone 5 must be tracked even when
+  /// callouts are switched off — and speaks it unless callouts are disabled
+  /// or the reading is above cap (rule: encouragement, including zone
+  /// callouts, is suppressed while above cap).
+  CoachingCue? _onZoneChanged(
+    int zoneNumber,
+    String effortLabel,
+    bool hrCalloutsEnabled,
+    DateTime now,
+  ) {
+    _currentZone = zoneNumber;
+    if (!hrCalloutsEnabled || _aboveCap) return null;
+    return _speak(
+      TrainerEventKind.hrZoneChanged,
+      SpeechPriority.milestone,
+      now,
+      args: {'zoneNumber': zoneNumber, 'effortLabel': effortLabel},
+    );
+  }
+
+  /// Safety path: never gated by [hrCalloutsEnabled] or caution mode, and
+  /// repeats no more often than [_capWarningRepeat] while the reading stays
+  /// above the cap.
+  CoachingCue? _onAboveCap(int bpm, int cap, DateTime now) {
+    _aboveCap = true;
+    final lastWarning = _lastCapWarningAt;
+    if (lastWarning != null &&
+        now.difference(lastWarning) < _capWarningRepeat) {
+      return null;
+    }
+
+    final cue = _speak(
+      TrainerEventKind.hrAboveCap,
+      SpeechPriority.safety,
+      now,
+      args: {'bpm': bpm, 'cap': cap},
+    );
+    if (cue != null) _lastCapWarningAt = now;
+    return cue;
+  }
+
+  /// Lifts the above-cap suppression and resets the repeat timer, so a later
+  /// cap crossing warns immediately rather than inheriting a stale cooldown.
+  CoachingCue? _onBackBelowCap(DateTime now) {
+    _aboveCap = false;
+    _lastCapWarningAt = null;
+    return _speak(
+        TrainerEventKind.hrBackBelowCap, SpeechPriority.milestone, now);
   }
 
   CoachingCue? _onSetLogged(DateTime now) {

--- a/lib/features/trainer/application/coaching_engine.dart
+++ b/lib/features/trainer/application/coaching_engine.dart
@@ -115,7 +115,7 @@ class CoachingEngine {
         _onZoneChanged(zoneNumber, effortLabel, hrCalloutsEnabled, now),
       HeartRateAboveCap(:final bpm, :final cap) =>
         _onAboveCap(bpm, cap, now, hrSafetyWarningsEnabled),
-      HeartRateBackBelowCap() => _onBackBelowCap(now),
+      HeartRateBackBelowCap() => _onBackBelowCap(now, hrSafetyWarningsEnabled),
     };
   }
 
@@ -194,17 +194,18 @@ class CoachingEngine {
   /// repeat timer, so a later cap crossing warns immediately rather than
   /// inheriting a stale cooldown.
   ///
-  /// Deliberately not gated by `hrSafetyWarningsEnabled` yet — that setting
-  /// is unreachable until a caller actually surfaces it (Task 4). Whoever
-  /// wires it in here must clear `_aboveCap`/`_lastCapWarningAt` first and
-  /// only then check the toggle, the same order `_onAboveCap` follows: an
-  /// early return before clearing state would leave encouragement suppressed
-  /// for the rest of the session with no event able to lift it.
-  CoachingCue? _onBackBelowCap(DateTime now) {
+  /// `hrSafetyWarningsEnabled` is checked only *after* the state above is
+  /// cleared, the same order `_onAboveCap` follows: an early return before
+  /// clearing state would leave encouragement suppressed for the rest of the
+  /// session with no event able to lift it. A muted user still gets the
+  /// suppression lifted; they just never hear the "back under" line.
+  CoachingCue? _onBackBelowCap(DateTime now, bool hrSafetyWarningsEnabled) {
     if (!_aboveCap) return null;
 
     _aboveCap = false;
     _lastCapWarningAt = null;
+    if (!hrSafetyWarningsEnabled) return null;
+
     return _speak(
       TrainerEventKind.hrBackBelowCap,
       SpeechPriority.milestone,

--- a/lib/features/trainer/application/coaching_engine.dart
+++ b/lib/features/trainer/application/coaching_engine.dart
@@ -72,55 +72,69 @@ class CoachingEngine {
     bool countdownsEnabled = true,
     bool encouragementEnabled = true,
     bool hrCalloutsEnabled = true,
+    bool hrSafetyWarningsEnabled = true,
     bool cautionMode = false,
   }) {
     return switch (event) {
-      WorkoutStarted() => _speak(event.kind, SpeechPriority.milestone, now),
+      WorkoutStarted() => _speak(event.kind, SpeechPriority.milestone, now,
+          cautionMode: cautionMode),
       WorkoutFinished(:final totalSets) => _speak(
           event.kind,
           SpeechPriority.milestone,
           now,
           args: {'totalSets': totalSets},
+          cautionMode: cautionMode,
         ),
-      SetLogged(isPersonalRecord: true) => _encouragementBlocked(cautionMode)
-          ? null
-          : _speak(event.kind, SpeechPriority.milestone, now),
+      SetLogged(isPersonalRecord: true) => _speak(
+          event.kind,
+          SpeechPriority.milestone,
+          now,
+          cautionMode: cautionMode,
+        ),
       SetLogged(isPersonalRecord: false) =>
-        (encouragementEnabled && !_encouragementBlocked(cautionMode))
-            ? _onSetLogged(now)
-            : null,
+        encouragementEnabled ? _onSetLogged(now, cautionMode) : null,
       RestCountdown(:final secondsLeft) => countdownsEnabled
           ? _speak(
               event.kind,
               SpeechPriority.countdown,
               now,
               args: {'secondsLeft': secondsLeft},
+              encouragement: false,
             )
           : null,
       RestFinished() => countdownsEnabled
-          ? _speak(event.kind, SpeechPriority.countdown, now)
+          ? _speak(event.kind, SpeechPriority.countdown, now,
+              encouragement: false)
           : null,
       RestStarted() => null,
       HeartRateZoneChanged(:final zoneNumber, :final effortLabel) =>
         _onZoneChanged(zoneNumber, effortLabel, hrCalloutsEnabled, now),
-      HeartRateAboveCap(:final bpm, :final cap) => _onAboveCap(bpm, cap, now),
+      HeartRateAboveCap(:final bpm, :final cap) =>
+        _onAboveCap(bpm, cap, now, hrSafetyWarningsEnabled),
       HeartRateBackBelowCap() => _onBackBelowCap(now),
     };
   }
 
-  /// True while no encouragement-type cue — motivational chatter or a
-  /// personal record — may be spoken: above the safety cap, in caution mode,
-  /// or once the user has reached zone 5.
+  /// True while no encouragement-type cue — motivational chatter, a
+  /// personal record, or another milestone announcement — may be spoken:
+  /// above the safety cap, in caution mode, or once the user has reached
+  /// zone 5.
   ///
-  /// Every encouragement-producing branch in [onEvent] routes through this
-  /// single check so a future event kind cannot quietly bypass the rule.
+  /// Checked from exactly one place, [_speak] itself, so every cue the
+  /// engine can produce passes through it by default; a path that must
+  /// bypass the rule (countdowns, zone callouts, the safety cues
+  /// themselves) opts out explicitly with `encouragement: false` rather
+  /// than the rule having to be remembered at each call site.
   bool _encouragementBlocked(bool cautionMode) =>
       _aboveCap || cautionMode || _currentZone == 5;
 
   /// Records the new zone unconditionally — zone 5 must be tracked even when
   /// callouts are switched off — and speaks it unless callouts are disabled
   /// or the reading is above cap (rule: encouragement, including zone
-  /// callouts, is suppressed while above cap).
+  /// callouts, is suppressed while above cap). Exempted from the shared
+  /// encouragement gate because, unlike encouragement, a zone callout must
+  /// still fire in caution mode and in zone 5 (that event is what sets the
+  /// zone to 5 in the first place).
   CoachingCue? _onZoneChanged(
     int zoneNumber,
     String effortLabel,
@@ -134,14 +148,25 @@ class CoachingEngine {
       SpeechPriority.milestone,
       now,
       args: {'zoneNumber': zoneNumber, 'effortLabel': effortLabel},
+      encouragement: false,
     );
   }
 
-  /// Safety path: never gated by [hrCalloutsEnabled] or caution mode, and
-  /// repeats no more often than [_capWarningRepeat] while the reading stays
-  /// above the cap.
-  CoachingCue? _onAboveCap(int bpm, int cap, DateTime now) {
+  /// Safety path: never gated by [hrCalloutsEnabled], caution mode, or zone —
+  /// only by [hrSafetyWarningsEnabled], the setting the user must
+  /// deliberately switch off. The above-cap flag is recorded before that
+  /// check so encouragement suppression still applies even when the audible
+  /// warning itself is silenced. Repeats no more often than
+  /// [_capWarningRepeat] while the reading stays above the cap.
+  CoachingCue? _onAboveCap(
+    int bpm,
+    int cap,
+    DateTime now,
+    bool hrSafetyWarningsEnabled,
+  ) {
     _aboveCap = true;
+    if (!hrSafetyWarningsEnabled) return null;
+
     final lastWarning = _lastCapWarningAt;
     if (lastWarning != null &&
         now.difference(lastWarning) < _capWarningRepeat) {
@@ -153,21 +178,31 @@ class CoachingEngine {
       SpeechPriority.safety,
       now,
       args: {'bpm': bpm, 'cap': cap},
+      encouragement: false,
     );
     if (cue != null) _lastCapWarningAt = now;
     return cue;
   }
 
-  /// Lifts the above-cap suppression and resets the repeat timer, so a later
-  /// cap crossing warns immediately rather than inheriting a stale cooldown.
+  /// The reassurance cue only makes sense as the bookend to a warning the
+  /// user actually heard, so it stays silent unless the engine was actually
+  /// tracking an above-cap episode. Lifts the suppression and resets the
+  /// repeat timer, so a later cap crossing warns immediately rather than
+  /// inheriting a stale cooldown.
   CoachingCue? _onBackBelowCap(DateTime now) {
+    if (!_aboveCap) return null;
+
     _aboveCap = false;
     _lastCapWarningAt = null;
     return _speak(
-        TrainerEventKind.hrBackBelowCap, SpeechPriority.milestone, now);
+      TrainerEventKind.hrBackBelowCap,
+      SpeechPriority.milestone,
+      now,
+      encouragement: false,
+    );
   }
 
-  CoachingCue? _onSetLogged(DateTime now) {
+  CoachingCue? _onSetLogged(DateTime now, bool cautionMode) {
     _setsSinceEncouragement++;
     if (_setsSinceEncouragement < _encouragementQuota) return null;
 
@@ -180,6 +215,7 @@ class CoachingEngine {
       TrainerEventKind.setLogged,
       SpeechPriority.encouragement,
       now,
+      cautionMode: cautionMode,
     );
     if (cue != null) {
       _setsSinceEncouragement = 0;
@@ -201,7 +237,11 @@ class CoachingEngine {
     SpeechPriority priority,
     DateTime now, {
     Map<String, Object> args = const {},
+    bool encouragement = true,
+    bool cautionMode = false,
   }) {
+    if (encouragement && _encouragementBlocked(cautionMode)) return null;
+
     final phrase = _pickPhrase(kind);
     if (phrase == null) return null;
 

--- a/lib/features/trainer/application/coaching_engine.dart
+++ b/lib/features/trainer/application/coaching_engine.dart
@@ -45,6 +45,15 @@ class CoachingEngine {
   DateTime? _lastCapWarningAt;
   int? _currentZone;
 
+  /// The current call's caution-mode flag, set as the first statement of
+  /// [onEvent] and read by [_encouragementBlocked]. A field rather than a
+  /// parameter threaded through every private helper and into [_speak]: a
+  /// forgotten parameter at a new call site is exactly how milestone cues
+  /// escaped the above-cap/zone-5 gate before (see fix round 1) — a field
+  /// cannot be forgotten the same way. Not session state, so [reset] leaves
+  /// it alone; it is overwritten on every [onEvent] call before it is read.
+  bool _cautionMode = false;
+
   /// Whether the last `HeartRateAboveCap`/`HeartRateBackBelowCap` event left
   /// the reading above the user's safe maximum.
   bool get isAboveCap => _aboveCap;
@@ -75,24 +84,19 @@ class CoachingEngine {
     bool hrSafetyWarningsEnabled = true,
     bool cautionMode = false,
   }) {
+    _cautionMode = cautionMode;
     return switch (event) {
-      WorkoutStarted() => _speak(event.kind, SpeechPriority.milestone, now,
-          cautionMode: cautionMode),
+      WorkoutStarted() => _speak(event.kind, SpeechPriority.milestone, now),
       WorkoutFinished(:final totalSets) => _speak(
           event.kind,
           SpeechPriority.milestone,
           now,
           args: {'totalSets': totalSets},
-          cautionMode: cautionMode,
         ),
-      SetLogged(isPersonalRecord: true) => _speak(
-          event.kind,
-          SpeechPriority.milestone,
-          now,
-          cautionMode: cautionMode,
-        ),
+      SetLogged(isPersonalRecord: true) =>
+        _speak(event.kind, SpeechPriority.milestone, now),
       SetLogged(isPersonalRecord: false) =>
-        encouragementEnabled ? _onSetLogged(now, cautionMode) : null,
+        encouragementEnabled ? _onSetLogged(now) : null,
       RestCountdown(:final secondsLeft) => countdownsEnabled
           ? _speak(
               event.kind,
@@ -125,8 +129,8 @@ class CoachingEngine {
   /// bypass the rule (countdowns, zone callouts, the safety cues
   /// themselves) opts out explicitly with `encouragement: false` rather
   /// than the rule having to be remembered at each call site.
-  bool _encouragementBlocked(bool cautionMode) =>
-      _aboveCap || cautionMode || _currentZone == 5;
+  bool get _encouragementBlocked =>
+      _aboveCap || _cautionMode || _currentZone == 5;
 
   /// Records the new zone unconditionally — zone 5 must be tracked even when
   /// callouts are switched off — and speaks it unless callouts are disabled
@@ -189,6 +193,13 @@ class CoachingEngine {
   /// tracking an above-cap episode. Lifts the suppression and resets the
   /// repeat timer, so a later cap crossing warns immediately rather than
   /// inheriting a stale cooldown.
+  ///
+  /// Deliberately not gated by `hrSafetyWarningsEnabled` yet — that setting
+  /// is unreachable until a caller actually surfaces it (Task 4). Whoever
+  /// wires it in here must clear `_aboveCap`/`_lastCapWarningAt` first and
+  /// only then check the toggle, the same order `_onAboveCap` follows: an
+  /// early return before clearing state would leave encouragement suppressed
+  /// for the rest of the session with no event able to lift it.
   CoachingCue? _onBackBelowCap(DateTime now) {
     if (!_aboveCap) return null;
 
@@ -202,7 +213,7 @@ class CoachingEngine {
     );
   }
 
-  CoachingCue? _onSetLogged(DateTime now, bool cautionMode) {
+  CoachingCue? _onSetLogged(DateTime now) {
     _setsSinceEncouragement++;
     if (_setsSinceEncouragement < _encouragementQuota) return null;
 
@@ -215,7 +226,6 @@ class CoachingEngine {
       TrainerEventKind.setLogged,
       SpeechPriority.encouragement,
       now,
-      cautionMode: cautionMode,
     );
     if (cue != null) {
       _setsSinceEncouragement = 0;
@@ -238,9 +248,8 @@ class CoachingEngine {
     DateTime now, {
     Map<String, Object> args = const {},
     bool encouragement = true,
-    bool cautionMode = false,
   }) {
-    if (encouragement && _encouragementBlocked(cautionMode)) return null;
+    if (encouragement && _encouragementBlocked) return null;
 
     final phrase = _pickPhrase(kind);
     if (phrase == null) return null;

--- a/lib/features/trainer/data/persona_packs.dart
+++ b/lib/features/trainer/data/persona_packs.dart
@@ -40,5 +40,19 @@ const Persona steadyPersona = Persona(
       'coachSteadyFinish2',
       'coachSteadyFinish3',
     ],
+    // Heart-rate cues (phase 2a). hrAboveCap is the safety path: a persona
+    // shipped without a phrase here degrades to silence with no error (see
+    // CoachingEngine._speak), so it must never be empty — enforced in
+    // persona_packs_test.dart across every persona, not just this one.
+    TrainerEventKind.hrZoneChanged: [
+      'coachSteadyZone',
+    ],
+    TrainerEventKind.hrAboveCap: [
+      'coachSteadyAboveCap1',
+      'coachSteadyAboveCap2',
+    ],
+    TrainerEventKind.hrBackBelowCap: [
+      'coachSteadyBackBelowCap',
+    ],
   },
 );

--- a/lib/features/trainer/domain/hr_zone_lookup.dart
+++ b/lib/features/trainer/domain/hr_zone_lookup.dart
@@ -1,0 +1,18 @@
+import 'package:hr_zones/hr_zones.dart';
+
+/// The zone containing [bpm], or null when the reading sits below zone 1.
+///
+/// Bounds follow the package's convention: `lowerBound` inclusive,
+/// `upperBound` exclusive. The top zone has a null `upperBound` and absorbs
+/// everything above it — a reading past the configured maximum is still "in"
+/// the top zone, and the above-cap warning is what handles that case.
+int? zoneNumberFor(ZoneConfiguration config, int bpm) {
+  for (final zone in config.zones) {
+    if (bpm < zone.lowerBound) continue;
+    final upper = zone.upperBound;
+    if (upper == null || bpm < upper) return zone.zoneNumber;
+  }
+  return bpm >= config.zones.first.lowerBound
+      ? config.zones.last.zoneNumber
+      : null;
+}

--- a/lib/features/trainer/domain/hr_zone_lookup.dart
+++ b/lib/features/trainer/domain/hr_zone_lookup.dart
@@ -2,17 +2,9 @@ import 'package:hr_zones/hr_zones.dart';
 
 /// The zone containing [bpm], or null when the reading sits below zone 1.
 ///
-/// Bounds follow the package's convention: `lowerBound` inclusive,
-/// `upperBound` exclusive. The top zone has a null `upperBound` and absorbs
-/// everything above it — a reading past the configured maximum is still "in"
-/// the top zone, and the above-cap warning is what handles that case.
-int? zoneNumberFor(ZoneConfiguration config, int bpm) {
-  for (final zone in config.zones) {
-    if (bpm < zone.lowerBound) continue;
-    final upper = zone.upperBound;
-    if (upper == null || bpm < upper) return zone.zoneNumber;
-  }
-  return bpm >= config.zones.first.lowerBound
-      ? config.zones.last.zoneNumber
-      : null;
-}
+/// Delegates to the package's own boundary logic (`lowerBound` inclusive,
+/// `upperBound` exclusive, top zone absorbs everything above it) so there is
+/// exactly one owner of those rules rather than a second implementation that
+/// could drift from it.
+int? zoneNumberFor(ZoneConfiguration config, int bpm) =>
+    currentZoneFromConfig(bpm, config)?.zoneNumber;

--- a/lib/features/trainer/domain/trainer_event.dart
+++ b/lib/features/trainer/domain/trainer_event.dart
@@ -77,6 +77,15 @@ class WorkoutFinished extends TrainerEvent {
 }
 
 /// The user has settled into a different training zone.
+///
+/// [descriptiveLabel] (e.g. "Aerobic") is carried for parity with
+/// [CalculatedZone] and potential future display/persona use, but the
+/// steady persona's spoken cue deliberately does not use it — see
+/// `phrase_resolver.dart`'s `coachSteadyZone` entry. [effortLabel] (e.g.
+/// "Moderate") already conveys the zone's intensity in a form that reads
+/// naturally out loud; adding the descriptive label on top would lengthen
+/// the cue without giving the user anything actionable, and the same
+/// information is already visible in the zone legend UI.
 class HeartRateZoneChanged extends TrainerEvent {
   const HeartRateZoneChanged({
     required this.zoneNumber,

--- a/lib/features/trainer/domain/trainer_event.dart
+++ b/lib/features/trainer/domain/trainer_event.dart
@@ -11,6 +11,9 @@ enum TrainerEventKind {
   restFinished,
   workoutFinished,
   quote,
+  hrZoneChanged,
+  hrAboveCap,
+  hrBackBelowCap,
 }
 
 /// Something that happened in the workout that the coach may react to.
@@ -71,4 +74,39 @@ class WorkoutFinished extends TrainerEvent {
 
   @override
   TrainerEventKind get kind => TrainerEventKind.workoutFinished;
+}
+
+/// The user has settled into a different training zone.
+class HeartRateZoneChanged extends TrainerEvent {
+  const HeartRateZoneChanged({
+    required this.zoneNumber,
+    required this.effortLabel,
+    required this.descriptiveLabel,
+  });
+
+  final int zoneNumber;
+  final String effortLabel;
+  final String descriptiveLabel;
+
+  @override
+  TrainerEventKind get kind => TrainerEventKind.hrZoneChanged;
+}
+
+/// The heart rate has crossed the user's safe maximum. Re-emitted while it
+/// stays there so the coach can repeat its warning.
+class HeartRateAboveCap extends TrainerEvent {
+  const HeartRateAboveCap({required this.bpm, required this.cap});
+
+  final int bpm;
+  final int cap;
+
+  @override
+  TrainerEventKind get kind => TrainerEventKind.hrAboveCap;
+}
+
+class HeartRateBackBelowCap extends TrainerEvent {
+  const HeartRateBackBelowCap();
+
+  @override
+  TrainerEventKind get kind => TrainerEventKind.hrBackBelowCap;
 }

--- a/lib/features/trainer/presentation/providers/coach_bridge.dart
+++ b/lib/features/trainer/presentation/providers/coach_bridge.dart
@@ -1,12 +1,14 @@
 import 'dart:async';
 import 'dart:math';
 
+import 'package:clock/clock.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:rep_foundry/l10n/generated/app_localizations.dart';
 
 import '../../../../core/entitlements/entitlement.dart';
 import '../../../../core/entitlements/entitlement_provider.dart';
 import '../../../../core/entitlements/entitlement_service.dart';
+import '../../../heart_rate/presentation/providers/zone_configuration_provider.dart';
 import '../../application/coaching_engine.dart';
 import '../../data/flutter_tts_speech_service.dart';
 import '../../data/persona_packs.dart';
@@ -96,9 +98,12 @@ class CoachBridge {
     // variety bank nor restart the encouragement cooldown.
     final cue = _engine.onEvent(
       event,
-      now: DateTime.now(),
+      now: clock.now(),
       countdownsEnabled: settings.countdownsEnabled,
       encouragementEnabled: settings.encouragementEnabled,
+      hrCalloutsEnabled: settings.hrCalloutsEnabled,
+      hrSafetyWarningsEnabled: settings.hrSafetyWarningsEnabled,
+      cautionMode: _ref.read(cautionModeProvider),
     );
     if (cue != null) {
       final text = resolvePhrase(strings, cue.phraseKey, cue.args);

--- a/lib/features/trainer/presentation/providers/coach_bridge.dart
+++ b/lib/features/trainer/presentation/providers/coach_bridge.dart
@@ -110,10 +110,19 @@ class CoachBridge {
     }
 
     // Reset for the next session, but never cut off the sign-off line we just
-    // started speaking.
+    // started speaking. A null cue here can now mean two different things:
+    // no phrase was available (safe to stop), or the finish cue was
+    // suppressed because the reading is still above the safety cap — in
+    // which case a SpeechPriority.safety warning is the most likely thing
+    // still playing, and cutting it off mid-sentence is the one truncation
+    // this feature must never produce. Read isAboveCap before reset() clears
+    // it.
     if (event is WorkoutFinished) {
+      final aboveCapAtFinish = _engine.isAboveCap;
       _engine.reset();
-      if (cue == null) unawaited(_ref.read(speechServiceProvider).stop());
+      if (cue == null && !aboveCapAtFinish) {
+        unawaited(_ref.read(speechServiceProvider).stop());
+      }
     }
   }
 

--- a/lib/features/trainer/presentation/providers/hr_event_source.dart
+++ b/lib/features/trainer/presentation/providers/hr_event_source.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hr_zones/hr_zones.dart';
 
 import '../../../../core/providers.dart';
+import '../../../heart_rate/presentation/controllers/heart_rate_panel_controller.dart';
 import '../../../heart_rate/presentation/providers/heart_rate_panel_visibility_provider.dart';
 import '../../../heart_rate/presentation/providers/max_hr_alert_provider.dart';
 import '../../../heart_rate/presentation/providers/zone_configuration_provider.dart';
@@ -217,12 +218,29 @@ class HrEventSource {
 
   /// Emits the very first [HeartRateAboveCap] of a crossing — see decision 1
   /// in the phase 2a HR coaching spec. Delayed by [_aboveCapAnnounceDelay]
-  /// only when the panel's own chime is actually expected to sound (its
-  /// sound toggle is on and the panel is mounted); otherwise there is no
-  /// chime to land after, so speaking immediately is correct.
+  /// only when the panel's own chime is actually expected to sound:
+  /// its sound toggle is on, the panel is mounted, *and* it is actively
+  /// monitoring — `_checkMaxHrAlert` in `heart_rate_panel_screen.dart`
+  /// returns immediately if `!panelState.isMonitoring`, before it ever gets
+  /// to the sound toggle, so a panel that is merely open (e.g. connected but
+  /// paused) has no chime coming and must not defer the safety line either.
+  ///
+  /// Two further conditions gate the chime and are **not** mirrored here,
+  /// deliberately: `_checkMaxHrAlert`'s own `currentHr == null` guard is
+  /// moot in this context (a fresh [bpm] reading is exactly what got us
+  /// here), and its 15s alert cooldown (`_lastMaxHrAlert`) is private
+  /// `State` on `_HeartRatePanelScreenState` with no provider exposing it —
+  /// mirroring it would mean promoting that cooldown into shared state
+  /// purely so a second, unrelated consumer could read it, which is a
+  /// bigger change than this file's job. The residual gap: a second
+  /// crossing landing inside the chime's own cooldown window still defers
+  /// the coach's line by 1.5s for a chime that won't actually sound.
+  /// Recorded here rather than silently accepted — no worse than speaking
+  /// slightly late, never a missed or wrong warning.
   void _announceAboveCap(int bpm, int cap) {
     final shouldDelay = _ref.read(maxHrAlertProvider).soundEnabled &&
-        _ref.read(heartRatePanelVisibleProvider);
+        _ref.read(heartRatePanelVisibleProvider) &&
+        _ref.read(heartRatePanelProvider).isMonitoring;
     if (!shouldDelay) {
       _emit(HeartRateAboveCap(bpm: bpm, cap: cap));
       return;

--- a/lib/features/trainer/presentation/providers/hr_event_source.dart
+++ b/lib/features/trainer/presentation/providers/hr_event_source.dart
@@ -1,0 +1,197 @@
+import 'dart:async';
+
+import 'package:clock/clock.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hr_zones/hr_zones.dart';
+
+import '../../../../core/providers.dart';
+import '../../../heart_rate/presentation/providers/zone_configuration_provider.dart';
+import '../../domain/hr_zone_lookup.dart';
+import '../../domain/trainer_event.dart';
+import 'trainer_event_bus.dart';
+
+/// Turns the live BLE heart rate stream into the trainer events the coach
+/// reacts to.
+///
+/// Two behaviours here exist to protect the safety path, not to make the
+/// coach chattier:
+///
+/// - **Cap-boundary hysteresis** (`capHysteresisMargin`, `capHysteresisDwell`):
+///   the engine (see `CoachingEngine`) resets its own 30 second warning
+///   window the instant a `HeartRateBackBelowCap` arrives, so a genuine
+///   second crossing is heard immediately — but that means this source is
+///   now the *only* thing standing between BPM noise at the cap boundary and
+///   the warning/reassurance pair alternating every couple of seconds. A
+///   reading only counts as "back below" once it has stayed at least
+///   [capHysteresisMargin] bpm under the cap for [capHysteresisDwell];
+///   anything less resets the dwell rather than merely pausing it, so a
+///   reading that pops back near the cap before the dwell completes must
+///   start over.
+/// - **Signal loss** (`signalLossTimeout`): the production `HeartRateService`
+///   (`FlutterBlueHeartRateService`) never closes or errors its
+///   `heartRateStream` on a BLE dropout — it simply stops emitting. If that
+///   happens while the user is above cap, nothing would ever clear
+///   `_aboveCap` in the engine, silencing all encouragement for the rest of
+///   the session with no explanation. A quiet period of [signalLossTimeout]
+///   is therefore treated the same as an explicit "back below cap": it is
+///   the only signal this source can rely on for the real hardware. Stream
+///   closure and stream errors are also handled the same way, both because a
+///   test double may use them and because they cost nothing to cover.
+class HrEventSource {
+  HrEventSource(
+    this._ref, {
+    Duration zoneDwell = const Duration(seconds: 10),
+    Duration capRepeat = const Duration(seconds: 30),
+    this.capHysteresisMargin = 5,
+    Duration capHysteresisDwell = const Duration(seconds: 5),
+    Duration signalLossTimeout = const Duration(seconds: 8),
+  })  : _zoneDwell = zoneDwell,
+        _capRepeat = capRepeat,
+        _capHysteresisDwell = capHysteresisDwell,
+        _signalLossTimeout = signalLossTimeout {
+    _subscription = _ref.read(heartRateServiceProvider).heartRateStream.listen(
+          _onReading,
+          onDone: _onSignalLoss,
+          onError: (Object _, StackTrace __) => _onSignalLoss(),
+        );
+  }
+
+  final Ref _ref;
+  final Duration _zoneDwell;
+  final Duration _capRepeat;
+
+  /// How far below the cap, in bpm, a reading must sit before it counts as
+  /// "meaningfully below" rather than noise. Five beats comfortably clears
+  /// the couple of beats of jitter a BLE reading can carry from one sample
+  /// to the next, without delaying a genuine recovery by much.
+  final int capHysteresisMargin;
+  final Duration _capHysteresisDwell;
+  final Duration _signalLossTimeout;
+
+  late final StreamSubscription<int> _subscription;
+  Timer? _signalLossTimer;
+
+  int? _currentZone;
+  int? _candidateZone;
+  DateTime? _candidateZoneSince;
+
+  bool _aboveCap = false;
+  DateTime? _lastCapWarningAt;
+  DateTime? _belowCapSince;
+
+  void _onReading(int bpm) {
+    _resetSignalLossTimer();
+
+    final config = _ref.read(zoneConfigurationProvider);
+    if (config == null) return;
+
+    _handleCap(bpm, config.maxHr);
+    _handleZone(bpm, config);
+  }
+
+  void _handleZone(int bpm, ZoneConfiguration config) {
+    final zoneNumber = zoneNumberFor(config, bpm);
+    if (zoneNumber == null) return;
+
+    if (zoneNumber == _currentZone) {
+      _candidateZone = null;
+      _candidateZoneSince = null;
+      return;
+    }
+
+    final now = clock.now();
+    if (_candidateZone != zoneNumber) {
+      _candidateZone = zoneNumber;
+      _candidateZoneSince = now;
+      return;
+    }
+
+    final since = _candidateZoneSince;
+    if (since == null || now.difference(since) < _zoneDwell) return;
+
+    _currentZone = zoneNumber;
+    _candidateZone = null;
+    _candidateZoneSince = null;
+
+    final zone = config.zones.firstWhere((z) => z.zoneNumber == zoneNumber);
+    _emit(HeartRateZoneChanged(
+      zoneNumber: zoneNumber,
+      effortLabel: zone.effortLabel,
+      descriptiveLabel: zone.descriptiveLabel,
+    ));
+  }
+
+  void _handleCap(int bpm, int cap) {
+    final now = clock.now();
+
+    if (bpm > cap) {
+      _belowCapSince = null;
+      if (!_aboveCap) {
+        _aboveCap = true;
+        _lastCapWarningAt = now;
+        _emit(HeartRateAboveCap(bpm: bpm, cap: cap));
+        return;
+      }
+      final last = _lastCapWarningAt;
+      if (last == null || now.difference(last) >= _capRepeat) {
+        _lastCapWarningAt = now;
+        _emit(HeartRateAboveCap(bpm: bpm, cap: cap));
+      }
+      return;
+    }
+
+    if (!_aboveCap) return;
+
+    if (bpm > cap - capHysteresisMargin) {
+      // Below the cap but still within the noise band — not a genuine
+      // recovery. Reset rather than pause the dwell: a reading that dips
+      // here after some dwell has already accrued must not be able to
+      // "top up" from where it left off.
+      _belowCapSince = null;
+      return;
+    }
+
+    final since = _belowCapSince;
+    if (since == null) {
+      _belowCapSince = now;
+      return;
+    }
+    if (now.difference(since) < _capHysteresisDwell) return;
+
+    _aboveCap = false;
+    _lastCapWarningAt = null;
+    _belowCapSince = null;
+    _emit(const HeartRateBackBelowCap());
+  }
+
+  void _resetSignalLossTimer() {
+    _signalLossTimer?.cancel();
+    _signalLossTimer = Timer(_signalLossTimeout, _onSignalLoss);
+  }
+
+  /// Fired when the stream goes quiet for [_signalLossTimeout], closes, or
+  /// errors. Only ever has anything to do while above cap — otherwise there
+  /// is no stuck suppression to clear.
+  void _onSignalLoss() {
+    if (!_aboveCap) return;
+    _aboveCap = false;
+    _lastCapWarningAt = null;
+    _belowCapSince = null;
+    _emit(const HeartRateBackBelowCap());
+  }
+
+  void _emit(TrainerEvent event) {
+    _ref.read(trainerEventBusProvider).emit(event);
+  }
+
+  void dispose() {
+    unawaited(_subscription.cancel());
+    _signalLossTimer?.cancel();
+  }
+}
+
+final hrEventSourceProvider = Provider<HrEventSource>((ref) {
+  final source = HrEventSource(ref);
+  ref.onDispose(source.dispose);
+  return source;
+});

--- a/lib/features/trainer/presentation/providers/hr_event_source.dart
+++ b/lib/features/trainer/presentation/providers/hr_event_source.dart
@@ -37,16 +37,36 @@ import 'trainer_event_bus.dart';
 ///   the only signal this source can rely on for the real hardware. Stream
 ///   closure and stream errors are also handled the same way, both because a
 ///   test double may use them and because they cost nothing to cover.
+///
+///   [signalLossTimeout] must stay longer than the service's own reconnect
+///   schedule (`ReconnectStrategy.defaultDelays`: 2s, 4s, 8s, …) plus the
+///   connect/discover/subscribe work after each delay, or a routine,
+///   recoverable dropout announces a false "back under your maximum" — a
+///   safety-relevant false negative — followed by a second "above your
+///   maximum" moments later once the strap reconnects and the reading
+///   arrives. Too long costs only extra silence (encouragement stays
+///   suppressed a little longer); too short speaks the false all-clear. See
+///   the constructor's default for the reasoning behind the chosen value.
 class HrEventSource {
   HrEventSource(
     this._ref, {
     Duration zoneDwell = const Duration(seconds: 10),
     Duration capRepeat = const Duration(seconds: 30),
-    this.capHysteresisMargin = 5,
+    int capHysteresisMargin = 5,
     Duration capHysteresisDwell = const Duration(seconds: 5),
-    Duration signalLossTimeout = const Duration(seconds: 8),
+    // Android routinely fails the first reconnect attempt with GATT 133
+    // (see FlutterBlueHeartRateService's doc comment and
+    // ReconnectStrategy), so the common case is recovery on the *second*
+    // attempt: cumulative delay 2s + 4s = 6s, plus connect/discoverServices/
+    // setNotifyValue overhead, lands around 8-12s. A third attempt starts at
+    // a cumulative 14s and can land close to 20s. 25s clears all three with
+    // a margin, while remaining well short of the fourth attempt's 30s
+    // cumulative delay — by that point the outage is genuinely extended and
+    // the asymmetry favours erring toward silence over a false all-clear.
+    Duration signalLossTimeout = const Duration(seconds: 25),
   })  : _zoneDwell = zoneDwell,
         _capRepeat = capRepeat,
+        _capHysteresisMargin = capHysteresisMargin,
         _capHysteresisDwell = capHysteresisDwell,
         _signalLossTimeout = signalLossTimeout {
     _subscription = _ref.read(heartRateServiceProvider).heartRateStream.listen(
@@ -64,7 +84,7 @@ class HrEventSource {
   /// "meaningfully below" rather than noise. Five beats comfortably clears
   /// the couple of beats of jitter a BLE reading can carry from one sample
   /// to the next, without delaying a genuine recovery by much.
-  final int capHysteresisMargin;
+  final int _capHysteresisMargin;
   final Duration _capHysteresisDwell;
   final Duration _signalLossTimeout;
 
@@ -83,8 +103,21 @@ class HrEventSource {
     _resetSignalLossTimer();
 
     final config = _ref.read(zoneConfigurationProvider);
-    if (config == null) return;
+    if (config == null) {
+      // The profile can go from usable to unusable mid-session (e.g. the
+      // user clears their age or health flags and calculateZones can no
+      // longer resolve a method). Readings keep arriving either way, so
+      // without this the signal-loss timer above keeps getting reset and
+      // never fires, and _aboveCap would stay stuck exactly as it would on
+      // a real BLE dropout. Route it through the same recovery path.
+      _onSignalLoss();
+      return;
+    }
 
+    // Cap before zone is load-bearing, not incidental: the engine swallows
+    // the zone callout entirely while above cap, so if a single reading is
+    // both a new zone and above the cap, the safety cue must be the one
+    // that reaches the engine first. Do not reorder these two lines.
     _handleCap(bpm, config.maxHr);
     _handleZone(bpm, config);
   }
@@ -132,8 +165,12 @@ class HrEventSource {
         _emit(HeartRateAboveCap(bpm: bpm, cap: cap));
         return;
       }
-      final last = _lastCapWarningAt;
-      if (last == null || now.difference(last) >= _capRepeat) {
+      // _lastCapWarningAt is always non-null here: it is set in the same
+      // statement as _aboveCap = true above and only ever cleared alongside
+      // _aboveCap = false, so reaching this branch (_aboveCap already true)
+      // guarantees it was set on some earlier reading.
+      final last = _lastCapWarningAt!;
+      if (now.difference(last) >= _capRepeat) {
         _lastCapWarningAt = now;
         _emit(HeartRateAboveCap(bpm: bpm, cap: cap));
       }
@@ -142,7 +179,7 @@ class HrEventSource {
 
     if (!_aboveCap) return;
 
-    if (bpm > cap - capHysteresisMargin) {
+    if (bpm > cap - _capHysteresisMargin) {
       // Below the cap but still within the noise band — not a genuine
       // recovery. Reset rather than pause the dwell: a reading that dips
       // here after some dwell has already accrued must not be able to
@@ -169,10 +206,18 @@ class HrEventSource {
     _signalLossTimer = Timer(_signalLossTimeout, _onSignalLoss);
   }
 
-  /// Fired when the stream goes quiet for [_signalLossTimeout], closes, or
-  /// errors. Only ever has anything to do while above cap — otherwise there
-  /// is no stuck suppression to clear.
+  /// Fired when the stream goes quiet for [_signalLossTimeout], closes,
+  /// errors, or the zone configuration becomes unusable mid-session.
+  ///
+  /// Always clears any pending zone candidate: a candidate zone recorded
+  /// just before a gap must not be promoted on the first reading afterwards
+  /// with credit for time it was never actually, continuously observed in.
+  /// Only clears the cap state and emits [HeartRateBackBelowCap] while
+  /// actually above cap — otherwise there is no stuck suppression to clear.
   void _onSignalLoss() {
+    _candidateZone = null;
+    _candidateZoneSince = null;
+
     if (!_aboveCap) return;
     _aboveCap = false;
     _lastCapWarningAt = null;

--- a/lib/features/trainer/presentation/providers/hr_event_source.dart
+++ b/lib/features/trainer/presentation/providers/hr_event_source.dart
@@ -5,6 +5,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hr_zones/hr_zones.dart';
 
 import '../../../../core/providers.dart';
+import '../../../heart_rate/presentation/providers/heart_rate_panel_visibility_provider.dart';
+import '../../../heart_rate/presentation/providers/max_hr_alert_provider.dart';
 import '../../../heart_rate/presentation/providers/zone_configuration_provider.dart';
 import '../../domain/hr_zone_lookup.dart';
 import '../../domain/trainer_event.dart';
@@ -64,11 +66,19 @@ class HrEventSource {
     // cumulative delay — by that point the outage is genuinely extended and
     // the asymmetry favours erring toward silence over a false all-clear.
     Duration signalLossTimeout = const Duration(seconds: 25),
+    // The panel's own chime (see heart_rate_panel_screen.dart's
+    // _checkMaxHrAlert) is the attention-getter and must be heard first — a
+    // chime cuts through instantly where a spoken line takes ~2s to land.
+    // Only the very first HeartRateAboveCap of a crossing is delayed; the
+    // capRepeat-driven re-warnings below have no accompanying chime moment
+    // to sequence after.
+    Duration aboveCapAnnounceDelay = const Duration(milliseconds: 1500),
   })  : _zoneDwell = zoneDwell,
         _capRepeat = capRepeat,
         _capHysteresisMargin = capHysteresisMargin,
         _capHysteresisDwell = capHysteresisDwell,
-        _signalLossTimeout = signalLossTimeout {
+        _signalLossTimeout = signalLossTimeout,
+        _aboveCapAnnounceDelay = aboveCapAnnounceDelay {
     _subscription = _ref.read(heartRateServiceProvider).heartRateStream.listen(
           _onReading,
           onDone: _onSignalLoss,
@@ -87,9 +97,11 @@ class HrEventSource {
   final int _capHysteresisMargin;
   final Duration _capHysteresisDwell;
   final Duration _signalLossTimeout;
+  final Duration _aboveCapAnnounceDelay;
 
   late final StreamSubscription<int> _subscription;
   Timer? _signalLossTimer;
+  Timer? _pendingAboveCapAnnouncement;
 
   int? _currentZone;
   int? _candidateZone;
@@ -162,7 +174,7 @@ class HrEventSource {
       if (!_aboveCap) {
         _aboveCap = true;
         _lastCapWarningAt = now;
-        _emit(HeartRateAboveCap(bpm: bpm, cap: cap));
+        _announceAboveCap(bpm, cap);
         return;
       }
       // _lastCapWarningAt is always non-null here: it is set in the same
@@ -198,7 +210,34 @@ class HrEventSource {
     _aboveCap = false;
     _lastCapWarningAt = null;
     _belowCapSince = null;
+    _pendingAboveCapAnnouncement?.cancel();
+    _pendingAboveCapAnnouncement = null;
     _emit(const HeartRateBackBelowCap());
+  }
+
+  /// Emits the very first [HeartRateAboveCap] of a crossing — see decision 1
+  /// in the phase 2a HR coaching spec. Delayed by [_aboveCapAnnounceDelay]
+  /// only when the panel's own chime is actually expected to sound (its
+  /// sound toggle is on and the panel is mounted); otherwise there is no
+  /// chime to land after, so speaking immediately is correct.
+  void _announceAboveCap(int bpm, int cap) {
+    final shouldDelay = _ref.read(maxHrAlertProvider).soundEnabled &&
+        _ref.read(heartRatePanelVisibleProvider);
+    if (!shouldDelay) {
+      _emit(HeartRateAboveCap(bpm: bpm, cap: cap));
+      return;
+    }
+
+    _pendingAboveCapAnnouncement?.cancel();
+    _pendingAboveCapAnnouncement = Timer(_aboveCapAnnounceDelay, () {
+      _pendingAboveCapAnnouncement = null;
+      // Guards against a recovery that happened during the delay window —
+      // _handleCap's back-below branch already cancels this timer on that
+      // path, but the check is cheap insurance against emitting a stale
+      // warning if that ever changes.
+      if (!_aboveCap) return;
+      _emit(HeartRateAboveCap(bpm: bpm, cap: cap));
+    });
   }
 
   void _resetSignalLossTimer() {
@@ -222,6 +261,8 @@ class HrEventSource {
     _aboveCap = false;
     _lastCapWarningAt = null;
     _belowCapSince = null;
+    _pendingAboveCapAnnouncement?.cancel();
+    _pendingAboveCapAnnouncement = null;
     _emit(const HeartRateBackBelowCap());
   }
 
@@ -232,6 +273,7 @@ class HrEventSource {
   void dispose() {
     unawaited(_subscription.cancel());
     _signalLossTimer?.cancel();
+    _pendingAboveCapAnnouncement?.cancel();
   }
 }
 

--- a/lib/features/trainer/presentation/providers/phrase_resolver.dart
+++ b/lib/features/trainer/presentation/providers/phrase_resolver.dart
@@ -36,6 +36,16 @@ final Map<String, PhraseBuilder> phraseResolvers = {
       s.coachSteadyFinish2(a['totalSets'] as int? ?? 0),
   'coachSteadyFinish3': (s, a) =>
       s.coachSteadyFinish3(a['totalSets'] as int? ?? 0),
+  // descriptiveLabel is deliberately not threaded through here — see
+  // HeartRateZoneChanged's doc comment for the decision. The spoken cue
+  // stays to zone number + effortLabel only.
+  'coachSteadyZone': (s, a) => s.coachSteadyZone(
+        a['zoneNumber'] as int? ?? 0,
+        a['effortLabel'] as String? ?? '',
+      ),
+  'coachSteadyAboveCap1': (s, _) => s.coachSteadyAboveCap1,
+  'coachSteadyAboveCap2': (s, _) => s.coachSteadyAboveCap2,
+  'coachSteadyBackBelowCap': (s, _) => s.coachSteadyBackBelowCap,
 };
 
 String? resolvePhrase(S s, String key, Map<String, Object> args) {

--- a/lib/features/trainer/presentation/providers/trainer_settings_provider.dart
+++ b/lib/features/trainer/presentation/providers/trainer_settings_provider.dart
@@ -9,6 +9,8 @@ class TrainerSettings {
     this.speechRate = 0.5,
     this.disclaimerAccepted = false,
     this.personaId = 'steady',
+    this.hrCalloutsEnabled = true,
+    this.hrSafetyWarningsEnabled = true,
   });
 
   final bool enabled;
@@ -18,6 +20,14 @@ class TrainerSettings {
   final bool disclaimerAccepted;
   final String personaId;
 
+  /// Whether the coach announces heart-rate zone changes.
+  final bool hrCalloutsEnabled;
+
+  /// Whether the coach speaks above/below-cap safety cues. Defaults to
+  /// true and is presented in settings as the one to leave switched on —
+  /// but, as the user's own choice, it must remain switchable off.
+  final bool hrSafetyWarningsEnabled;
+
   TrainerSettings copyWith({
     bool? enabled,
     bool? countdownsEnabled,
@@ -25,6 +35,8 @@ class TrainerSettings {
     double? speechRate,
     bool? disclaimerAccepted,
     String? personaId,
+    bool? hrCalloutsEnabled,
+    bool? hrSafetyWarningsEnabled,
   }) {
     return TrainerSettings(
       enabled: enabled ?? this.enabled,
@@ -33,6 +45,9 @@ class TrainerSettings {
       speechRate: speechRate ?? this.speechRate,
       disclaimerAccepted: disclaimerAccepted ?? this.disclaimerAccepted,
       personaId: personaId ?? this.personaId,
+      hrCalloutsEnabled: hrCalloutsEnabled ?? this.hrCalloutsEnabled,
+      hrSafetyWarningsEnabled:
+          hrSafetyWarningsEnabled ?? this.hrSafetyWarningsEnabled,
     );
   }
 }
@@ -60,6 +75,8 @@ class TrainerSettingsNotifier extends Notifier<TrainerSettings> {
       speechRate: prefs.getDouble('trainer_speech_rate') ?? 0.5,
       disclaimerAccepted: prefs.getBool('trainer_disclaimer_accepted') ?? false,
       personaId: prefs.getString('trainer_persona') ?? 'steady',
+      hrCalloutsEnabled: prefs.getBool('trainer_hr_callouts') ?? true,
+      hrSafetyWarningsEnabled: prefs.getBool('trainer_hr_safety') ?? true,
     );
   }
 
@@ -85,6 +102,20 @@ class TrainerSettingsNotifier extends Notifier<TrainerSettings> {
     state = state.copyWith(encouragementEnabled: value);
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool('trainer_encouragement', value);
+  }
+
+  Future<void> setHrCallouts(bool value) async {
+    await _loading;
+    state = state.copyWith(hrCalloutsEnabled: value);
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('trainer_hr_callouts', value);
+  }
+
+  Future<void> setHrSafetyWarnings(bool value) async {
+    await _loading;
+    state = state.copyWith(hrSafetyWarningsEnabled: value);
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('trainer_hr_safety', value);
   }
 
   Future<void> setSpeechRate(double value) async {

--- a/lib/features/trainer/presentation/screens/trainer_settings_screen.dart
+++ b/lib/features/trainer/presentation/screens/trainer_settings_screen.dart
@@ -97,6 +97,21 @@ class _TrainerSettingsScreenState extends ConsumerState<TrainerSettingsScreen> {
             value: settings.encouragementEnabled,
             onChanged: notifier.setEncouragement,
           ),
+          SwitchListTile(
+            title: Text(s.trainerHrCallouts),
+            subtitle: Text(s.trainerHrCalloutsSubtitle),
+            value: settings.hrCalloutsEnabled,
+            onChanged: notifier.setHrCallouts,
+          ),
+          // Listed last among the toggles and with copy explaining why: this
+          // is the one setting the user should leave alone, but — as their
+          // own choice — it must remain switchable off like every other cue.
+          SwitchListTile(
+            title: Text(s.trainerHrSafetyWarnings),
+            subtitle: Text(s.trainerHrSafetyWarningsSubtitle),
+            value: settings.hrSafetyWarningsEnabled,
+            onChanged: notifier.setHrSafetyWarnings,
+          ),
           ListTile(
             leading: const Icon(Icons.info_outline),
             title: Text(s.trainerReviewDisclaimer),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -996,6 +996,16 @@
   "@coachSteadyFinish3": {
     "placeholders": { "totalSets": { "type": "int" } }
   },
+  "coachSteadyZone": "Zone {zoneNumber} — {effortLabel}.",
+  "@coachSteadyZone": {
+    "placeholders": {
+      "zoneNumber": { "type": "int" },
+      "effortLabel": { "type": "String" }
+    }
+  },
+  "coachSteadyAboveCap1": "Your heart rate is above your maximum. Ease off and bring it down.",
+  "coachSteadyAboveCap2": "Still above your maximum. Slow down, breathe.",
+  "coachSteadyBackBelowCap": "Good — you're back under your maximum.",
 
   "trainerDisclaimerTitle": "Before your coach speaks",
   "trainerDisclaimerBody": "The coach is a companion to help you stay on track — not a personal trainer, and not medical advice. It does not know your form, your injuries, or your limits. Stop exercising and seek medical help if you feel pain, dizziness, or chest discomfort.",
@@ -1014,6 +1024,10 @@
   "trainerTestPhrase": "This is your coach. Good set — take your rest.",
   "trainerCountdowns": "Rest countdowns",
   "trainerEncouragement": "Encouragement",
+  "trainerHrCallouts": "Heart rate zone callouts",
+  "trainerHrCalloutsSubtitle": "Announces your training zone as it changes, when a heart rate monitor is connected.",
+  "trainerHrSafetyWarnings": "Heart rate safety warnings",
+  "trainerHrSafetyWarningsSubtitle": "Speaks a calm reminder if your heart rate goes above your safe maximum. Recommended to leave switched on.",
   "trainerReviewDisclaimer": "Review safety notice",
   "trainerVoiceUnavailable": "No speech engine found on this device, so the coach cannot speak.",
   "trainerWithdrawConsent": "Withdraw consent",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -3834,6 +3834,30 @@ abstract class S {
   /// **'Finished. {totalSets} sets in the bank.'**
   String coachSteadyFinish3(int totalSets);
 
+  /// No description provided for @coachSteadyZone.
+  ///
+  /// In en, this message translates to:
+  /// **'Zone {zoneNumber} — {effortLabel}.'**
+  String coachSteadyZone(int zoneNumber, String effortLabel);
+
+  /// No description provided for @coachSteadyAboveCap1.
+  ///
+  /// In en, this message translates to:
+  /// **'Your heart rate is above your maximum. Ease off and bring it down.'**
+  String get coachSteadyAboveCap1;
+
+  /// No description provided for @coachSteadyAboveCap2.
+  ///
+  /// In en, this message translates to:
+  /// **'Still above your maximum. Slow down, breathe.'**
+  String get coachSteadyAboveCap2;
+
+  /// No description provided for @coachSteadyBackBelowCap.
+  ///
+  /// In en, this message translates to:
+  /// **'Good — you\'re back under your maximum.'**
+  String get coachSteadyBackBelowCap;
+
   /// No description provided for @trainerDisclaimerTitle.
   ///
   /// In en, this message translates to:
@@ -3929,6 +3953,30 @@ abstract class S {
   /// In en, this message translates to:
   /// **'Encouragement'**
   String get trainerEncouragement;
+
+  /// No description provided for @trainerHrCallouts.
+  ///
+  /// In en, this message translates to:
+  /// **'Heart rate zone callouts'**
+  String get trainerHrCallouts;
+
+  /// No description provided for @trainerHrCalloutsSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Announces your training zone as it changes, when a heart rate monitor is connected.'**
+  String get trainerHrCalloutsSubtitle;
+
+  /// No description provided for @trainerHrSafetyWarnings.
+  ///
+  /// In en, this message translates to:
+  /// **'Heart rate safety warnings'**
+  String get trainerHrSafetyWarnings;
+
+  /// No description provided for @trainerHrSafetyWarningsSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Speaks a calm reminder if your heart rate goes above your safe maximum. Recommended to leave switched on.'**
+  String get trainerHrSafetyWarningsSubtitle;
 
   /// No description provided for @trainerReviewDisclaimer.
   ///

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -2130,6 +2130,23 @@ class SEn extends S {
   }
 
   @override
+  String coachSteadyZone(int zoneNumber, String effortLabel) {
+    return 'Zone $zoneNumber — $effortLabel.';
+  }
+
+  @override
+  String get coachSteadyAboveCap1 =>
+      'Your heart rate is above your maximum. Ease off and bring it down.';
+
+  @override
+  String get coachSteadyAboveCap2 =>
+      'Still above your maximum. Slow down, breathe.';
+
+  @override
+  String get coachSteadyBackBelowCap =>
+      'Good — you\'re back under your maximum.';
+
+  @override
   String get trainerDisclaimerTitle => 'Before your coach speaks';
 
   @override
@@ -2179,6 +2196,20 @@ class SEn extends S {
 
   @override
   String get trainerEncouragement => 'Encouragement';
+
+  @override
+  String get trainerHrCallouts => 'Heart rate zone callouts';
+
+  @override
+  String get trainerHrCalloutsSubtitle =>
+      'Announces your training zone as it changes, when a heart rate monitor is connected.';
+
+  @override
+  String get trainerHrSafetyWarnings => 'Heart rate safety warnings';
+
+  @override
+  String get trainerHrSafetyWarningsSubtitle =>
+      'Speaks a calm reminder if your heart rate goes above your safe maximum. Recommended to leave switched on.';
 
   @override
   String get trainerReviewDisclaimer => 'Review safety notice';

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -2083,6 +2083,23 @@ class SJa extends S {
   }
 
   @override
+  String coachSteadyZone(int zoneNumber, String effortLabel) {
+    return 'Zone $zoneNumber — $effortLabel.';
+  }
+
+  @override
+  String get coachSteadyAboveCap1 =>
+      'Your heart rate is above your maximum. Ease off and bring it down.';
+
+  @override
+  String get coachSteadyAboveCap2 =>
+      'Still above your maximum. Slow down, breathe.';
+
+  @override
+  String get coachSteadyBackBelowCap =>
+      'Good — you\'re back under your maximum.';
+
+  @override
   String get trainerDisclaimerTitle => 'Before your coach speaks';
 
   @override
@@ -2132,6 +2149,20 @@ class SJa extends S {
 
   @override
   String get trainerEncouragement => 'Encouragement';
+
+  @override
+  String get trainerHrCallouts => 'Heart rate zone callouts';
+
+  @override
+  String get trainerHrCalloutsSubtitle =>
+      'Announces your training zone as it changes, when a heart rate monitor is connected.';
+
+  @override
+  String get trainerHrSafetyWarnings => 'Heart rate safety warnings';
+
+  @override
+  String get trainerHrSafetyWarningsSubtitle =>
+      'Speaks a calm reminder if your heart rate goes above your safe maximum. Recommended to leave switched on.';
 
   @override
   String get trainerReviewDisclaimer => 'Review safety notice';

--- a/lib/l10n/generated/app_localizations_ko.dart
+++ b/lib/l10n/generated/app_localizations_ko.dart
@@ -2082,6 +2082,23 @@ class SKo extends S {
   }
 
   @override
+  String coachSteadyZone(int zoneNumber, String effortLabel) {
+    return 'Zone $zoneNumber — $effortLabel.';
+  }
+
+  @override
+  String get coachSteadyAboveCap1 =>
+      'Your heart rate is above your maximum. Ease off and bring it down.';
+
+  @override
+  String get coachSteadyAboveCap2 =>
+      'Still above your maximum. Slow down, breathe.';
+
+  @override
+  String get coachSteadyBackBelowCap =>
+      'Good — you\'re back under your maximum.';
+
+  @override
   String get trainerDisclaimerTitle => 'Before your coach speaks';
 
   @override
@@ -2131,6 +2148,20 @@ class SKo extends S {
 
   @override
   String get trainerEncouragement => 'Encouragement';
+
+  @override
+  String get trainerHrCallouts => 'Heart rate zone callouts';
+
+  @override
+  String get trainerHrCalloutsSubtitle =>
+      'Announces your training zone as it changes, when a heart rate monitor is connected.';
+
+  @override
+  String get trainerHrSafetyWarnings => 'Heart rate safety warnings';
+
+  @override
+  String get trainerHrSafetyWarningsSubtitle =>
+      'Speaks a calm reminder if your heart rate goes above your safe maximum. Recommended to leave switched on.';
 
   @override
   String get trainerReviewDisclaimer => 'Review safety notice';

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -2076,6 +2076,23 @@ class SZh extends S {
   }
 
   @override
+  String coachSteadyZone(int zoneNumber, String effortLabel) {
+    return 'Zone $zoneNumber — $effortLabel.';
+  }
+
+  @override
+  String get coachSteadyAboveCap1 =>
+      'Your heart rate is above your maximum. Ease off and bring it down.';
+
+  @override
+  String get coachSteadyAboveCap2 =>
+      'Still above your maximum. Slow down, breathe.';
+
+  @override
+  String get coachSteadyBackBelowCap =>
+      'Good — you\'re back under your maximum.';
+
+  @override
   String get trainerDisclaimerTitle => 'Before your coach speaks';
 
   @override
@@ -2125,6 +2142,20 @@ class SZh extends S {
 
   @override
   String get trainerEncouragement => 'Encouragement';
+
+  @override
+  String get trainerHrCallouts => 'Heart rate zone callouts';
+
+  @override
+  String get trainerHrCalloutsSubtitle =>
+      'Announces your training zone as it changes, when a heart rate monitor is connected.';
+
+  @override
+  String get trainerHrSafetyWarnings => 'Heart rate safety warnings';
+
+  @override
+  String get trainerHrSafetyWarningsSubtitle =>
+      'Speaks a calm reminder if your heart rate goes above your safe maximum. Recommended to leave switched on.';
 
   @override
   String get trainerReviewDisclaimer => 'Review safety notice';

--- a/test/features/heart_rate/presentation/screens/heart_rate_panel_screen_test.dart
+++ b/test/features/heart_rate/presentation/screens/heart_rate_panel_screen_test.dart
@@ -15,6 +15,7 @@ import 'package:hr_zones/hr_zones.dart';
 import 'package:rep_foundry/features/heart_rate/presentation/controllers/heart_rate_panel_controller.dart';
 import 'package:rep_foundry/features/heart_rate/presentation/controllers/heart_rate_panel_state.dart';
 import 'package:rep_foundry/features/heart_rate/presentation/providers/health_profile_provider.dart';
+import 'package:rep_foundry/features/heart_rate/presentation/providers/heart_rate_panel_visibility_provider.dart';
 import 'package:rep_foundry/features/heart_rate/presentation/screens/heart_rate_panel_screen.dart';
 import 'package:rep_foundry/features/workout/data/workout_repository_impl.dart';
 import 'package:rep_foundry/l10n/generated/app_localizations.dart';
@@ -235,6 +236,57 @@ void main() {
         find.text('Waiting for heart rate data...'),
         findsOneWidget,
       );
+    });
+
+    testWidgets(
+        'marks heartRatePanelVisibleProvider true while mounted and false '
+        'once disposed', (tester) async {
+      // This is the signal HrEventSource reads to decide whether to delay
+      // the coach's cap warning behind the panel's own chime (decision 1) —
+      // wrong in either direction either mis-sequences the warning or
+      // silently drops the delay for a screen that is actually on-screen.
+      final container = ProviderContainer(overrides: [
+        databaseProvider.overrideWithValue(database),
+        cardioSessionRepositoryProvider.overrideWithValue(cardioRepo),
+        saveCardioSessionUseCaseProvider.overrideWithValue(
+          SaveCardioSessionUseCase(
+            cardioRepository: cardioRepo,
+            workoutRepository: workoutRepo,
+          ),
+        ),
+        locationServiceProvider.overrideWithValue(locationService),
+        heartRateServiceProvider.overrideWithValue(heartRateService),
+        healthSyncServiceProvider.overrideWithValue(HealthSyncService()),
+        healthSyncSettingsProvider
+            .overrideWith(() => HealthSyncSettingsNotifier()),
+      ]);
+      addTearDown(container.dispose);
+
+      expect(container.read(heartRatePanelVisibleProvider), isFalse,
+          reason: 'false before the screen ever mounts');
+
+      await tester.pumpWidget(UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(
+          localizationsDelegates: S.localizationsDelegates,
+          supportedLocales: S.supportedLocales,
+          home: HeartRatePanelScreen(),
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(container.read(heartRatePanelVisibleProvider), isTrue);
+
+      await tester.pumpWidget(UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(home: SizedBox()),
+      ));
+      // The flag is cleared via a microtask (dispose() cannot modify a
+      // provider synchronously) — a couple of empty pumps flush it.
+      await tester.pump();
+      await tester.pump();
+
+      expect(container.read(heartRatePanelVisibleProvider), isFalse);
     });
   });
 

--- a/test/features/trainer/application/coaching_engine_hr_test.dart
+++ b/test/features/trainer/application/coaching_engine_hr_test.dart
@@ -1,0 +1,172 @@
+import 'dart:math';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_foundry/features/trainer/application/coaching_engine.dart';
+import 'package:rep_foundry/features/trainer/domain/coaching_cue.dart';
+import 'package:rep_foundry/features/trainer/domain/persona.dart';
+import 'package:rep_foundry/features/trainer/domain/trainer_event.dart';
+
+const _testPersona = Persona(
+  id: 'test',
+  phrasesByKind: {
+    TrainerEventKind.workoutStarted: ['start1', 'start2', 'start3'],
+    TrainerEventKind.setLogged: ['set1', 'set2', 'set3'],
+    TrainerEventKind.personalRecord: ['pr1', 'pr2', 'pr3'],
+    TrainerEventKind.restCountdown: ['count1'],
+    TrainerEventKind.restFinished: ['go1', 'go2', 'go3'],
+    TrainerEventKind.workoutFinished: ['done1', 'done2', 'done3'],
+    TrainerEventKind.hrZoneChanged: ['zone1'],
+    TrainerEventKind.hrAboveCap: ['abovecap1', 'abovecap2'],
+    TrainerEventKind.hrBackBelowCap: ['backbelow1'],
+  },
+);
+
+/// Fixed cadence by default so tests stay deterministic.
+CoachingEngine _engine({
+  int encouragementEverySets = 2,
+  Duration cooldown = const Duration(seconds: 20),
+}) =>
+    CoachingEngine(
+      persona: _testPersona,
+      random: Random(1),
+      encouragementCooldown: cooldown,
+      encouragementMinSets: encouragementEverySets,
+      encouragementMaxSets: encouragementEverySets,
+    );
+
+void main() {
+  final t0 = DateTime.utc(2026, 1, 1, 12);
+
+  test('above cap produces a safety-priority cue', () {
+    final engine = _engine();
+    final cue = engine.onEvent(
+      const HeartRateAboveCap(bpm: 180, cap: 170),
+      now: t0,
+    );
+
+    expect(cue, isNotNull);
+    expect(cue!.priority, SpeechPriority.safety);
+    expect(cue.args['bpm'], 180);
+    expect(engine.isAboveCap, isTrue);
+  });
+
+  test('the cap warning repeats no more than every 30 seconds', () {
+    final engine = _engine();
+    engine.onEvent(const HeartRateAboveCap(bpm: 180, cap: 170), now: t0);
+
+    final tooSoon = engine.onEvent(
+      const HeartRateAboveCap(bpm: 182, cap: 170),
+      now: t0.add(const Duration(seconds: 10)),
+    );
+    final later = engine.onEvent(
+      const HeartRateAboveCap(bpm: 182, cap: 170),
+      now: t0.add(const Duration(seconds: 31)),
+    );
+
+    expect(tooSoon, isNull);
+    expect(later, isNotNull);
+  });
+
+  test('encouragement is suppressed entirely while above cap', () {
+    final engine = _engine(encouragementEverySets: 1, cooldown: Duration.zero);
+    engine.onEvent(const HeartRateAboveCap(bpm: 180, cap: 170), now: t0);
+
+    final cue = engine.onEvent(
+      const SetLogged(setNumber: 1, isPersonalRecord: false),
+      now: t0.add(const Duration(seconds: 5)),
+    );
+
+    expect(cue, isNull);
+  });
+
+  test('dropping back below the cap lifts the suppression', () {
+    final engine = _engine(encouragementEverySets: 1, cooldown: Duration.zero);
+    engine.onEvent(const HeartRateAboveCap(bpm: 180, cap: 170), now: t0);
+    engine.onEvent(const HeartRateBackBelowCap(),
+        now: t0.add(const Duration(seconds: 20)));
+
+    final cue = engine.onEvent(
+      const SetLogged(setNumber: 1, isPersonalRecord: false),
+      now: t0.add(const Duration(seconds: 25)),
+    );
+
+    expect(cue, isNotNull);
+    expect(engine.isAboveCap, isFalse);
+  });
+
+  test('a personal record is still suppressed above cap', () {
+    // PRs are milestone priority and normally bypass the cooldown, so they are
+    // the most likely cue to escape the safety suppression.
+    final engine = _engine();
+    engine.onEvent(const HeartRateAboveCap(bpm: 180, cap: 170), now: t0);
+
+    final cue = engine.onEvent(
+      const SetLogged(setNumber: 1, isPersonalRecord: true),
+      now: t0.add(const Duration(seconds: 5)),
+    );
+
+    expect(cue, isNull);
+  });
+
+  test('caution mode produces zone callouts but no encouragement', () {
+    final engine = _engine(encouragementEverySets: 1, cooldown: Duration.zero);
+
+    final zone = engine.onEvent(
+      const HeartRateZoneChanged(
+          zoneNumber: 3, effortLabel: 'Moderate', descriptiveLabel: 'Aerobic'),
+      now: t0,
+      cautionMode: true,
+    );
+    final encouragement = engine.onEvent(
+      const SetLogged(setNumber: 1, isPersonalRecord: false),
+      now: t0.add(const Duration(minutes: 1)),
+      cautionMode: true,
+    );
+
+    expect(zone, isNotNull);
+    expect(encouragement, isNull);
+  });
+
+  test('encouragement never fires in zone 5', () {
+    final engine = _engine(encouragementEverySets: 1, cooldown: Duration.zero);
+    engine.onEvent(
+      const HeartRateZoneChanged(
+          zoneNumber: 5, effortLabel: 'Maximum', descriptiveLabel: 'VO₂ Max'),
+      now: t0,
+    );
+
+    final cue = engine.onEvent(
+      const SetLogged(setNumber: 1, isPersonalRecord: false),
+      now: t0.add(const Duration(minutes: 1)),
+    );
+
+    expect(cue, isNull);
+  });
+
+  test('hrCalloutsEnabled false silences zone callouts', () {
+    final engine = _engine();
+
+    final cue = engine.onEvent(
+      const HeartRateZoneChanged(
+          zoneNumber: 3, effortLabel: 'Moderate', descriptiveLabel: 'Aerobic'),
+      now: t0,
+      hrCalloutsEnabled: false,
+    );
+
+    expect(cue, isNull);
+  });
+
+  test('hrCalloutsEnabled false still allows cap warnings', () {
+    // The safety path must not be switchable off by a convenience toggle.
+    final engine = _engine();
+
+    final cue = engine.onEvent(
+      const HeartRateAboveCap(bpm: 180, cap: 170),
+      now: t0,
+      hrCalloutsEnabled: false,
+    );
+
+    expect(cue, isNotNull);
+    expect(cue!.priority, SpeechPriority.safety);
+  });
+}

--- a/test/features/trainer/application/coaching_engine_hr_test.dart
+++ b/test/features/trainer/application/coaching_engine_hr_test.dart
@@ -356,5 +356,60 @@ void main() {
       expect(cue, isNull);
       expect(engine.isAboveCap, isTrue);
     });
+
+    // Requirement B (carried forward from earlier reviews): the toggle must
+    // also govern HeartRateBackBelowCap, not just HeartRateAboveCap — a user
+    // who muted safety warnings must never hear "back under your maximum"
+    // having never heard a warning.
+    test('false silences the back-below-cap reassurance too', () {
+      final engine = _engine();
+      engine.onEvent(
+        const HeartRateAboveCap(bpm: 180, cap: 170),
+        now: t0,
+        hrSafetyWarningsEnabled: false,
+      );
+
+      final cue = engine.onEvent(
+        const HeartRateBackBelowCap(),
+        now: t0.add(const Duration(seconds: 5)),
+        hrSafetyWarningsEnabled: false,
+      );
+
+      expect(cue, isNull);
+      expect(engine.isAboveCap, isFalse,
+          reason: 'the suppression must still lift even though the '
+              'reassurance itself stays silent');
+    });
+
+    test(
+        'false still lets encouragement resume once back below cap — the '
+        'toggle must not leave the session silenced for good', () {
+      // Critical constraint: _onBackBelowCap must clear _aboveCap and
+      // _lastCapWarningAt before checking the toggle, not after an early
+      // return. Getting the order wrong here leaves encouragement suppressed
+      // for the rest of the session with no event able to lift it.
+      final engine =
+          _engine(encouragementEverySets: 1, cooldown: Duration.zero);
+      engine.onEvent(
+        const HeartRateAboveCap(bpm: 180, cap: 170),
+        now: t0,
+        hrSafetyWarningsEnabled: false,
+      );
+      final reassurance = engine.onEvent(
+        const HeartRateBackBelowCap(),
+        now: t0.add(const Duration(seconds: 5)),
+        hrSafetyWarningsEnabled: false,
+      );
+
+      final cue = engine.onEvent(
+        const SetLogged(setNumber: 1, isPersonalRecord: false),
+        now: t0.add(const Duration(seconds: 10)),
+      );
+
+      expect(reassurance, isNull, reason: 'muted, so no speech');
+      expect(cue, isNotNull,
+          reason: 'encouragement must resume once genuinely back below cap, '
+              'even though the toggle kept the bookend line silent');
+    });
   });
 }

--- a/test/features/trainer/application/coaching_engine_hr_test.dart
+++ b/test/features/trainer/application/coaching_engine_hr_test.dart
@@ -169,4 +169,171 @@ void main() {
     expect(cue, isNotNull);
     expect(cue!.priority, SpeechPriority.safety);
   });
+
+  group('milestone cues respect the encouragement gate', () {
+    // Fix round 1, Critical 1: WorkoutFinished (and, defensively, every other
+    // milestone-priority cue) must not congratulate the user while their
+    // heart rate is above the safety cap, in caution mode, or in zone 5 —
+    // the engine must not rely on the caller resetting it at the right time.
+    test('workout finished is suppressed above cap', () {
+      final engine = _engine();
+      engine.onEvent(const HeartRateAboveCap(bpm: 180, cap: 170), now: t0);
+
+      final cue = engine.onEvent(
+        const WorkoutFinished(totalSets: 15),
+        now: t0.add(const Duration(seconds: 5)),
+      );
+
+      expect(cue, isNull);
+    });
+
+    test('workout finished is suppressed in caution mode', () {
+      final engine = _engine();
+
+      final cue = engine.onEvent(
+        const WorkoutFinished(totalSets: 15),
+        now: t0,
+        cautionMode: true,
+      );
+
+      expect(cue, isNull);
+    });
+
+    test('workout finished is suppressed in zone 5', () {
+      final engine = _engine();
+      engine.onEvent(
+        const HeartRateZoneChanged(
+            zoneNumber: 5, effortLabel: 'Maximum', descriptiveLabel: 'VO₂ Max'),
+        now: t0,
+      );
+
+      final cue = engine.onEvent(
+        const WorkoutFinished(totalSets: 15),
+        now: t0.add(const Duration(minutes: 1)),
+      );
+
+      expect(cue, isNull);
+    });
+
+    test('workout started is suppressed above cap', () {
+      // Masked in the original implementation only by the bridge resetting
+      // the engine before this event — the engine itself must not depend on
+      // that caller ordering.
+      final engine = _engine();
+      engine.onEvent(const HeartRateAboveCap(bpm: 180, cap: 170), now: t0);
+
+      final cue = engine.onEvent(
+        const WorkoutStarted(),
+        now: t0.add(const Duration(seconds: 5)),
+      );
+
+      expect(cue, isNull);
+    });
+  });
+
+  group('reset clears the new heart-rate state', () {
+    // Fix round 1, Important 3: without this, reset() runs inside other
+    // tests and its lines count as "covered" while nothing asserts the
+    // fields it clears actually unblock the engine afterwards.
+    test('reset lifts above-cap suppression', () {
+      final engine =
+          _engine(encouragementEverySets: 1, cooldown: Duration.zero);
+      engine.onEvent(const HeartRateAboveCap(bpm: 180, cap: 170), now: t0);
+
+      engine.reset();
+
+      final cue = engine.onEvent(
+        const SetLogged(setNumber: 1, isPersonalRecord: false),
+        now: t0.add(const Duration(seconds: 1)),
+      );
+
+      expect(cue, isNotNull);
+      expect(engine.isAboveCap, isFalse);
+    });
+
+    test('reset lifts zone-5 suppression', () {
+      final engine =
+          _engine(encouragementEverySets: 1, cooldown: Duration.zero);
+      engine.onEvent(
+        const HeartRateZoneChanged(
+            zoneNumber: 5, effortLabel: 'Maximum', descriptiveLabel: 'VO₂ Max'),
+        now: t0,
+      );
+
+      engine.reset();
+
+      final cue = engine.onEvent(
+        const SetLogged(setNumber: 1, isPersonalRecord: false),
+        now: t0.add(const Duration(seconds: 1)),
+      );
+
+      expect(cue, isNotNull);
+    });
+  });
+
+  group('back below cap without a genuine crossing', () {
+    // Fix round 1, Important 5: the reassurance cue only makes sense as the
+    // bookend to a warning the user actually heard.
+    test('stays silent when the engine was never above cap', () {
+      final engine = _engine();
+
+      final cue = engine.onEvent(const HeartRateBackBelowCap(), now: t0);
+
+      expect(cue, isNull);
+    });
+
+    test('a genuine departure and a fresh crossing both warn', () {
+      // Fix round 1 ruling: resetting _lastCapWarningAt on a genuine
+      // below-cap departure is correct — pinned here so it cannot regress.
+      final engine = _engine();
+      engine.onEvent(const HeartRateAboveCap(bpm: 180, cap: 170), now: t0);
+      engine.onEvent(const HeartRateBackBelowCap(),
+          now: t0.add(const Duration(seconds: 5)));
+
+      final secondCrossing = engine.onEvent(
+        const HeartRateAboveCap(bpm: 180, cap: 170),
+        now: t0.add(const Duration(seconds: 10)),
+      );
+
+      expect(secondCrossing, isNotNull);
+      expect(secondCrossing!.priority, SpeechPriority.safety);
+    });
+  });
+
+  group('hrSafetyWarningsEnabled', () {
+    test('false silences the cap warning without starting its cooldown', () {
+      final engine = _engine();
+      final silenced = engine.onEvent(
+        const HeartRateAboveCap(bpm: 180, cap: 170),
+        now: t0,
+        hrSafetyWarningsEnabled: false,
+      );
+
+      final reEnabled = engine.onEvent(
+        const HeartRateAboveCap(bpm: 182, cap: 170),
+        now: t0.add(const Duration(seconds: 1)),
+      );
+
+      expect(silenced, isNull);
+      expect(reEnabled, isNotNull);
+    });
+
+    test('false still suppresses encouragement while above cap', () {
+      final engine =
+          _engine(encouragementEverySets: 1, cooldown: Duration.zero);
+      engine.onEvent(
+        const HeartRateAboveCap(bpm: 180, cap: 170),
+        now: t0,
+        hrSafetyWarningsEnabled: false,
+      );
+
+      final cue = engine.onEvent(
+        const SetLogged(setNumber: 1, isPersonalRecord: false),
+        now: t0.add(const Duration(seconds: 5)),
+      );
+
+      expect(cue, isNull);
+      expect(engine.isAboveCap, isTrue);
+    });
+  });
 }

--- a/test/features/trainer/application/coaching_engine_hr_test.dart
+++ b/test/features/trainer/application/coaching_engine_hr_test.dart
@@ -251,6 +251,27 @@ void main() {
       expect(engine.isAboveCap, isFalse);
     });
 
+    test('reset clears the cap-warning repeat timer', () {
+      // Fix round 2, Important 2: reset() clears _lastCapWarningAt, but
+      // nothing re-issued HeartRateAboveCap afterwards to prove it. Live
+      // consequence: coach_bridge.dart calls reset() on both WorkoutStarted
+      // and WorkoutFinished, so a session ending above cap followed by a new
+      // one starting within 30s would have its first safety warning
+      // swallowed by a stale repeat window.
+      final engine = _engine();
+      engine.onEvent(const HeartRateAboveCap(bpm: 180, cap: 170), now: t0);
+
+      engine.reset();
+
+      final cue = engine.onEvent(
+        const HeartRateAboveCap(bpm: 180, cap: 170),
+        now: t0.add(const Duration(seconds: 5)),
+      );
+
+      expect(cue, isNotNull);
+      expect(cue!.priority, SpeechPriority.safety);
+    });
+
     test('reset lifts zone-5 suppression', () {
       final engine =
           _engine(encouragementEverySets: 1, cooldown: Duration.zero);

--- a/test/features/trainer/data/persona_packs_test.dart
+++ b/test/features/trainer/data/persona_packs_test.dart
@@ -85,6 +85,39 @@ const _spokenKinds = [
   TrainerEventKind.workoutFinished,
 ];
 
+/// Heart-rate cues (phase 2a). Kept separate from [_spokenKinds] because
+/// their variety-count expectations differ (see the brief's exact phrase
+/// lists — one or two phrases per kind, not the three required elsewhere),
+/// but they still need to pass through the uniqueness, resolver, and
+/// denylist loops below.
+const _hrKinds = [
+  TrainerEventKind.hrZoneChanged,
+  TrainerEventKind.hrAboveCap,
+  TrainerEventKind.hrBackBelowCap,
+];
+
+/// Every kind whose phrases must resolve to text and obey the denylist.
+const _allSpokenKinds = [..._spokenKinds, ..._hrKinds];
+
+/// Every persona the app ships. Steady is the only one in v1; iterating a
+/// list (rather than just `steadyPersona`) means the non-empty-bank
+/// assertion below automatically covers Hype and Sergeant once phase 2 adds
+/// them, instead of silently only ever checking Steady.
+const _allPersonas = [steadyPersona];
+
+/// Mirrors the args CoachingEngine attaches to a CoachingCue for this kind
+/// (see coaching_engine.dart) — invoking with the wrong shape would surface
+/// a cast failure at test time rather than mid-workout.
+Map<String, Object> _argsFor(TrainerEventKind kind) => switch (kind) {
+      TrainerEventKind.restCountdown => const {'secondsLeft': 3},
+      TrainerEventKind.workoutFinished => const {'totalSets': 12},
+      TrainerEventKind.hrZoneChanged => const {
+          'zoneNumber': 3,
+          'effortLabel': 'Moderate',
+        },
+      _ => const <String, Object>{},
+    };
+
 void main() {
   test('steady persona has at least three phrases per spoken kind', () {
     for (final kind in _spokenKinds) {
@@ -97,7 +130,7 @@ void main() {
   });
 
   test('phrase keys are unique across the pack', () {
-    final all = _spokenKinds.expand(steadyPersona.phrasesFor).toList();
+    final all = _allSpokenKinds.expand(steadyPersona.phrasesFor).toList();
 
     expect(all.toSet().length, all.length, reason: 'duplicate phrase key');
   });
@@ -106,21 +139,30 @@ void main() {
       'every phrase key in the steady persona has a resolver that produces '
       'text with the args its event kind actually supplies', () {
     final s = lookupS(const Locale('en'));
-    for (final kind in _spokenKinds) {
-      // Mirrors the args CoachingEngine attaches to a CoachingCue for this
-      // kind (see coaching_engine.dart) — invoking with the wrong shape here
-      // would surface a cast failure at test time rather than mid-workout.
-      final args = switch (kind) {
-        TrainerEventKind.restCountdown => const {'secondsLeft': 3},
-        TrainerEventKind.workoutFinished => const {'totalSets': 12},
-        _ => const <String, Object>{},
-      };
+    for (final kind in _allSpokenKinds) {
+      final args = _argsFor(kind);
       for (final key in steadyPersona.phrasesFor(kind)) {
         final builder = phraseResolvers[key];
         expect(builder, isNotNull, reason: 'no resolver entry for $key');
         final text = builder!(s, args);
         expect(text, isNotEmpty, reason: '$key produced empty text');
       }
+    }
+  });
+
+  // Requirement A (carried forward from earlier reviews): _speak returns
+  // null when a phrase bank is empty, so a persona shipped without
+  // hrAboveCap phrases silently degrades the safety path — no error, just
+  // silence. Iterates every persona so Hype and Sergeant are covered the
+  // moment they land, not just Steady.
+  test('every persona has a non-empty cap-warning bank', () {
+    for (final persona in _allPersonas) {
+      expect(
+        persona.phrasesFor(TrainerEventKind.hrAboveCap),
+        isNotEmpty,
+        reason: '${persona.id} persona has no hrAboveCap phrases — the '
+            'safety warning would silently degrade to no speech at all',
+      );
     }
   });
 
@@ -131,12 +173,8 @@ void main() {
     final s = lookupS(const Locale('en'));
     final offences = <String>[];
 
-    for (final kind in _spokenKinds) {
-      final args = switch (kind) {
-        TrainerEventKind.restCountdown => const {'secondsLeft': 3},
-        TrainerEventKind.workoutFinished => const {'totalSets': 12},
-        _ => const <String, Object>{},
-      };
+    for (final kind in _allSpokenKinds) {
+      final args = _argsFor(kind);
       for (final key in steadyPersona.phrasesFor(kind)) {
         final text = _normalise(phraseResolvers[key]!(s, args));
         for (final entry in _bannedLanguage.entries) {

--- a/test/features/trainer/data/persona_packs_test.dart
+++ b/test/features/trainer/data/persona_packs_test.dart
@@ -151,18 +151,26 @@ void main() {
   });
 
   // Requirement A (carried forward from earlier reviews): _speak returns
-  // null when a phrase bank is empty, so a persona shipped without
-  // hrAboveCap phrases silently degrades the safety path — no error, just
-  // silence. Iterates every persona so Hype and Sergeant are covered the
-  // moment they land, not just Steady.
-  test('every persona has a non-empty cap-warning bank', () {
+  // null when a phrase bank is empty, so a persona shipped without phrases
+  // for one of these kinds silently degrades to no speech at all — no
+  // error, just silence. Iterates every persona so Hype and Sergeant are
+  // covered the moment they land, not just Steady.
+  //
+  // Fix round 1: this previously checked hrAboveCap only. The
+  // uniqueness/resolver/denylist loops above iterate `phrasesFor(kind)`,
+  // which passes vacuously on an empty bank — without an explicit
+  // non-empty assertion for every HR kind, hrZoneChanged or hrBackBelowCap
+  // could ship with no phrases and nothing here would catch it.
+  test('every persona has a non-empty bank for every HR cue kind', () {
     for (final persona in _allPersonas) {
-      expect(
-        persona.phrasesFor(TrainerEventKind.hrAboveCap),
-        isNotEmpty,
-        reason: '${persona.id} persona has no hrAboveCap phrases — the '
-            'safety warning would silently degrade to no speech at all',
-      );
+      for (final kind in _hrKinds) {
+        expect(
+          persona.phrasesFor(kind),
+          isNotEmpty,
+          reason: '${persona.id} persona has no $kind phrases — that cue '
+              'would silently degrade to no speech at all',
+        );
+      }
     }
   });
 

--- a/test/features/trainer/domain/hr_zone_lookup_test.dart
+++ b/test/features/trainer/domain/hr_zone_lookup_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hr_zones/hr_zones.dart';
+import 'package:rep_foundry/features/trainer/domain/hr_zone_lookup.dart';
+
+ZoneConfiguration _config() => calculateZones(
+      const HealthProfile(age: 40),
+    )!;
+
+void main() {
+  group('zoneNumberFor', () {
+    test('returns null below the bottom of zone 1', () {
+      final config = _config();
+      final belowZone1 = config.zones.first.lowerBound - 1;
+
+      expect(zoneNumberFor(config, belowZone1), isNull);
+    });
+
+    test('returns the zone containing the reading', () {
+      final config = _config();
+      for (final zone in config.zones) {
+        expect(zoneNumberFor(config, zone.lowerBound), zone.zoneNumber,
+            reason: 'lower bound of zone ${zone.zoneNumber} is inclusive');
+      }
+    });
+
+    test('an upper bound belongs to the next zone up, not its own', () {
+      final config = _config();
+      final zone1 = config.zones.first;
+
+      expect(zoneNumberFor(config, zone1.upperBound!), 2);
+    });
+
+    test('readings above the top zone stay in the top zone', () {
+      final config = _config();
+
+      expect(zoneNumberFor(config, config.maxHr + 40),
+          config.zones.last.zoneNumber);
+    });
+  });
+}

--- a/test/features/trainer/presentation/coach_bridge_test.dart
+++ b/test/features/trainer/presentation/coach_bridge_test.dart
@@ -366,6 +366,31 @@ void main() {
   });
 
   test(
+      'WorkoutFinished above cap does not cut off an in-flight safety '
+      'warning', () async {
+    // Regression: the finish cue is suppressed while above cap, which makes
+    // the bridge's null-cue branch reachable for the first time in exactly
+    // this state — the one state where a SpeechPriority.safety warning is
+    // most likely still playing. The old code called stop() unconditionally
+    // on a null cue, so it would cut that warning off mid-sentence.
+    final container = buildContainer();
+    final bridge = container.read(_bridgeUnderTest);
+    bridge.strings = lookupS(const Locale('en'));
+
+    final bus = container.read(trainerEventBusProvider);
+    bus.emit(const HeartRateAboveCap(bpm: 180, cap: 170));
+    await Future<void>.delayed(Duration.zero);
+    expect(speechService.stopCount, 0);
+
+    bus.emit(const WorkoutFinished(totalSets: 5));
+    await Future<void>.delayed(Duration.zero);
+
+    expect(speechService.stopCount, 0,
+        reason: 'the finish cue is suppressed above cap, but the safety '
+            'warning must be left to finish, not cut off');
+  });
+
+  test(
       'reading coachBridgeProvider again after a locale change reuses the '
       'same bridge instead of leaking a duplicate subscription', () async {
     final container = ProviderContainer(overrides: [

--- a/test/features/trainer/presentation/coach_bridge_test.dart
+++ b/test/features/trainer/presentation/coach_bridge_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:rep_foundry/core/entitlements/entitlement.dart';
 import 'package:rep_foundry/core/entitlements/entitlement_provider.dart';
 import 'package:rep_foundry/core/entitlements/entitlement_service.dart';
+import 'package:rep_foundry/features/heart_rate/presentation/providers/zone_configuration_provider.dart';
 import 'package:rep_foundry/features/trainer/domain/trainer_event.dart';
 import 'package:rep_foundry/features/trainer/presentation/providers/coach_bridge.dart';
 import 'package:rep_foundry/features/trainer/presentation/providers/trainer_event_bus.dart';
@@ -88,6 +89,11 @@ void main() {
       ),
       entitlementServiceProvider
           .overrideWithValue(entitlementService ?? _AlwaysEntitled()),
+      // Overridden directly rather than left to resolve through
+      // healthProfileProvider: that chain needs a real client/database
+      // setup this test file doesn't provide. cautionModeProvider is a
+      // plain Provider, so overriding it sidesteps the chain entirely.
+      cautionModeProvider.overrideWithValue(false),
       _bridgeUnderTest.overrideWith((ref) {
         final bridge = CoachBridge(ref, random: Random(seed));
         ref.onDispose(bridge.dispose);
@@ -181,6 +187,7 @@ void main() {
           ),
         ),
         entitlementServiceProvider.overrideWithValue(_AlwaysEntitled()),
+        cautionModeProvider.overrideWithValue(false),
         _bridgeUnderTest.overrideWith((ref) {
           final bridge = CoachBridge(ref, random: Random(seed));
           ref.onDispose(bridge.dispose);
@@ -401,6 +408,7 @@ void main() {
         ),
       ),
       entitlementServiceProvider.overrideWithValue(_AlwaysEntitled()),
+      cautionModeProvider.overrideWithValue(false),
     ]);
     addTearDown(container.dispose);
 

--- a/test/features/trainer/presentation/hr_coaching_integration_test.dart
+++ b/test/features/trainer/presentation/hr_coaching_integration_test.dart
@@ -186,6 +186,13 @@ void main() {
       expect(speech.spoken, hasLength(2));
       expect(speech.spoken.last, contains('maximum'));
 
+      // Clears the engine's 20s encouragement cooldown, which the cap
+      // crossing's speak just started (via clock.now(), driven by this same
+      // fake clock). Without this, the loop below is blocked by the
+      // cooldown before it ever reaches the above-cap suppression check —
+      // it would pass even with that suppression deleted entirely.
+      async.elapse(const Duration(seconds: 21));
+
       // Encouragement goes silent above cap: push comfortably more than the
       // engine's max encouragement quota (3 sets) — if suppression were
       // broken, at least one of these would speak regardless of the exact
@@ -201,11 +208,20 @@ void main() {
               'the safety cap');
 
       // Back below cap (hysteresis: meaningfully below for the dwell).
+      // 140, not 170: by now the 21s elapse above has left the zone-5
+      // candidate (started by the 190 reading) sitting well past its own
+      // 10s dwell, so a reading that still sits in zone 5 (>=162) would
+      // silently promote it — engine correctly never speaks that (still
+      // above cap), but it would leave `_currentZone == 5` afterwards, and
+      // encouragement never fires in zone 5 by design, permanently
+      // confounding the "resumes below cap" assertion below with an
+      // unrelated suppression rule. 140 matches the zone (3) already
+      // promoted at the top of this test, so no candidate is even pending.
       async.elapse(const Duration(seconds: 1));
-      hr.emitHeartRate(170);
+      hr.emitHeartRate(140);
       async.flushMicrotasks();
       async.elapse(const Duration(seconds: 5));
-      hr.emitHeartRate(170);
+      hr.emitHeartRate(140);
       async.flushMicrotasks();
 
       expect(speech.spoken, hasLength(3));
@@ -278,6 +294,84 @@ void main() {
       expect(speech.spoken, isEmpty,
           reason: 'the user switched safety warnings off — that choice '
               'must be honoured end to end');
+    });
+  });
+
+  // Fix round 1: cautionMode and hrCalloutsEnabled were only exercised at
+  // the engine layer — every bridge/integration test pinned
+  // cautionModeProvider to false and none drove hrCalloutsEnabled: false
+  // through real TrainerSettings, so the suite stayed green even with both
+  // hardcoded in coach_bridge.dart. These two prove the bridge itself
+  // actually reads them, not just that the engine honours them once told.
+  test(
+      'cautionMode true silences encouragement but still speaks a cap '
+      'warning', () {
+    fakeAsync((async) {
+      final hr = FakeHeartRateService();
+      final speech = SilentSpeechService();
+      final container = buildContainer(
+        heartRateService: hr,
+        speechService: speech,
+        cautionMode: true,
+      );
+      mountCoach(container);
+
+      // Over-provisioned past the engine's max encouragement quota (3
+      // sets), same reasoning as the main test above: `_lastSpokenAt` is
+      // null at the start of this test, so nothing here is blocked by the
+      // cooldown gate — a hardcoded `cautionMode: false` in the bridge
+      // would let at least one of these through.
+      for (var setNumber = 1; setNumber <= 5; setNumber++) {
+        container.read(trainerEventBusProvider).emit(
+              SetLogged(setNumber: setNumber, isPersonalRecord: false),
+            );
+        async.flushMicrotasks();
+      }
+      expect(speech.spoken, isEmpty,
+          reason: 'caution mode must suppress encouragement — this has to '
+              'come from the bridge actually reading cautionModeProvider, '
+              'not a hardcoded false');
+
+      hr.emitHeartRate(190);
+      async.flushMicrotasks();
+      expect(speech.spoken, hasLength(1),
+          reason: 'the safety cue is never gated by caution mode');
+      expect(speech.spoken.single, contains('maximum'));
+    });
+  });
+
+  test(
+      'hrCalloutsEnabled false silences the zone callout but still speaks '
+      'a cap warning', () {
+    fakeAsync((async) {
+      final hr = FakeHeartRateService();
+      final speech = SilentSpeechService();
+      final container = buildContainer(
+        heartRateService: hr,
+        speechService: speech,
+        settings: const TrainerSettings(
+          enabled: true,
+          disclaimerAccepted: true,
+          hrCalloutsEnabled: false,
+        ),
+      );
+      mountCoach(container);
+
+      hr.emitHeartRate(130); // zone 3
+      async.flushMicrotasks();
+      async.elapse(const Duration(seconds: 10));
+      hr.emitHeartRate(130);
+      async.flushMicrotasks();
+      expect(speech.spoken, isEmpty,
+          reason: 'hrCalloutsEnabled is off — the zone callout must not '
+              'speak, and this has to come from the bridge actually '
+              'reading the setting, not a hardcoded true');
+
+      hr.emitHeartRate(190);
+      async.flushMicrotasks();
+      expect(speech.spoken, hasLength(1),
+          reason: 'the safety cue is never gated by hrCalloutsEnabled');
+      expect(speech.spoken.single, contains('maximum'));
     });
   });
 }

--- a/test/features/trainer/presentation/hr_coaching_integration_test.dart
+++ b/test/features/trainer/presentation/hr_coaching_integration_test.dart
@@ -1,0 +1,283 @@
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hr_zones/hr_zones.dart';
+import 'package:rep_foundry/core/entitlements/entitlement.dart';
+import 'package:rep_foundry/core/entitlements/entitlement_provider.dart';
+import 'package:rep_foundry/core/entitlements/entitlement_service.dart';
+import 'package:rep_foundry/core/providers.dart';
+import 'package:rep_foundry/features/cardio/data/heart_rate_service.dart';
+import 'package:rep_foundry/features/heart_rate/presentation/providers/max_hr_alert_provider.dart';
+import 'package:rep_foundry/features/heart_rate/presentation/providers/zone_configuration_provider.dart';
+import 'package:rep_foundry/features/trainer/domain/trainer_event.dart';
+import 'package:rep_foundry/features/trainer/presentation/providers/coach_bridge.dart';
+import 'package:rep_foundry/features/trainer/presentation/providers/hr_event_source.dart';
+import 'package:rep_foundry/features/trainer/presentation/providers/trainer_event_bus.dart';
+import 'package:rep_foundry/features/trainer/presentation/providers/trainer_settings_provider.dart';
+import 'package:rep_foundry/l10n/generated/app_localizations.dart';
+
+import '../../cardio/data/fake_heart_rate_service.dart';
+import '../data/silent_speech_service.dart';
+
+/// End-to-end wiring test for Task 4: a fake HR service feeds
+/// [HrEventSource], which emits onto the real [trainerEventBusProvider],
+/// which [CoachBridge] turns into speech via [SilentSpeechService] — the
+/// full path Tasks 1-3 built but nothing had connected yet.
+
+class _AlwaysEntitled implements EntitlementService {
+  @override
+  bool has(Entitlement entitlement) => true;
+}
+
+/// Pushes a fixed [TrainerSettings] synchronously, bypassing
+/// `SharedPreferences` — mirrors the identical helper in coach_bridge_test.
+class _SeededTrainerSettingsNotifier extends TrainerSettingsNotifier {
+  _SeededTrainerSettingsNotifier(this._seed);
+
+  final TrainerSettings _seed;
+
+  @override
+  TrainerSettings build() => _seed;
+}
+
+/// Pushes a fixed [MaxHrAlertSettings] synchronously, bypassing
+/// `SharedPreferences` — mirrors the identical helper in
+/// hr_event_source_test. Needed because `_announceAboveCap` always reads
+/// this provider, even when the panel isn't mounted and no delay applies.
+class _SeededMaxHrAlertNotifier extends MaxHrAlertNotifier {
+  _SeededMaxHrAlertNotifier(this._seed);
+
+  final MaxHrAlertSettings _seed;
+
+  @override
+  MaxHrAlertSettings build() => _seed;
+}
+
+/// Zone boundaries matching hr_event_source_test's fixture: cap = maxHr =
+/// 180, so 190 is above cap and 130/170 sit in zones 3/5 respectively
+/// without crossing the cap.
+ZoneConfiguration _config() => const ZoneConfiguration(
+      method: ZoneMethod.percentOfEstimatedMax,
+      reliability: ZoneReliability.medium,
+      maxHr: 180,
+      reason: 'test config',
+      zones: [
+        CalculatedZone(
+          zoneNumber: 1,
+          label: 'Zone 1',
+          effortLabel: 'Easy',
+          descriptiveLabel: 'Recovery',
+          lowerBound: 90,
+          upperBound: 108,
+          color: 0xFF000000,
+        ),
+        CalculatedZone(
+          zoneNumber: 2,
+          label: 'Zone 2',
+          effortLabel: 'Light',
+          descriptiveLabel: 'Aerobic',
+          lowerBound: 108,
+          upperBound: 126,
+          color: 0xFF000000,
+        ),
+        CalculatedZone(
+          zoneNumber: 3,
+          label: 'Zone 3',
+          effortLabel: 'Moderate',
+          descriptiveLabel: 'Aerobic',
+          lowerBound: 126,
+          upperBound: 144,
+          color: 0xFF000000,
+        ),
+        CalculatedZone(
+          zoneNumber: 4,
+          label: 'Zone 4',
+          effortLabel: 'Hard',
+          descriptiveLabel: 'Anaerobic',
+          lowerBound: 144,
+          upperBound: 162,
+          color: 0xFF000000,
+        ),
+        CalculatedZone(
+          zoneNumber: 5,
+          label: 'Zone 5',
+          effortLabel: 'Maximum',
+          descriptiveLabel: 'VO2 Max',
+          lowerBound: 162,
+          color: 0xFF000000,
+        ),
+      ],
+    );
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  /// Builds a real container (not a stand-in) wired for the happy path:
+  /// entitled, enabled, disclaimer accepted, both HR toggles on, and a
+  /// usable zone config. The panel-visibility flag is deliberately left at
+  /// its default (false / not mounted) throughout this file — that default
+  /// is exactly what step 5 of the brief needs to prove.
+  ProviderContainer buildContainer({
+    required HeartRateService heartRateService,
+    required SilentSpeechService speechService,
+    TrainerSettings settings = const TrainerSettings(
+      enabled: true,
+      disclaimerAccepted: true,
+    ),
+    bool cautionMode = false,
+  }) {
+    final container = ProviderContainer(overrides: [
+      heartRateServiceProvider.overrideWithValue(heartRateService),
+      entitlementServiceProvider.overrideWithValue(_AlwaysEntitled()),
+      speechServiceProvider.overrideWithValue(speechService),
+      trainerSettingsProvider.overrideWith(
+        () => _SeededTrainerSettingsNotifier(settings),
+      ),
+      zoneConfigurationProvider.overrideWithValue(_config()),
+      // Overridden directly rather than left to resolve through
+      // healthProfileProvider, which needs a real client/database this test
+      // file doesn't set up.
+      cautionModeProvider.overrideWithValue(cautionMode),
+      // Overridden directly rather than left to resolve through
+      // SharedPreferences, which the real notifier can't load without a
+      // mocked plugin channel this test file doesn't set up.
+      maxHrAlertProvider.overrideWith(
+        () => _SeededMaxHrAlertNotifier(const MaxHrAlertSettings()),
+      ),
+    ]);
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  /// Mounts both real providers the way `router.dart`'s shell does, and
+  /// pushes in the localisations the bridge needs before it can speak.
+  void mountCoach(ProviderContainer container) {
+    final bridge = container.read(coachBridgeProvider);
+    bridge.strings = lookupS(const Locale('en'));
+    container.read(hrEventSourceProvider);
+  }
+
+  test(
+      'zone change after dwell speaks, cap crossing speaks a safety line, '
+      'and encouragement goes silent above cap and returns below it', () {
+    fakeAsync((async) {
+      final hr = FakeHeartRateService();
+      final speech = SilentSpeechService();
+      final container =
+          buildContainer(heartRateService: hr, speechService: speech);
+      mountCoach(container);
+
+      // Zone change after dwell speaks.
+      hr.emitHeartRate(130); // zone 3
+      async.flushMicrotasks();
+      async.elapse(const Duration(seconds: 10));
+      hr.emitHeartRate(130);
+      async.flushMicrotasks();
+
+      expect(speech.spoken, hasLength(1),
+          reason: 'the zone callout must speak once the dwell has elapsed');
+      expect(speech.spoken.single, contains('Zone 3'));
+
+      // Cap crossing speaks a safety line.
+      hr.emitHeartRate(190);
+      async.flushMicrotasks();
+
+      expect(speech.spoken, hasLength(2));
+      expect(speech.spoken.last, contains('maximum'));
+
+      // Encouragement goes silent above cap: push comfortably more than the
+      // engine's max encouragement quota (3 sets) — if suppression were
+      // broken, at least one of these would speak regardless of the exact
+      // (randomised, unseeded in the real bridge) quota drawn.
+      for (var setNumber = 1; setNumber <= 5; setNumber++) {
+        container.read(trainerEventBusProvider).emit(
+              SetLogged(setNumber: setNumber, isPersonalRecord: false),
+            );
+        async.flushMicrotasks();
+      }
+      expect(speech.spoken, hasLength(2),
+          reason: 'encouragement must stay completely silent while above '
+              'the safety cap');
+
+      // Back below cap (hysteresis: meaningfully below for the dwell).
+      async.elapse(const Duration(seconds: 1));
+      hr.emitHeartRate(170);
+      async.flushMicrotasks();
+      async.elapse(const Duration(seconds: 5));
+      hr.emitHeartRate(170);
+      async.flushMicrotasks();
+
+      expect(speech.spoken, hasLength(3));
+      expect(speech.spoken.last, contains('under your maximum'));
+
+      // Encouragement returns below cap — same over-provisioned push as
+      // above so the assertion doesn't depend on the exact random quota.
+      // Also clears the engine's 20s encouragement cooldown (now driven by
+      // the same fake clock as everything else in this test, via
+      // package:clock), which the back-below-cap line above just started.
+      async.elapse(const Duration(seconds: 21));
+      final spokenBeforeReturn = speech.spoken.length;
+      for (var setNumber = 6; setNumber <= 10; setNumber++) {
+        container.read(trainerEventBusProvider).emit(
+              SetLogged(setNumber: setNumber, isPersonalRecord: false),
+            );
+        async.flushMicrotasks();
+      }
+      expect(speech.spoken.length, greaterThan(spokenBeforeReturn),
+          reason: 'encouragement must resume once genuinely back below cap');
+    });
+  });
+
+  // Step 5 of the brief: the gap-closure benefit this whole feature exists
+  // for. Before this task, a safety warning was only ever heard while the
+  // HR panel screen happened to be on screen; mounting HrEventSource at the
+  // app-shell level (router.dart), independent of any one screen, is what
+  // fixes that. heartRatePanelVisibleProvider is left at its default
+  // (false) throughout this test — the panel is never mounted.
+  test(
+      'a cap crossing still produces a spoken warning when the HR panel '
+      'screen is not mounted', () {
+    fakeAsync((async) {
+      final hr = FakeHeartRateService();
+      final speech = SilentSpeechService();
+      final container =
+          buildContainer(heartRateService: hr, speechService: speech);
+      mountCoach(container);
+
+      hr.emitHeartRate(190);
+      async.flushMicrotasks();
+
+      expect(speech.spoken, hasLength(1),
+          reason: 'the coach must not be gated behind the HR panel screen '
+              'being on screen');
+      expect(speech.spoken.single, contains('maximum'));
+    });
+  });
+
+  test(
+      'cap warnings pass through when hrSafetyWarningsEnabled is true, '
+      'and stay silent when the user has switched it off', () {
+    fakeAsync((async) {
+      final hr = FakeHeartRateService();
+      final speech = SilentSpeechService();
+      final container = buildContainer(
+        heartRateService: hr,
+        speechService: speech,
+        settings: const TrainerSettings(
+          enabled: true,
+          disclaimerAccepted: true,
+          hrSafetyWarningsEnabled: false,
+        ),
+      );
+      mountCoach(container);
+
+      hr.emitHeartRate(190);
+      async.flushMicrotasks();
+
+      expect(speech.spoken, isEmpty,
+          reason: 'the user switched safety warnings off — that choice '
+              'must be honoured end to end');
+    });
+  });
+}

--- a/test/features/trainer/presentation/hr_event_source_test.dart
+++ b/test/features/trainer/presentation/hr_event_source_test.dart
@@ -133,13 +133,21 @@ void main() {
     // distinct from "use the default test config", and a bare `T?` parameter
     // can't distinguish "not passed" from "passed as null".
     bool nullZoneConfig = false,
+    // Lets a test change the resolved config mid-session (paired with
+    // `container.invalidate(zoneConfigurationProvider)`), for scenarios
+    // where the profile goes from usable to unusable partway through.
+    // Takes precedence over `nullZoneConfig` when supplied.
+    ZoneConfiguration? Function()? zoneConfigResolver,
     HrEventSource Function(Ref ref)? create,
   }) {
     final container = ProviderContainer(overrides: [
       heartRateServiceProvider.overrideWithValue(heartRateService),
       entitlementServiceProvider.overrideWithValue(_AlwaysEntitled()),
-      zoneConfigurationProvider
-          .overrideWithValue(nullZoneConfig ? null : _config()),
+      zoneConfigurationProvider.overrideWith(
+        (ref) => zoneConfigResolver != null
+            ? zoneConfigResolver()
+            : (nullZoneConfig ? null : _config()),
+      ),
       _sourceUnderTest.overrideWith(create ?? (ref) => HrEventSource(ref)),
     ]);
     addTearDown(container.dispose);
@@ -215,6 +223,32 @@ void main() {
         expect(received, hasLength(1),
             reason: 'the zone never changed, so no further zone events '
                 'should be emitted');
+      });
+    });
+
+    test(
+        'alternating between two zones never settles long enough to be '
+        'announced — the anti-flicker path the dwell exists for', () {
+      fakeAsync((async) {
+        final hr = FakeHeartRateService();
+        final container = buildContainer(heartRateService: hr);
+        container.read(_sourceUnderTest);
+
+        // 130 (zone 3) and 150 (zone 4), once a second, for 30s — every
+        // reading replaces the previous candidate before it can ever
+        // accumulate the 10s dwell, so this specifically exercises the
+        // candidate-replacement branch with two genuinely different zones,
+        // not just the "same zone repeated" path the other tests cover.
+        for (var i = 0; i < 30; i++) {
+          hr.emitHeartRate(i.isEven ? 130 : 150);
+          async.flushMicrotasks();
+          async.elapse(const Duration(seconds: 1));
+        }
+
+        expect(received, isEmpty,
+            reason: 'boundary flicker between two zones must never be '
+                'announced — this is the single most likely way the '
+                'feature becomes intolerable');
       });
     });
   });
@@ -458,11 +492,11 @@ void main() {
         async.flushMicrotasks();
         expect(received, hasLength(1));
 
-        async.elapse(const Duration(seconds: 7));
+        async.elapse(const Duration(seconds: 24));
         expect(received, hasLength(1),
             reason: 'the signal-loss timeout has not elapsed yet');
 
-        async.elapse(const Duration(seconds: 2));
+        async.elapse(const Duration(seconds: 1));
         expect(received, hasLength(2));
         expect(received.last, isA<HeartRateBackBelowCap>());
       });
@@ -477,7 +511,10 @@ void main() {
         hr.emitHeartRate(130); // ordinary reading, well under the cap
         async.flushMicrotasks();
 
-        async.elapse(const Duration(seconds: 20));
+        // Past the 25s default signal-loss timeout, so this genuinely
+        // exercises the quiet-timer firing, not just a gap too short to
+        // matter.
+        async.elapse(const Duration(seconds: 30));
 
         expect(received.whereType<HeartRateBackBelowCap>(), isEmpty);
       });
@@ -538,6 +575,48 @@ void main() {
         expect(received, isEmpty);
       });
     });
+
+    test(
+        'the config going null mid-session while above cap immediately '
+        'clears the stuck suppression, not just on the next signal-loss '
+        'timeout', () {
+      fakeAsync((async) {
+        final hr = FakeHeartRateService();
+        ZoneConfiguration? config = _config();
+        final container = buildContainer(
+          heartRateService: hr,
+          zoneConfigResolver: () => config,
+        );
+        container.read(_sourceUnderTest);
+
+        hr.emitHeartRate(190); // above the 180 cap while config is usable
+        async.flushMicrotasks();
+        expect(received, hasLength(1));
+        expect(received.single, isA<HeartRateAboveCap>());
+
+        // The user clears their health profile — calculateZones can no
+        // longer resolve a method, so zoneConfigurationProvider goes null.
+        config = null;
+        container.invalidate(zoneConfigurationProvider);
+
+        hr.emitHeartRate(190); // would still be above a cap, if one existed
+        async.flushMicrotasks();
+
+        expect(received, hasLength(2),
+            reason: 'a null config must not leave _aboveCap stuck; without '
+                'this fix, encouragement would stay suppressed for the rest '
+                'of the session with no event able to lift it, and nothing '
+                'short of the (much longer) signal-loss timeout would ever '
+                'clear it');
+        expect(received.last, isA<HeartRateBackBelowCap>());
+
+        // And it must not then repeat on every further null-config reading —
+        // _aboveCap is already false, so there is nothing left to clear.
+        hr.emitHeartRate(190);
+        async.flushMicrotasks();
+        expect(received, hasLength(2));
+      });
+    });
   });
 
   group('lifecycle', () {
@@ -556,12 +635,22 @@ void main() {
         // If dispose failed to cancel the signal-loss timer, this elapse
         // would fire it and wrongly emit HeartRateBackBelowCap even though
         // the source has been torn down.
-        async.elapse(const Duration(seconds: 8));
+        async.elapse(const Duration(seconds: 25));
         expect(received, hasLength(1),
             reason: 'dispose must cancel the signal-loss timer');
 
-        // A leaked subscription would still forward further readings.
-        hr.emitHeartRate(30);
+        // A leaked subscription would still forward further readings. The
+        // probe has to be one that would actually emit from a *live* source
+        // — a bare disconnected-looking value like 30 resolves to no zone
+        // and, since bpm <= cap, only ever touches `_belowCapSince` inside
+        // `_handleCap`, so it would pass this assertion even with a leaked
+        // subscription. 130 twice, 5s apart, is exactly the sequence that
+        // would produce HeartRateBackBelowCap from a live source (still
+        // above cap from the very first reading above).
+        hr.emitHeartRate(130);
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 5));
+        hr.emitHeartRate(130);
         async.flushMicrotasks();
         expect(received, hasLength(1),
             reason: 'dispose must cancel the stream subscription');
@@ -660,7 +749,7 @@ void main() {
         expect(capEvents(), hasLength(3));
         expect(capEvents().last, isA<HeartRateBackBelowCap>());
 
-        // Signal-loss timeout: 3s instead of the 8s default.
+        // Signal-loss timeout: 3s instead of the 25s default.
         hr.emitHeartRate(190);
         async.flushMicrotasks();
         expect(capEvents(), hasLength(4));

--- a/test/features/trainer/presentation/hr_event_source_test.dart
+++ b/test/features/trainer/presentation/hr_event_source_test.dart
@@ -1,0 +1,673 @@
+import 'dart:async';
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hr_zones/hr_zones.dart';
+import 'package:rep_foundry/core/entitlements/entitlement.dart';
+import 'package:rep_foundry/core/entitlements/entitlement_provider.dart';
+import 'package:rep_foundry/core/entitlements/entitlement_service.dart';
+import 'package:rep_foundry/core/providers.dart';
+import 'package:rep_foundry/features/cardio/data/heart_rate_service.dart';
+import 'package:rep_foundry/features/heart_rate/presentation/providers/zone_configuration_provider.dart';
+import 'package:rep_foundry/features/trainer/domain/trainer_event.dart';
+import 'package:rep_foundry/features/trainer/presentation/providers/hr_event_source.dart';
+import 'package:rep_foundry/features/trainer/presentation/providers/trainer_event_bus.dart';
+
+import '../../cardio/data/fake_heart_rate_service.dart';
+
+class _AlwaysEntitled implements EntitlementService {
+  @override
+  bool has(Entitlement entitlement) => true;
+}
+
+/// A minimal [HeartRateService] whose stream can be made to emit an error,
+/// which [FakeHeartRateService] has no hook for.
+class _ErroringHeartRateService implements HeartRateService {
+  final _controller = StreamController<int>.broadcast();
+
+  @override
+  Stream<int> get heartRateStream => _controller.stream;
+
+  void addReading(int bpm) => _controller.add(bpm);
+  void addError() => _controller.addError(Exception('BLE read failed'));
+
+  @override
+  Future<bool> checkAndRequestPermission() async => true;
+
+  @override
+  Future<bool> turnOnBluetooth() async => true;
+
+  @override
+  Future<List<DiscoveredHrDevice>> scanForDevices({
+    Duration timeout = const Duration(seconds: 10),
+  }) async =>
+      const [];
+
+  @override
+  Future<void> connectToDevice(String deviceId) async {}
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  Stream<HrConnectionState> get connectionStateStream => const Stream.empty();
+
+  @override
+  bool get isConnected => true;
+}
+
+/// Zone boundaries chosen so cap-boundary tests (cap = maxHr = 180, default
+/// hysteresis margin 5 bpm) never cross a zone boundary, and zone tests never
+/// approach the cap.
+ZoneConfiguration _config({int maxHr = 180}) => ZoneConfiguration(
+      method: ZoneMethod.percentOfEstimatedMax,
+      reliability: ZoneReliability.medium,
+      maxHr: maxHr,
+      reason: 'test config',
+      zones: const [
+        CalculatedZone(
+          zoneNumber: 1,
+          label: 'Zone 1',
+          effortLabel: 'Easy',
+          descriptiveLabel: 'Recovery',
+          lowerBound: 90,
+          upperBound: 108,
+          color: 0xFF000000,
+        ),
+        CalculatedZone(
+          zoneNumber: 2,
+          label: 'Zone 2',
+          effortLabel: 'Light',
+          descriptiveLabel: 'Aerobic',
+          lowerBound: 108,
+          upperBound: 126,
+          color: 0xFF000000,
+        ),
+        CalculatedZone(
+          zoneNumber: 3,
+          label: 'Zone 3',
+          effortLabel: 'Moderate',
+          descriptiveLabel: 'Aerobic',
+          lowerBound: 126,
+          upperBound: 144,
+          color: 0xFF000000,
+        ),
+        CalculatedZone(
+          zoneNumber: 4,
+          label: 'Zone 4',
+          effortLabel: 'Hard',
+          descriptiveLabel: 'Anaerobic',
+          lowerBound: 144,
+          upperBound: 162,
+          color: 0xFF000000,
+        ),
+        CalculatedZone(
+          zoneNumber: 5,
+          label: 'Zone 5',
+          effortLabel: 'Maximum',
+          descriptiveLabel: 'VO2 Max',
+          lowerBound: 162,
+          color: 0xFF000000,
+        ),
+      ],
+    );
+
+/// A stand-in for [hrEventSourceProvider] whose `create` callback each test
+/// overrides, so constructor parameters can be varied — the real provider
+/// only ever passes the defaults in production.
+final _sourceUnderTest = Provider<HrEventSource>((ref) => HrEventSource(ref));
+
+void main() {
+  late List<TrainerEvent> received;
+
+  /// Builds a container wired for the happy path (entitled, a usable zone
+  /// config) with the given heart rate service and, optionally, a
+  /// non-default [HrEventSource]. Subscribes to the bus immediately so
+  /// `received` captures everything emitted from the moment the container is
+  /// built.
+  ProviderContainer buildContainer({
+    required HeartRateService heartRateService,
+    // A separate flag rather than a nullable `zoneConfig` parameter: the
+    // caller needs to be able to say "override with null" explicitly,
+    // distinct from "use the default test config", and a bare `T?` parameter
+    // can't distinguish "not passed" from "passed as null".
+    bool nullZoneConfig = false,
+    HrEventSource Function(Ref ref)? create,
+  }) {
+    final container = ProviderContainer(overrides: [
+      heartRateServiceProvider.overrideWithValue(heartRateService),
+      entitlementServiceProvider.overrideWithValue(_AlwaysEntitled()),
+      zoneConfigurationProvider
+          .overrideWithValue(nullZoneConfig ? null : _config()),
+      _sourceUnderTest.overrideWith(create ?? (ref) => HrEventSource(ref)),
+    ]);
+    addTearDown(container.dispose);
+
+    final sub = container.read(trainerEventBusProvider).events.listen(
+          received.add,
+        );
+    addTearDown(sub.cancel);
+
+    return container;
+  }
+
+  setUp(() {
+    received = [];
+  });
+
+  group('zone dwell', () {
+    test('no emission before the dwell elapses', () {
+      fakeAsync((async) {
+        final hr = FakeHeartRateService();
+        final container = buildContainer(heartRateService: hr);
+        container.read(_sourceUnderTest);
+
+        hr.emitHeartRate(130); // zone 3
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 9));
+        hr.emitHeartRate(130);
+        async.flushMicrotasks();
+
+        expect(received, isEmpty);
+      });
+    });
+
+    test('exactly one emission once the dwell has elapsed', () {
+      fakeAsync((async) {
+        final hr = FakeHeartRateService();
+        final container = buildContainer(heartRateService: hr);
+        container.read(_sourceUnderTest);
+
+        hr.emitHeartRate(130); // zone 3
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 10));
+        hr.emitHeartRate(130);
+        async.flushMicrotasks();
+
+        expect(received, hasLength(1));
+        final event = received.single as HeartRateZoneChanged;
+        expect(event.zoneNumber, 3);
+        expect(event.effortLabel, 'Moderate');
+        expect(event.descriptiveLabel, 'Aerobic');
+      });
+    });
+
+    test('no repeat while the zone holds', () {
+      fakeAsync((async) {
+        final hr = FakeHeartRateService();
+        final container = buildContainer(heartRateService: hr);
+        container.read(_sourceUnderTest);
+
+        hr.emitHeartRate(130);
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 10));
+        hr.emitHeartRate(130);
+        async.flushMicrotasks();
+        expect(received, hasLength(1));
+
+        for (var i = 0; i < 5; i++) {
+          async.elapse(const Duration(seconds: 3));
+          hr.emitHeartRate(131);
+          async.flushMicrotasks();
+        }
+
+        expect(received, hasLength(1),
+            reason: 'the zone never changed, so no further zone events '
+                'should be emitted');
+      });
+    });
+  });
+
+  group('above cap', () {
+    test('emits immediately on the first reading above the cap', () {
+      fakeAsync((async) {
+        final hr = FakeHeartRateService();
+        final container = buildContainer(heartRateService: hr);
+        container.read(_sourceUnderTest);
+
+        hr.emitHeartRate(190);
+        async.flushMicrotasks();
+
+        expect(received, hasLength(1));
+        final event = received.single as HeartRateAboveCap;
+        expect(event.bpm, 190);
+        expect(event.cap, 180);
+      });
+    });
+
+    test('does not repeat before capRepeat elapses', () {
+      fakeAsync((async) {
+        final hr = FakeHeartRateService();
+        final container = buildContainer(heartRateService: hr);
+        container.read(_sourceUnderTest);
+
+        hr.emitHeartRate(190);
+        async.flushMicrotasks();
+        expect(received.whereType<HeartRateAboveCap>(), hasLength(1));
+
+        // A real strap reports roughly once a second; readings every second
+        // for 29s keep the signal-loss timer from firing (it would
+        // otherwise fire on a single 29s gap with nothing in between and
+        // wrongly clear _aboveCap, which is not what this test is about —
+        // see the dedicated 'signal loss' group for that).
+        for (var i = 0; i < 29; i++) {
+          async.elapse(const Duration(seconds: 1));
+          hr.emitHeartRate(190);
+          async.flushMicrotasks();
+        }
+
+        expect(received.whereType<HeartRateAboveCap>(), hasLength(1),
+            reason: 'the 30 second repeat window has not elapsed yet');
+      });
+    });
+
+    test('repeats every capRepeat (30s) while it stays above', () {
+      fakeAsync((async) {
+        final hr = FakeHeartRateService();
+        final container = buildContainer(heartRateService: hr);
+        container.read(_sourceUnderTest);
+
+        hr.emitHeartRate(190);
+        async.flushMicrotasks();
+        expect(received.whereType<HeartRateAboveCap>(), hasLength(1));
+
+        for (var i = 0; i < 31; i++) {
+          async.elapse(const Duration(seconds: 1));
+          hr.emitHeartRate(190);
+          async.flushMicrotasks();
+        }
+
+        expect(received.whereType<HeartRateAboveCap>(), hasLength(2));
+      });
+    });
+  });
+
+  group('back below cap hysteresis', () {
+    test('stays above while only marginally below the cap (within margin)', () {
+      fakeAsync((async) {
+        final hr = FakeHeartRateService();
+        final container = buildContainer(heartRateService: hr);
+        container.read(_sourceUnderTest);
+
+        hr.emitHeartRate(190); // above cap of 180
+        async.flushMicrotasks();
+        expect(received, hasLength(1));
+
+        // 178 is below 180 but within the 5 bpm hysteresis margin (i.e. not
+        // <= 175), so it must not count as "meaningfully below".
+        for (var i = 0; i < 8; i++) {
+          async.elapse(const Duration(seconds: 1));
+          hr.emitHeartRate(178);
+          async.flushMicrotasks();
+        }
+
+        expect(received, hasLength(1),
+            reason: 'a reading within the hysteresis margin of the cap must '
+                'never trigger back-below-cap');
+      });
+    });
+
+    test(
+        'emits back-below once the reading has been meaningfully below the '
+        'cap for the hysteresis dwell', () {
+      fakeAsync((async) {
+        final hr = FakeHeartRateService();
+        final container = buildContainer(heartRateService: hr);
+        container.read(_sourceUnderTest);
+
+        hr.emitHeartRate(190);
+        async.flushMicrotasks();
+        expect(received, hasLength(1));
+
+        // 170 <= 180 - 5 = 175, so this is "meaningfully below".
+        async.elapse(const Duration(seconds: 1));
+        hr.emitHeartRate(170);
+        async.flushMicrotasks();
+        expect(received, hasLength(1),
+            reason: 'the hysteresis dwell has not elapsed yet');
+
+        async.elapse(const Duration(seconds: 3));
+        hr.emitHeartRate(170);
+        async.flushMicrotasks();
+        expect(received, hasLength(1),
+            reason: 'still short of the 5 second hysteresis dwell');
+
+        async.elapse(const Duration(seconds: 2));
+        hr.emitHeartRate(170);
+        async.flushMicrotasks();
+
+        expect(received, hasLength(2));
+        expect(received.last, isA<HeartRateBackBelowCap>());
+      });
+    });
+
+    test(
+        'a partial recovery that returns near the cap resets the hysteresis '
+        'dwell rather than resuming it', () {
+      fakeAsync((async) {
+        final hr = FakeHeartRateService();
+        final container = buildContainer(heartRateService: hr);
+        container.read(_sourceUnderTest);
+
+        // Filtered to the cap events specifically: the readings below stay
+        // in zone 5 throughout, and the dwell/reset arithmetic this test
+        // exercises pushes total elapsed time past the (unrelated) zone
+        // dwell, which would otherwise contaminate a raw `received` count.
+        List<TrainerEvent> capEvents() => received
+            .where((e) => e is HeartRateAboveCap || e is HeartRateBackBelowCap)
+            .toList();
+
+        hr.emitHeartRate(190);
+        async.flushMicrotasks();
+
+        async.elapse(const Duration(seconds: 1));
+        hr.emitHeartRate(170); // meaningfully below; dwell candidate starts
+        async.flushMicrotasks();
+
+        async.elapse(const Duration(seconds: 3));
+        hr.emitHeartRate(170); // 3s into the dwell, not yet 5s
+        async.flushMicrotasks();
+        expect(capEvents(), hasLength(1));
+
+        async.elapse(const Duration(seconds: 1));
+        hr.emitHeartRate(178); // pops back within the margin band
+        async.flushMicrotasks();
+        expect(capEvents(), hasLength(1));
+
+        // If the dwell had merely paused rather than reset, 5s after the
+        // very first below-cap reading (i.e. now) would already satisfy it.
+        async.elapse(const Duration(seconds: 1));
+        hr.emitHeartRate(170);
+        async.flushMicrotasks();
+        expect(capEvents(), hasLength(1),
+            reason: 'the dwell must restart from this reading, not resume '
+                'from the interrupted attempt');
+
+        async.elapse(const Duration(seconds: 5));
+        hr.emitHeartRate(170);
+        async.flushMicrotasks();
+
+        expect(capEvents(), hasLength(2));
+        expect(capEvents().last, isA<HeartRateBackBelowCap>());
+      });
+    });
+
+    test(
+        'rapid oscillation around the cap does not produce alternating '
+        'events', () {
+      fakeAsync((async) {
+        final hr = FakeHeartRateService();
+        final container = buildContainer(heartRateService: hr);
+        container.read(_sourceUnderTest);
+
+        const oscillation = [182, 178, 183, 177, 181, 179, 184, 176];
+        for (final bpm in oscillation) {
+          hr.emitHeartRate(bpm);
+          async.flushMicrotasks();
+          async.elapse(const Duration(seconds: 1));
+        }
+
+        expect(received, hasLength(1),
+            reason: 'noise of a few beats either side of the cap must '
+                'produce exactly the one initial warning, never an '
+                'alternating above/below chatter');
+        expect(received.single, isA<HeartRateAboveCap>());
+      });
+    });
+
+    test('a genuine second crossing after back-below warns immediately', () {
+      fakeAsync((async) {
+        final hr = FakeHeartRateService();
+        final container = buildContainer(heartRateService: hr);
+        container.read(_sourceUnderTest);
+
+        hr.emitHeartRate(190);
+        async.flushMicrotasks();
+
+        async.elapse(const Duration(seconds: 1));
+        hr.emitHeartRate(170);
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 5));
+        hr.emitHeartRate(170);
+        async.flushMicrotasks();
+        expect(received, hasLength(2));
+        expect(received.last, isA<HeartRateBackBelowCap>());
+
+        async.elapse(const Duration(seconds: 1));
+        hr.emitHeartRate(190);
+        async.flushMicrotasks();
+
+        expect(received, hasLength(3),
+            reason: 'a genuine new crossing is new information and must not '
+                'be swallowed by a stale 30 second repeat window');
+        expect(received.last, isA<HeartRateAboveCap>());
+      });
+    });
+  });
+
+  group('signal loss', () {
+    test('a quiet stream while above cap emits back-below after the timeout',
+        () {
+      fakeAsync((async) {
+        final hr = FakeHeartRateService();
+        final container = buildContainer(heartRateService: hr);
+        container.read(_sourceUnderTest);
+
+        hr.emitHeartRate(190);
+        async.flushMicrotasks();
+        expect(received, hasLength(1));
+
+        async.elapse(const Duration(seconds: 7));
+        expect(received, hasLength(1),
+            reason: 'the signal-loss timeout has not elapsed yet');
+
+        async.elapse(const Duration(seconds: 2));
+        expect(received, hasLength(2));
+        expect(received.last, isA<HeartRateBackBelowCap>());
+      });
+    });
+
+    test('a quiet stream while not above cap stays silent', () {
+      fakeAsync((async) {
+        final hr = FakeHeartRateService();
+        final container = buildContainer(heartRateService: hr);
+        container.read(_sourceUnderTest);
+
+        hr.emitHeartRate(130); // ordinary reading, well under the cap
+        async.flushMicrotasks();
+
+        async.elapse(const Duration(seconds: 20));
+
+        expect(received.whereType<HeartRateBackBelowCap>(), isEmpty);
+      });
+    });
+
+    test('the stream closing while above cap emits back-below', () {
+      fakeAsync((async) {
+        final hr = FakeHeartRateService();
+        final container = buildContainer(heartRateService: hr);
+        container.read(_sourceUnderTest);
+
+        hr.emitHeartRate(190);
+        async.flushMicrotasks();
+        expect(received, hasLength(1));
+
+        hr.dispose(); // closes the heart rate stream controller
+        async.flushMicrotasks();
+
+        expect(received, hasLength(2));
+        expect(received.last, isA<HeartRateBackBelowCap>());
+      });
+    });
+
+    test('the stream erroring while above cap emits back-below', () {
+      fakeAsync((async) {
+        final hr = _ErroringHeartRateService();
+        final container = buildContainer(heartRateService: hr);
+        container.read(_sourceUnderTest);
+
+        hr.addReading(190);
+        async.flushMicrotasks();
+        expect(received, hasLength(1));
+
+        hr.addError();
+        async.flushMicrotasks();
+
+        expect(received, hasLength(2));
+        expect(received.last, isA<HeartRateBackBelowCap>());
+      });
+    });
+  });
+
+  group('zone configuration', () {
+    test('null zone config emits nothing at all', () {
+      fakeAsync((async) {
+        final hr = FakeHeartRateService();
+        final container =
+            buildContainer(heartRateService: hr, nullZoneConfig: true);
+        container.read(_sourceUnderTest);
+
+        hr.emitHeartRate(130);
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 15));
+        hr.emitHeartRate(190); // would be above a 180 cap, if there were one
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 40));
+
+        expect(received, isEmpty);
+      });
+    });
+  });
+
+  group('lifecycle', () {
+    test('dispose cancels the subscription and the signal-loss timer', () {
+      fakeAsync((async) {
+        final hr = FakeHeartRateService();
+        final container = buildContainer(heartRateService: hr);
+        final source = container.read(_sourceUnderTest);
+
+        hr.emitHeartRate(190);
+        async.flushMicrotasks();
+        expect(received, hasLength(1));
+
+        source.dispose();
+
+        // If dispose failed to cancel the signal-loss timer, this elapse
+        // would fire it and wrongly emit HeartRateBackBelowCap even though
+        // the source has been torn down.
+        async.elapse(const Duration(seconds: 8));
+        expect(received, hasLength(1),
+            reason: 'dispose must cancel the signal-loss timer');
+
+        // A leaked subscription would still forward further readings.
+        hr.emitHeartRate(30);
+        async.flushMicrotasks();
+        expect(received, hasLength(1),
+            reason: 'dispose must cancel the stream subscription');
+      });
+    });
+
+    test(
+        'the real hrEventSourceProvider constructs with its default '
+        'parameters and disposes when the container does', () {
+      fakeAsync((async) {
+        final hr = FakeHeartRateService();
+        final container = ProviderContainer(overrides: [
+          heartRateServiceProvider.overrideWithValue(hr),
+          entitlementServiceProvider.overrideWithValue(_AlwaysEntitled()),
+          zoneConfigurationProvider.overrideWithValue(_config()),
+        ]);
+        final sub = container.read(trainerEventBusProvider).events.listen(
+              received.add,
+            );
+
+        container.read(hrEventSourceProvider);
+        hr.emitHeartRate(190);
+        async.flushMicrotasks();
+        expect(received, hasLength(1));
+        expect(received.single, isA<HeartRateAboveCap>());
+
+        container.dispose();
+
+        // A leaked subscription from a source the container failed to
+        // dispose would still forward this reading.
+        hr.emitHeartRate(190);
+        async.flushMicrotasks();
+        expect(received, hasLength(1));
+
+        unawaited(sub.cancel());
+      });
+    });
+  });
+
+  group('constructor parameters', () {
+    test('custom durations and margin are honoured, not just the defaults', () {
+      fakeAsync((async) {
+        final hr = FakeHeartRateService();
+        final container = buildContainer(
+          heartRateService: hr,
+          create: (ref) => HrEventSource(
+            ref,
+            zoneDwell: const Duration(seconds: 2),
+            capRepeat: const Duration(seconds: 5),
+            capHysteresisMargin: 2,
+            capHysteresisDwell: const Duration(seconds: 1),
+            signalLossTimeout: const Duration(seconds: 3),
+          ),
+        );
+        container.read(_sourceUnderTest);
+
+        // Cap events specifically: every bpm value used from here on sits in
+        // zone 5, and with a 2s custom zoneDwell a second (unrelated) zone
+        // callout is expected somewhere in here too — filtering keeps this
+        // test's assertions about only the parameters it's actually probing.
+        List<TrainerEvent> capEvents() => received
+            .where((e) => e is HeartRateAboveCap || e is HeartRateBackBelowCap)
+            .toList();
+
+        // Zone dwell: 2s instead of the 10s default.
+        hr.emitHeartRate(130);
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 2));
+        hr.emitHeartRate(130);
+        async.flushMicrotasks();
+        expect(received, hasLength(1));
+        expect(received.single, isA<HeartRateZoneChanged>());
+
+        // Cap repeat: 5s instead of the 30s default. Readings every 2s (well
+        // under the custom 3s signal-loss timeout) keep the strap "alive"
+        // while the 5s repeat window is crossed.
+        hr.emitHeartRate(190);
+        async.flushMicrotasks();
+        expect(capEvents(), hasLength(1));
+        for (var i = 0; i < 3; i++) {
+          async.elapse(const Duration(seconds: 2));
+          hr.emitHeartRate(190);
+          async.flushMicrotasks();
+        }
+        expect(capEvents().whereType<HeartRateAboveCap>(), hasLength(2),
+            reason: 'the 5 second custom repeat window was crossed');
+
+        // Hysteresis margin/dwell: 2 bpm / 1s instead of 5 bpm / 5s. 177 is
+        // more than 2 bpm below the 180 cap.
+        async.elapse(const Duration(seconds: 1));
+        hr.emitHeartRate(177);
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 1));
+        hr.emitHeartRate(177);
+        async.flushMicrotasks();
+        expect(capEvents(), hasLength(3));
+        expect(capEvents().last, isA<HeartRateBackBelowCap>());
+
+        // Signal-loss timeout: 3s instead of the 8s default.
+        hr.emitHeartRate(190);
+        async.flushMicrotasks();
+        expect(capEvents(), hasLength(4));
+        async.elapse(const Duration(seconds: 3));
+        expect(capEvents(), hasLength(5));
+        expect(capEvents().last, isA<HeartRateBackBelowCap>());
+      });
+    });
+  });
+}

--- a/test/features/trainer/presentation/hr_event_source_test.dart
+++ b/test/features/trainer/presentation/hr_event_source_test.dart
@@ -9,6 +9,8 @@ import 'package:rep_foundry/core/entitlements/entitlement_provider.dart';
 import 'package:rep_foundry/core/entitlements/entitlement_service.dart';
 import 'package:rep_foundry/core/providers.dart';
 import 'package:rep_foundry/features/cardio/data/heart_rate_service.dart';
+import 'package:rep_foundry/features/heart_rate/presentation/providers/heart_rate_panel_visibility_provider.dart';
+import 'package:rep_foundry/features/heart_rate/presentation/providers/max_hr_alert_provider.dart';
 import 'package:rep_foundry/features/heart_rate/presentation/providers/zone_configuration_provider.dart';
 import 'package:rep_foundry/features/trainer/domain/trainer_event.dart';
 import 'package:rep_foundry/features/trainer/presentation/providers/hr_event_source.dart';
@@ -19,6 +21,19 @@ import '../../cardio/data/fake_heart_rate_service.dart';
 class _AlwaysEntitled implements EntitlementService {
   @override
   bool has(Entitlement entitlement) => true;
+}
+
+/// Pushes a fixed [MaxHrAlertSettings] synchronously, bypassing
+/// `SharedPreferences` entirely — this test file has nothing to do with
+/// heart-rate readings, so the real notifier's plugin-channel load must
+/// never run.
+class _SeededMaxHrAlertNotifier extends MaxHrAlertNotifier {
+  _SeededMaxHrAlertNotifier(this._seed);
+
+  final MaxHrAlertSettings _seed;
+
+  @override
+  MaxHrAlertSettings build() => _seed;
 }
 
 /// A minimal [HeartRateService] whose stream can be made to emit an error,
@@ -139,6 +154,11 @@ void main() {
     // Takes precedence over `nullZoneConfig` when supplied.
     ZoneConfiguration? Function()? zoneConfigResolver,
     HrEventSource Function(Ref ref)? create,
+    // Defaults match production defaults (chime on, panel not mounted), so
+    // every existing test's timing is unaffected — the sequencing delay only
+    // ever activates when a test opts in via [panelVisible].
+    bool panelVisible = false,
+    MaxHrAlertSettings maxHrAlertSettings = const MaxHrAlertSettings(),
   }) {
     final container = ProviderContainer(overrides: [
       heartRateServiceProvider.overrideWithValue(heartRateService),
@@ -148,8 +168,20 @@ void main() {
             ? zoneConfigResolver()
             : (nullZoneConfig ? null : _config()),
       ),
+      // Overridden directly rather than left to resolve through
+      // SharedPreferences: the real notifier can't load without a mocked
+      // plugin channel, which this test file deliberately does not set up
+      // (it has nothing to do with heart-rate readings).
+      // heartRatePanelVisibleProvider needs no override — its notifier is
+      // in-memory only and never touches SharedPreferences.
+      maxHrAlertProvider.overrideWith(
+        () => _SeededMaxHrAlertNotifier(maxHrAlertSettings),
+      ),
       _sourceUnderTest.overrideWith(create ?? (ref) => HrEventSource(ref)),
     ]);
+    if (panelVisible) {
+      container.read(heartRatePanelVisibleProvider.notifier).setVisible(true);
+    }
     addTearDown(container.dispose);
 
     final sub = container.read(trainerEventBusProvider).events.listen(
@@ -619,6 +651,160 @@ void main() {
     });
   });
 
+  group('sequencing with the max-HR alert chime (decision 1)', () {
+    // The panel's own chime is the faster safety signal and must be heard
+    // first, so the coach's spoken warning is delayed by ~1.5s — but only
+    // when the panel is actually mounted and its sound alert is on; the
+    // chime never sounds otherwise, so there is nothing to sequence after.
+    test(
+        'delays the first above-cap emission when the panel is visible and '
+        'its sound alert is on', () {
+      fakeAsync((async) {
+        final hr = FakeHeartRateService();
+        final container = buildContainer(
+          heartRateService: hr,
+          panelVisible: true,
+          maxHrAlertSettings: const MaxHrAlertSettings(soundEnabled: true),
+        );
+        container.read(_sourceUnderTest);
+
+        hr.emitHeartRate(190);
+        async.flushMicrotasks();
+        expect(received, isEmpty,
+            reason: 'must not speak before the chime has had time to play');
+
+        async.elapse(const Duration(milliseconds: 1499));
+        expect(received, isEmpty);
+
+        async.elapse(const Duration(milliseconds: 1));
+        expect(received, hasLength(1));
+        expect(received.single, isA<HeartRateAboveCap>());
+      });
+    });
+
+    test(
+        'does not delay when the panel is not mounted — the gap-closure '
+        'benefit this feature exists for must not regress', () {
+      fakeAsync((async) {
+        final hr = FakeHeartRateService();
+        final container = buildContainer(
+          heartRateService: hr,
+          panelVisible: false,
+          maxHrAlertSettings: const MaxHrAlertSettings(soundEnabled: true),
+        );
+        container.read(_sourceUnderTest);
+
+        hr.emitHeartRate(190);
+        async.flushMicrotasks();
+
+        expect(received, hasLength(1),
+            reason: 'a cap crossing must still speak immediately when the '
+                'HR panel screen is not on screen — the coach is not gated '
+                'behind that screen');
+        expect(received.single, isA<HeartRateAboveCap>());
+      });
+    });
+
+    test(
+        'does not delay when the panel is visible but its sound alert is '
+        'switched off — there is no chime to land after', () {
+      fakeAsync((async) {
+        final hr = FakeHeartRateService();
+        final container = buildContainer(
+          heartRateService: hr,
+          panelVisible: true,
+          maxHrAlertSettings: const MaxHrAlertSettings(soundEnabled: false),
+        );
+        container.read(_sourceUnderTest);
+
+        hr.emitHeartRate(190);
+        async.flushMicrotasks();
+
+        expect(received, hasLength(1));
+      });
+    });
+
+    test(
+        'only the first emission of a crossing is delayed, never the '
+        'capRepeat-driven re-warnings', () {
+      fakeAsync((async) {
+        // Filtered to cap events specifically: 190bpm also sits in zone 5,
+        // and the 30s spent below crosses the (unrelated) 10s zone dwell —
+        // see the same pattern in the "constructor parameters" group above.
+        List<TrainerEvent> capEvents() =>
+            received.whereType<HeartRateAboveCap>().toList();
+
+        final hr = FakeHeartRateService();
+        final container = buildContainer(
+          heartRateService: hr,
+          panelVisible: true,
+          maxHrAlertSettings: const MaxHrAlertSettings(soundEnabled: true),
+        );
+        container.read(_sourceUnderTest);
+
+        hr.emitHeartRate(190);
+        async.elapse(const Duration(milliseconds: 1500));
+        async.flushMicrotasks();
+        expect(capEvents(), hasLength(1));
+
+        for (var i = 0; i < 31; i++) {
+          async.elapse(const Duration(seconds: 1));
+          hr.emitHeartRate(190);
+          async.flushMicrotasks();
+        }
+
+        // The repeat at ~30s must not itself be delayed by a further 1.5s —
+        // it lands on the same flush as the reading that triggers it.
+        expect(capEvents(), hasLength(2));
+      });
+    });
+
+    test(
+        'a recovery inside the delay window cancels the pending warning '
+        'rather than speaking a stale one', () {
+      fakeAsync((async) {
+        final hr = FakeHeartRateService();
+        final container = buildContainer(
+          heartRateService: hr,
+          panelVisible: true,
+          maxHrAlertSettings: const MaxHrAlertSettings(soundEnabled: true),
+          // A short hysteresis dwell so the recovery can land inside the
+          // 1.5s delay window.
+          create: (ref) => HrEventSource(
+            ref,
+            capHysteresisDwell: const Duration(milliseconds: 200),
+          ),
+        );
+        container.read(_sourceUnderTest);
+
+        hr.emitHeartRate(190);
+        async.flushMicrotasks();
+        expect(received, isEmpty);
+
+        async.elapse(const Duration(milliseconds: 300));
+        hr.emitHeartRate(170); // meaningfully below; dwell starts
+        async.flushMicrotasks();
+        async.elapse(const Duration(milliseconds: 250));
+        hr.emitHeartRate(170); // dwell elapses at ~550ms — before the 1.5s
+        async.flushMicrotasks(); // announce delay — a genuine recovery.
+
+        expect(received, hasLength(1),
+            reason: 'the recovery itself always speaks once the hysteresis '
+                'dwell has elapsed, regardless of the pending announcement');
+        expect(received.single, isA<HeartRateBackBelowCap>());
+
+        // The pending above-cap warning must have been cancelled by the
+        // recovery, not merely delayed further — nothing further arrives
+        // once its original 1.5s delay would have elapsed.
+        async.elapse(const Duration(seconds: 5));
+        async.flushMicrotasks();
+
+        expect(received, hasLength(1),
+            reason: 'the cancelled above-cap warning must never speak late');
+      });
+    });
+  });
+
   group('lifecycle', () {
     test('dispose cancels the subscription and the signal-loss timer', () {
       fakeAsync((async) {
@@ -666,6 +852,9 @@ void main() {
           heartRateServiceProvider.overrideWithValue(hr),
           entitlementServiceProvider.overrideWithValue(_AlwaysEntitled()),
           zoneConfigurationProvider.overrideWithValue(_config()),
+          maxHrAlertProvider.overrideWith(
+            () => _SeededMaxHrAlertNotifier(const MaxHrAlertSettings()),
+          ),
         ]);
         final sub = container.read(trainerEventBusProvider).events.listen(
               received.add,
@@ -686,6 +875,49 @@ void main() {
         expect(received, hasLength(1));
 
         unawaited(sub.cancel());
+      });
+    });
+
+    // Requirement F (carried forward from earlier reviews): phase 1 shipped
+    // a Provider.family that was not autoDispose and leaked a second bridge,
+    // which would have made the coach speak every line twice. The analogous
+    // defect here is a duplicate HrEventSource producing duplicate safety
+    // warnings — this is the test that would catch it.
+    test(
+        'reading hrEventSourceProvider twice returns the same instance and '
+        'does not double-emit', () {
+      fakeAsync((async) {
+        final hr = FakeHeartRateService();
+        final container = ProviderContainer(overrides: [
+          heartRateServiceProvider.overrideWithValue(hr),
+          entitlementServiceProvider.overrideWithValue(_AlwaysEntitled()),
+          zoneConfigurationProvider.overrideWithValue(_config()),
+          maxHrAlertProvider.overrideWith(
+            () => _SeededMaxHrAlertNotifier(const MaxHrAlertSettings()),
+          ),
+        ]);
+        addTearDown(container.dispose);
+        final sub = container.read(trainerEventBusProvider).events.listen(
+              received.add,
+            );
+        addTearDown(sub.cancel);
+
+        // Mirrors how the router shell reads the provider on every rebuild
+        // (see coachBridgeProvider's analogous test and its doc comment).
+        final first = container.read(hrEventSourceProvider);
+        final second = container.read(hrEventSourceProvider);
+
+        expect(identical(first, second), isTrue,
+            reason: 'hrEventSourceProvider must not be recreated on repeat '
+                'reads, or a leaked second source would double-subscribe to '
+                'the heart rate stream');
+
+        hr.emitHeartRate(190);
+        async.flushMicrotasks();
+
+        expect(received, hasLength(1),
+            reason: 'a leaked second source would emit every safety '
+                'warning twice');
       });
     });
   });

--- a/test/features/trainer/presentation/hr_event_source_test.dart
+++ b/test/features/trainer/presentation/hr_event_source_test.dart
@@ -9,6 +9,8 @@ import 'package:rep_foundry/core/entitlements/entitlement_provider.dart';
 import 'package:rep_foundry/core/entitlements/entitlement_service.dart';
 import 'package:rep_foundry/core/providers.dart';
 import 'package:rep_foundry/features/cardio/data/heart_rate_service.dart';
+import 'package:rep_foundry/features/heart_rate/presentation/controllers/heart_rate_panel_controller.dart';
+import 'package:rep_foundry/features/heart_rate/presentation/controllers/heart_rate_panel_state.dart';
 import 'package:rep_foundry/features/heart_rate/presentation/providers/heart_rate_panel_visibility_provider.dart';
 import 'package:rep_foundry/features/heart_rate/presentation/providers/max_hr_alert_provider.dart';
 import 'package:rep_foundry/features/heart_rate/presentation/providers/zone_configuration_provider.dart';
@@ -34,6 +36,22 @@ class _SeededMaxHrAlertNotifier extends MaxHrAlertNotifier {
 
   @override
   MaxHrAlertSettings build() => _seed;
+}
+
+/// Pushes a fixed [HeartRatePanelState] synchronously — used only to control
+/// `isMonitoring` for the sequencing-delay tests below (fix round 1: the
+/// delay predicate now also checks it, since the panel's own chime never
+/// sounds while paused).
+class _SeededPanelNotifier extends HeartRatePanelController {
+  _SeededPanelNotifier(this._seed);
+
+  final HeartRatePanelState _seed;
+
+  @override
+  HeartRatePanelState build() {
+    super.build();
+    return _seed;
+  }
 }
 
 /// A minimal [HeartRateService] whose stream can be made to emit an error,
@@ -158,6 +176,10 @@ void main() {
     // every existing test's timing is unaffected — the sequencing delay only
     // ever activates when a test opts in via [panelVisible].
     bool panelVisible = false,
+    // Defaults true so tests that only pass `panelVisible: true` keep
+    // exercising the delay without also having to seed monitoring — the
+    // dedicated "not monitoring" test below is the one that sets this false.
+    bool panelMonitoring = true,
     MaxHrAlertSettings maxHrAlertSettings = const MaxHrAlertSettings(),
   }) {
     final container = ProviderContainer(overrides: [
@@ -176,6 +198,11 @@ void main() {
       // in-memory only and never touches SharedPreferences.
       maxHrAlertProvider.overrideWith(
         () => _SeededMaxHrAlertNotifier(maxHrAlertSettings),
+      ),
+      heartRatePanelProvider.overrideWith(
+        () => _SeededPanelNotifier(
+          HeartRatePanelState(isMonitoring: panelMonitoring),
+        ),
       ),
       _sourceUnderTest.overrideWith(create ?? (ref) => HrEventSource(ref)),
     ]);
@@ -714,6 +741,32 @@ void main() {
           heartRateService: hr,
           panelVisible: true,
           maxHrAlertSettings: const MaxHrAlertSettings(soundEnabled: false),
+        );
+        container.read(_sourceUnderTest);
+
+        hr.emitHeartRate(190);
+        async.flushMicrotasks();
+
+        expect(received, hasLength(1));
+      });
+    });
+
+    // Fix round 1: the delay predicate was tightened to also check
+    // isMonitoring, since heart_rate_panel_screen.dart's _checkMaxHrAlert
+    // returns before ever consulting the sound toggle when the panel isn't
+    // actively monitoring — a panel that is merely open (e.g. connected but
+    // paused) has no chime coming.
+    test(
+        'does not delay when the panel is visible and its sound alert is on '
+        'but it is not actively monitoring — there is no chime to land '
+        'after either', () {
+      fakeAsync((async) {
+        final hr = FakeHeartRateService();
+        final container = buildContainer(
+          heartRateService: hr,
+          panelVisible: true,
+          panelMonitoring: false,
+          maxHrAlertSettings: const MaxHrAlertSettings(soundEnabled: true),
         );
         container.read(_sourceUnderTest);
 

--- a/test/features/trainer/presentation/trainer_settings_provider_test.dart
+++ b/test/features/trainer/presentation/trainer_settings_provider_test.dart
@@ -64,4 +64,69 @@ void main() {
     // The value the load would have applied must still land correctly.
     expect(container.read(trainerSettingsProvider).countdownsEnabled, isFalse);
   });
+
+  group('heart-rate settings', () {
+    test('hrCalloutsEnabled and hrSafetyWarningsEnabled default to true',
+        () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final settings = container.read(trainerSettingsProvider);
+      expect(settings.hrCalloutsEnabled, isTrue);
+      expect(settings.hrSafetyWarningsEnabled, isTrue);
+    });
+
+    test('setHrCallouts persists under its own preference key', () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await container.read(trainerSettingsProvider.notifier).setHrCallouts(
+            false,
+          );
+
+      expect(
+          container.read(trainerSettingsProvider).hrCalloutsEnabled, isFalse);
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getBool('trainer_hr_callouts'), isFalse);
+    });
+
+    test(
+        'setHrSafetyWarnings persists under its own preference key,'
+        ' distinct from hrCallouts', () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await container
+          .read(trainerSettingsProvider.notifier)
+          .setHrSafetyWarnings(false);
+
+      final settings = container.read(trainerSettingsProvider);
+      expect(settings.hrSafetyWarningsEnabled, isFalse);
+      expect(settings.hrCalloutsEnabled, isTrue,
+          reason: 'the two toggles must be independent');
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getBool('trainer_hr_safety'), isFalse);
+    });
+
+    test('a stored false value for either toggle is honoured on load',
+        () async {
+      SharedPreferences.setMockInitialValues({
+        'trainer_hr_callouts': false,
+        'trainer_hr_safety': false,
+      });
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      // Awaiting any mutator forces the notifier to wait on its own
+      // in-flight load first (see `_loading` in the notifier), which is the
+      // reliable way to know the load has resolved — an arbitrary
+      // `Future.delayed` is not guaranteed to flush every microtask the
+      // real SharedPreferences plugin channel involves.
+      await container.read(trainerSettingsProvider.notifier).acceptDisclaimer();
+
+      final settings = container.read(trainerSettingsProvider);
+      expect(settings.hrCalloutsEnabled, isFalse);
+      expect(settings.hrSafetyWarningsEnabled, isFalse);
+    });
+  });
 }

--- a/test/features/trainer/presentation/trainer_settings_screen_test.dart
+++ b/test/features/trainer/presentation/trainer_settings_screen_test.dart
@@ -214,6 +214,8 @@ void main() {
     await enableViaMasterSwitch(tester);
     expect(findEnableSwitch(tester).value, isTrue);
 
+    await tester.ensureVisible(find.text('Review safety notice'));
+    await tester.pumpAndSettle();
     await tester.tap(find.text('Review safety notice'));
     await tester.pumpAndSettle();
     await tester.tap(find.text('Not now'));
@@ -225,6 +227,15 @@ void main() {
     final settings = container.read(trainerSettingsProvider);
     expect(settings.disclaimerAccepted, isTrue);
     expect(settings.enabled, isTrue);
+
+    // Scroll back up: the earlier ensureVisible() left "Enable coach" outside
+    // the lazily-built ListView's built extent, so ensureVisible (which only
+    // scrolls an already-built element into view) can't reach it directly.
+    tester
+        .state<ScrollableState>(find.byType(Scrollable).first)
+        .position
+        .jumpTo(0);
+    await tester.pumpAndSettle();
     expect(findEnableSwitch(tester).value, isTrue);
   });
 
@@ -293,6 +304,69 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Withdraw consent'), findsNothing);
+  });
+
+  group('heart-rate settings', () {
+    testWidgets(
+        'both HR switches default on and are listed with HR safety '
+        'warnings last', (tester) async {
+      await tester.pumpWidget(buildScreen());
+      await tester.pumpAndSettle();
+
+      final calloutsSwitch = tester.widget<SwitchListTile>(
+        find.widgetWithText(SwitchListTile, 'Heart rate zone callouts'),
+      );
+      final safetySwitch = tester.widget<SwitchListTile>(
+        find.widgetWithText(SwitchListTile, 'Heart rate safety warnings'),
+      );
+      expect(calloutsSwitch.value, isTrue);
+      expect(safetySwitch.value, isTrue);
+
+      // "Listed last" among the toggles: HR safety warnings sits below HR
+      // callouts on screen.
+      final calloutsY = tester.getTopLeft(find.byWidget(calloutsSwitch)).dy;
+      final safetyY = tester.getTopLeft(find.byWidget(safetySwitch)).dy;
+      expect(safetyY, greaterThan(calloutsY));
+    });
+
+    testWidgets(
+        'toggling HR callouts off persists independently of HR '
+        'safety warnings', (tester) async {
+      await tester.pumpWidget(buildScreen());
+      await tester.pumpAndSettle();
+
+      await tester.tap(
+        find.widgetWithText(SwitchListTile, 'Heart rate zone callouts'),
+      );
+      await tester.pumpAndSettle();
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(TrainerSettingsScreen)),
+      );
+      final settings = container.read(trainerSettingsProvider);
+      expect(settings.hrCalloutsEnabled, isFalse);
+      expect(settings.hrSafetyWarningsEnabled, isTrue);
+    });
+
+    testWidgets(
+        'toggling HR safety warnings off is the user\'s own choice '
+        'to make, and it takes effect', (tester) async {
+      await tester.pumpWidget(buildScreen());
+      await tester.pumpAndSettle();
+
+      await tester.tap(
+        find.widgetWithText(SwitchListTile, 'Heart rate safety warnings'),
+      );
+      await tester.pumpAndSettle();
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(TrainerSettingsScreen)),
+      );
+      expect(
+        container.read(trainerSettingsProvider).hrSafetyWarningsEnabled,
+        isFalse,
+      );
+    });
   });
 
   group('SettingsScreen entitlement gate', () {


### PR DESCRIPTION
Implements phase 2a of the Virtual Personal Trainer: the coach becomes heart-rate aware. It announces training-zone changes, warns when the user exceeds their safe maximum, and — the point of the whole phase — **stops encouraging anyone whose heart rate is already above their cap**.

This is the first time `SpeechPriority.safety` is reachable in the product.

Plan: `docs/superpowers/plans/2026-08-02-virtual-trainer-phase-2a-hr-coaching.md`
Spec: `docs/superpowers/specs/2026-08-01-virtual-personal-trainer-design.md` §6

Closes #91. Personas and the quote bank are #99 and deliberately not here.

## What's here

- **Zone lookup and three HR events** — `HeartRateZoneChanged`, `HeartRateAboveCap`, `HeartRateBackBelowCap`. The lookup delegates to the `hr_zones` package so boundary semantics have one owner.
- **Engine safety rules** — above cap, all encouragement is suppressed and a calm warning repeats at most every 30 s; caution mode leaves zone callouts but stops encouragement at any intensity; encouragement never fires in zone 5; the callout toggle can never silence a cap warning.
- **HR event source** — maps the BLE stream onto events, with a 10 s dwell before announcing a zone change so boundary flicker cannot make the coach chatter.
- **Wiring, settings and phrases** — two new toggles (HR callouts, and HR safety warnings defaulting on), the Steady pack's HR phrases, and the source mounted app-wide.

## Two design decisions worth knowing

**The existing max-HR alert stays as the attention-getter.** It keeps firing unchanged; the coach's line lands ~1.5 s *after* it. A chime cuts through instantly where a spoken line takes ~2 s, so unlike the rest-timer fix in #98 the chime is the better safety signal here and is deliberately not suppressed.

**This closes a real gap.** The existing alert only fires while the HR panel screen is mounted. Lifting with a strap on and the panel closed — the normal case — nothing warned you at all. The coach's bridge is app-wide, so it now does. There is a test for it.

## Verification

1261 tests passing, `dart analyze` clean, `dart format` clean, `coaching_engine.dart` at 100%.

Four review rounds found things the tests did not, which is worth recording:

- **The coach congratulated users above their cap.** `WorkoutFinished` spoke unconditionally, so finishing a hard session over your maximum produced "Session complete, well done". The suppression rule had been applied in two switch arms rather than at one choke point, so the milestone branches were simply never brought in.
- **Fixing that made `stop()` reachable and truncated the safety warning.** Suppressing the finish cue exposed a bridge branch that cut off an in-flight "ease off" line — the one utterance that must never be clipped.
- **The signal-loss timeout was shorter than the BLE reconnect schedule.** At 8 s it fired during a routine GATT-133 retry and announced "back under your maximum" while the user was genuinely still above it. Now 25 s, which clears the first three reconnect attempts.
- **Three tests passed while proving nothing.** The integration test asserting end-to-end suppression ran its logged sets with zero elapsed time, so they died at the encouragement cooldown and never reached the safety check — it would have passed with the suppression deleted. Same class of problem for the anti-flicker branch and the `dispose()` probe. Coverage read 100% throughout.

## Device verification — PARTIAL, and the important half is outstanding

Run on a Galaxy S9+ with this build:

- ✅ Builds, installs, launches cleanly with the event source mounted — no crash, no `E/flutter`.
- ✅ Panel-visibility lifecycle: three tab cycles, background/foreground, rotate — no exception, no `StateError`.
  - Limit: the flag's *value* is not observable without a cap crossing, so this rules out its wiring throwing, not the flag sticking `true` after unmount.

**Not verified — every one of these needs a chest strap worn, and none has been done:**

1. **Stale replayed reading.** `lastValueStream` replays its cached value on subscribe and the service re-subscribes on reconnect, so the first reading after a dropout may be the stale pre-dropout bpm. Go above cap, kill the strap, let it reconnect: confirm no false "back under your maximum" during recovery, and no re-fired warning from stale data afterwards. **No test can settle this.**
2. **Real TTS sequencing** — chime, then ~1.5 s, then the spoken warning intact and not truncated.
3. **Hysteresis in the field** — the "back under" line should only come after 5 bpm and 5 s below the cap, not on the first dip.
4. **Second crossing inside the chime's 15 s cooldown** — the coach's line arrives 1.5 s late with no chime ahead of it; does that read as a pause or a swallowed warning?
5. **Polar H9 notification cadence** — if it notifies only on change rather than ~1 Hz, the 25 s signal-loss timeout becomes reachable at steady state.

Suggested safe method for the crossings: set Measured Max Heart Rate to ~100 so the cap sits in the resting range, reachable by standing up and clearable by sitting down. **Do not exercise toward a real maximum to test this.**
