### PR TITLE
fix: point header nav at the component path, not the site root

### DIFF
--- a/ui/src/partials/header-content.hbs
+++ b/ui/src/partials/header-content.hbs
@@ -13,9 +13,12 @@
     </div>
     <div id="topbar-nav" class="navbar-menu">
       <div class="navbar-end">
-        <a class="navbar-item" href="{{{relativize '/index.html'}}}">Overview</a>
-        <a class="navbar-item" href="{{{relativize '/getting-started.html'}}}">Getting Started</a>
-        <a class="navbar-item" href="{{{relativize '/architecture.html'}}}">Architecture</a>
+        {{!-- Antora namespaces every page under its component name, so these
+              must be /repfoundry/… and not site-root paths. The component name
+              comes from src/docs/antora.yml; rename it there and these break. --}}
+        <a class="navbar-item" href="{{{relativize '/repfoundry/index.html'}}}">Overview</a>
+        <a class="navbar-item" href="{{{relativize '/repfoundry/getting-started.html'}}}">Getting Started</a>
+        <a class="navbar-item" href="{{{relativize '/repfoundry/architecture.html'}}}">Architecture</a>
         <a class="navbar-item is-external" href="https://github.com/bovinemagnet/RepFoundry">Source</a>
         <button class="theme-toggle" type="button" aria-label="Toggle light and dark theme" title="Toggle light and dark theme">
           <span class="icon icon-dark">dark_mode</span>


### PR DESCRIPTION
The **Getting Started** and **Architecture** links in the site header 404.

## Cause

`ui/src/partials/header-content.hbs` used site-root-absolute paths:

```hbs
<a class="navbar-item" href="{{{relativize '/getting-started.html'}}}">Getting Started</a>
```

Antora namespaces every page under its component name (`repfoundry`, from `src/docs/antora.yml`), so the page actually lives at `/repfoundry/getting-started.html`. From a page at `/repfoundry/architecture.html` that template rendered `../getting-started.html`, which escapes the component directory:

| URL | Before |
|---|---|
| `/RepFoundry/getting-started.html` | **404** |
| `/RepFoundry/architecture.html` | **404** |
| `/RepFoundry/repfoundry/getting-started.html` | 200 |

**Overview** appeared to work, but only because Antora generates a redirect stub at the site root — it was bouncing through a redirect rather than linking directly. It now points at the component index.

These three literals were the only affected links; a grep of `relativize '` across all partials and layouts found nothing else.

## Verification

`relativize` adapts to page depth, so the fix has to hold at more than one level. Every generated `navbar-item` href was resolved against the built site:

| Page | Rendered href | Resolves to |
|---|---|---|
| `/repfoundry/index.html` | `getting-started.html` | ✅ |
| `/repfoundry/architecture.html` | `getting-started.html` | ✅ |
| `/repfoundry/features/heart-rate.html` | `../getting-started.html` | ✅ |
| `/404.html` | `/RepFoundry/repfoundry/getting-started.html` | ✅ |

The 404 page is a deliberate special case — Antora emits site-root-absolute URLs there because a 404 can be served from any path, where relative links would break.

## Note

Nothing catches this class of bug automatically. Antora validates `xref:` between pages, but links hardcoded in UI templates are invisible to it — which is exactly why these shipped. A link-checker step over `build/site` in the docs workflow would close the gap; happy to add one if you want it.
