### PR TITLE
chore: align the iOS and macOS bundle id with Android and CloudKit

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -496,7 +496,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.repfoundry.repFoundry;
+				PRODUCT_BUNDLE_IDENTIFIER = com.repfoundry.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -513,7 +513,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.repfoundry.repFoundry.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.repfoundry.app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -531,7 +531,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.repfoundry.repFoundry.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.repfoundry.app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -547,7 +547,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.repfoundry.repFoundry.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.repfoundry.app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -679,7 +679,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.repfoundry.repFoundry;
+				PRODUCT_BUNDLE_IDENTIFIER = com.repfoundry.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -702,7 +702,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.repfoundry.repFoundry;
+				PRODUCT_BUNDLE_IDENTIFIER = com.repfoundry.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -471,7 +471,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.repfoundry.repFoundry.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.repfoundry.app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/rep_foundry.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/rep_foundry";
@@ -486,7 +486,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.repfoundry.repFoundry.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.repfoundry.app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/rep_foundry.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/rep_foundry";
@@ -501,7 +501,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.repfoundry.repFoundry.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.repfoundry.app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/rep_foundry.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/rep_foundry";

--- a/macos/Runner/Configs/AppInfo.xcconfig
+++ b/macos/Runner/Configs/AppInfo.xcconfig
@@ -8,7 +8,7 @@
 PRODUCT_NAME = rep_foundry
 
 // The application's bundle identifier
-PRODUCT_BUNDLE_IDENTIFIER = com.repfoundry.repFoundry
+PRODUCT_BUNDLE_IDENTIFIER = com.repfoundry.app
 
 // The copyright displayed in application information
 PRODUCT_COPYRIGHT = Copyright © 2026 com.repfoundry. All rights reserved.


### PR DESCRIPTION
Renames the iOS and macOS bundle identifier from `com.repfoundry.repFoundry` to `com.repfoundry.app`.

## Why now

A bundle identifier **cannot be changed once the app has shipped to the App Store**. This is the last free moment to fix it, and it came up while registering the App ID.

## Why it needed fixing

The project disagreed with itself three ways:

| Where | Identifier |
|---|---|
| iOS / macOS Xcode projects | `com.repfoundry.repFoundry` |
| Android (`android/app/build.gradle`) | `com.repfoundry.app` |
| iCloud container in `ios/Runner/Runner.entitlements` | `iCloud.com.repfoundry.app` |

The camelCase form was Flutter's default, derived from the Dart package name `rep_foundry` — nothing chose it.

More to the point, `ios/Runner/CloudKitSyncPlugin.swift` already hardcodes **both** `iCloud.com.repfoundry.app` as the CloudKit container and `com.repfoundry.app/cloudkit_sync` as the method channel. The Swift side was written against an identifier the Xcode project did not use. That mismatch was latent — it would have surfaced as CloudKit failing at runtime on a signed build, well after the point where the identifier could still be changed.

## What changed

`com.repfoundry.repFoundry` → `com.repfoundry.app` in:

- `ios/Runner.xcodeproj/project.pbxproj` — Runner (debug/profile/release) and RunnerTests
- `macos/Runner.xcodeproj/project.pbxproj` — RunnerTests
- `macos/Runner/Configs/AppInfo.xcconfig` — the macOS Runner

macOS is included rather than left as the odd one out, and matching identifiers keep universal purchase available later.

## Verification

- `flutter build ios --no-codesign` succeeds. The build log reports "Building com.repfoundry.app for device", and the produced `build/ios/iphoneos/Runner.app` reports `CFBundleIdentifier = com.repfoundry.app` via PlistBuddy — checked on the artefact, not inferred from the source edit.
- 1315 tests passing.
- Two SPM `Package.resolved` files that the iOS build touched as a side effect were reverted; they are unrelated to this change.

## Not included

`DEVELOPMENT_TEAM` is still unset in both Xcode projects. Left to Xcode or CI secrets rather than checked in.
