### PR TITLE
ci: publish the Antora docs site to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,64 @@
+name: Documentation
+
+# Builds the Antora site from src/docs and publishes it to GitHub Pages.
+#
+# Pull requests build the site but do not deploy — --log-failure-level=warn
+# turns a broken xref or missing include into a failed check, so documentation
+# breakage is caught on the PR rather than after it lands on main.
+#
+# Repo setting required once: Settings → Pages → Build and deployment →
+# Source = "GitHub Actions".
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+# Serialise deployments. Queued runs wait rather than cancel, so a rapid
+# sequence of pushes still ends with the newest commit published.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build Antora site
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      # Mirrors the local `gradle21w antora` build (org.antora Gradle plugin,
+      # Antora 3.1) but invokes Antora directly so the docs job needs no JVM.
+      # Keep the pinned major in step with the plugin's bundled version.
+      - name: Build site
+        run: npx --yes antora@3.1 --fetch --log-failure-level=warn antora-playbook.yml
+
+      - name: Upload Pages artifact
+        if: github.event_name == 'push'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: build/site
+
+  deploy:
+    name: Deploy to GitHub Pages
+    if: github.event_name == 'push'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -1,5 +1,9 @@
 site:
   title: RepFoundry Documentation
+  # Project-site URL on GitHub Pages. The /RepFoundry path segment matters —
+  # Antora uses it as the site's base path when generating the 404 page and
+  # sitemap, which would otherwise point at the domain root.
+  url: https://bovinemagnet.github.io/RepFoundry
   start_page: repfoundry::index.adoc
 
 content:


### PR DESCRIPTION
Sets up GitHub Pages publishing for the Antora documentation site under `src/docs`.

## What changed

**`.github/workflows/docs.yml`** (new) — two jobs:

- **build** — checkout, Node 20, `npx --yes antora@3.1 --fetch --log-failure-level=warn antora-playbook.yml`, then upload `build/site` as a Pages artifact (push only).
- **deploy** — `actions/deploy-pages@v4` into the `github-pages` environment, gated to pushes on `main`.

Pull requests build the site without deploying. `--log-failure-level=warn` is what makes that check worth having: a broken `xref` or missing include exits non-zero instead of only logging, so docs breakage fails the PR rather than landing on `main`. Concurrency group `pages` with `cancel-in-progress: false` serialises deploys so the newest commit wins.

Antora is invoked directly through `npx` rather than the `org.antora` Gradle plugin, so the docs job needs no JVM. The pinned major (3.1) matches the version the plugin bundles (3.1.15) — keep the two in step.

**`antora-playbook.yml`** — added `site.url: https://bovinemagnet.github.io/RepFoundry`, which was previously unset. The `/RepFoundry` path segment is what marks this as a project site rather than a user site; Antora uses it as the base path for the generated 404 page and sitemap.

**Repository setting** — Pages enabled via the API with `build_type=workflow`. Already applied, so no manual step is needed after merge.

## Verification

- `npx antora@3.1 --fetch --log-failure-level=warn antora-playbook.yml` exits 0 against the current docs, so the strict PR check does not fail on existing content.
- `gradle21w antora` still builds clean.
- With `site.url` set, `build/site/404.html` emits `href="/RepFoundry/_/css/site.css"` and `sitemap.xml` is generated — neither was the case before.

The build job on this PR is itself the first real test of the workflow.

## Notes

- `build.gradle` sets `environment = ['SITE_URL': 'https://repfoundry.dev']`. That variable has no effect — Antora reads `URL`, not `SITE_URL`. It is dead config from an earlier attempt at this, left untouched here as out of scope, but worth removing or wiring up if a custom domain is still wanted.
- The strict failure level is CI-only; `gradle21w antora` stays lenient locally. Adding `--log-failure-level=warn` to `options` in `build.gradle` would bring local builds in line.
