### PR TITLE
fix: stop the LOG SET button being clipped off narrow phones

### DIFF
--- a/integration_test/flows/complete_workout_test.dart
+++ b/integration_test/flows/complete_workout_test.dart
@@ -60,8 +60,11 @@ void main() {
       await tester.pumpAndSettle();
 
       // 10. A set card should appear showing the weight and reps (the reps
-      // use a "×" multiplication sign in the redesigned set chip).
-      expect(find.text('100.0kg'), findsOneWidget);
+      // use a "×" multiplication sign in the redesigned set chip). The
+      // weight has no trailing ".0": the chip renders through
+      // WeightUnit.formatFromKg, which drops a zero decimal, so 100 kg
+      // reads "100kg" and 62.5 kg reads "62.5kg".
+      expect(find.text('100kg'), findsOneWidget);
       expect(find.text('× 5'), findsOneWidget);
 
       // The first set sets a personal record, whose celebration overlay covers

--- a/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -19,6 +19,33 @@
       }
     },
     {
+      "identity" : "dkcamera",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/zhangao0086/DKCamera",
+      "state" : {
+        "branch" : "master",
+        "revision" : "5c691d11014b910aff69f960475d70e65d9dcc96"
+      }
+    },
+    {
+      "identity" : "dkimagepickercontroller",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/zhangao0086/DKImagePickerController",
+      "state" : {
+        "branch" : "4.3.9",
+        "revision" : "0bdfeacefa308545adde07bef86e349186335915"
+      }
+    },
+    {
+      "identity" : "dkphotogallery",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/zhangao0086/DKPhotoGallery",
+      "state" : {
+        "branch" : "master",
+        "revision" : "311c1bc7a94f1538f82773a79c84374b12a2ef3d"
+      }
+    },
+    {
       "identity" : "googlesignin-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleSignIn-iOS.git",
@@ -61,6 +88,33 @@
       "state" : {
         "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
         "version" : "2.4.0"
+      }
+    },
+    {
+      "identity" : "sdwebimage",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SDWebImage/SDWebImage",
+      "state" : {
+        "revision" : "2de3a496eaf6df9a1312862adcfd54acd73c39c0",
+        "version" : "5.21.7"
+      }
+    },
+    {
+      "identity" : "swiftygif",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kirualex/SwiftyGif.git",
+      "state" : {
+        "revision" : "4430cbc148baa3907651d40562d96325426f409a",
+        "version" : "5.4.5"
+      }
+    },
+    {
+      "identity" : "tocropviewcontroller",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/TimOliver/TOCropViewController",
+      "state" : {
+        "revision" : "d4a6d8100f4b886fdbc8ae399bf144ff3e9afb7e",
+        "version" : "2.8.0"
       }
     }
   ],

--- a/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -19,6 +19,33 @@
       }
     },
     {
+      "identity" : "dkcamera",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/zhangao0086/DKCamera",
+      "state" : {
+        "branch" : "master",
+        "revision" : "5c691d11014b910aff69f960475d70e65d9dcc96"
+      }
+    },
+    {
+      "identity" : "dkimagepickercontroller",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/zhangao0086/DKImagePickerController",
+      "state" : {
+        "branch" : "4.3.9",
+        "revision" : "0bdfeacefa308545adde07bef86e349186335915"
+      }
+    },
+    {
+      "identity" : "dkphotogallery",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/zhangao0086/DKPhotoGallery",
+      "state" : {
+        "branch" : "master",
+        "revision" : "311c1bc7a94f1538f82773a79c84374b12a2ef3d"
+      }
+    },
+    {
       "identity" : "googlesignin-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleSignIn-iOS.git",
@@ -61,6 +88,33 @@
       "state" : {
         "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
         "version" : "2.4.0"
+      }
+    },
+    {
+      "identity" : "sdwebimage",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SDWebImage/SDWebImage",
+      "state" : {
+        "revision" : "2de3a496eaf6df9a1312862adcfd54acd73c39c0",
+        "version" : "5.21.7"
+      }
+    },
+    {
+      "identity" : "swiftygif",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kirualex/SwiftyGif.git",
+      "state" : {
+        "revision" : "4430cbc148baa3907651d40562d96325426f409a",
+        "version" : "5.4.5"
+      }
+    },
+    {
+      "identity" : "tocropviewcontroller",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/TimOliver/TOCropViewController",
+      "state" : {
+        "revision" : "d4a6d8100f4b886fdbc8ae399bf144ff3e9afb7e",
+        "version" : "2.8.0"
       }
     }
   ],

--- a/lib/features/workout/presentation/widgets/set_input_card.dart
+++ b/lib/features/workout/presentation/widgets/set_input_card.dart
@@ -242,67 +242,82 @@ class _SetInputCardState extends State<SetInputCard> {
           // ── Action row ─────────────────────────────────────────────
           // "+ Add RPE" (accent mono text), "Warm-up" ghost pill toggle,
           // and "+ Log Set" KineticCta pushed to the trailing edge.
+          //
+          // The affordances sit in a Wrap inside an Expanded rather than
+          // directly in this Row. Laid out in a row they need 522pt, and
+          // every phone we support gives less — 393pt on an iPhone 16 Pro —
+          // which clipped the LOG SET call-to-action off the right edge and
+          // painted it under the Add Exercise button. A Wrap cannot overflow
+          // horizontally: it reflows onto a second line instead, at any
+          // width, in any language. The CTA stays outside it so it keeps the
+          // trailing edge on wide layouts.
           Row(
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
-              // "+ Add RPE" affordance — accent mono, matches rf.css
-              // inline style: color:var(--accent-line), JetBrains Mono 700 12px.
-              GestureDetector(
-                onTap: () => setState(() => _showRpe = !_showRpe),
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
+              Expanded(
+                child: Wrap(
+                  spacing: 10,
+                  runSpacing: 8,
+                  crossAxisAlignment: WrapCrossAlignment.center,
                   children: [
-                    Icon(
-                      _showRpe ? Icons.remove : Icons.add,
-                      size: 16,
-                      color: cs.primary,
-                    ),
-                    const SizedBox(width: 5),
-                    Text(
-                      (_showRpe ? s.hideRpe : s.addRpe).toUpperCase(),
-                      style: KineticText.mono(
-                        size: 12,
-                        letterSpacing: 0.5,
-                        color: cs.primary,
+                    // "+ Add RPE" affordance — accent mono, matches rf.css
+                    // inline style: color:var(--accent-line), JetBrains Mono 700 12px.
+                    GestureDetector(
+                      onTap: () => setState(() => _showRpe = !_showRpe),
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Icon(
+                            _showRpe ? Icons.remove : Icons.add,
+                            size: 16,
+                            color: cs.primary,
+                          ),
+                          const SizedBox(width: 5),
+                          Text(
+                            (_showRpe ? s.hideRpe : s.addRpe).toUpperCase(),
+                            style: KineticText.mono(
+                              size: 12,
+                              letterSpacing: 0.5,
+                              color: cs.primary,
+                            ),
+                          ),
+                        ],
                       ),
                     ),
+                    // "Warm-up" ghost pill toggle
+                    GestureDetector(
+                      onTap: () => setState(() => _isWarmUp = !_isWarmUp),
+                      child: KineticPill(
+                        s.warmUpLabel,
+                        variant: _isWarmUp
+                            ? KineticPillVariant.accent
+                            : KineticPillVariant.ghost,
+                      ),
+                    ),
+                    // "Add warm-up" ramp affordance — only for loadable equipment.
+                    if (widget.onAddWarmup != null)
+                      GestureDetector(
+                        onTap: _addWarmup,
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Icon(Icons.whatshot, size: 16, color: cs.primary),
+                            const SizedBox(width: 5),
+                            Text(
+                              s.addWarmup.toUpperCase(),
+                              style: KineticText.mono(
+                                size: 12,
+                                letterSpacing: 0.5,
+                                color: cs.primary,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
                   ],
                 ),
               ),
               const SizedBox(width: 10),
-              // "Warm-up" ghost pill toggle
-              GestureDetector(
-                onTap: () => setState(() => _isWarmUp = !_isWarmUp),
-                child: KineticPill(
-                  s.warmUpLabel,
-                  variant: _isWarmUp
-                      ? KineticPillVariant.accent
-                      : KineticPillVariant.ghost,
-                ),
-              ),
-              // "Add warm-up" ramp affordance — only for loadable equipment.
-              if (widget.onAddWarmup != null) ...[
-                const SizedBox(width: 10),
-                GestureDetector(
-                  onTap: _addWarmup,
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Icon(Icons.whatshot, size: 16, color: cs.primary),
-                      const SizedBox(width: 5),
-                      Text(
-                        s.addWarmup.toUpperCase(),
-                        style: KineticText.mono(
-                          size: 12,
-                          letterSpacing: 0.5,
-                          color: cs.primary,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ],
-              const Spacer(),
               // "+ Log Set" CTA — auto width, 46px height
               KineticCta(
                 label: s.logSet,

--- a/test/features/workout/presentation/widgets/set_input_card_overflow_test.dart
+++ b/test/features/workout/presentation/widgets/set_input_card_overflow_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_foundry/features/workout/presentation/widgets/set_input_card.dart';
+import 'package:rep_foundry/l10n/generated/app_localizations.dart';
+
+/// Phone-width layout guard for [SetInputCard]'s action row.
+///
+/// **This test lives alone in its own file on purpose.** Flutter lays a
+/// widget out differently the second time the same overflowing `RenderFlex`
+/// is built in one test run: the first build reports the true offset (LOG SET
+/// at x=521.8 against 393pt available) and throws; every later build in the
+/// same file reports the clamped 393.0 and throws nothing. A layout guard
+/// sharing a file with other tests therefore passes or fails according to its
+/// position rather than according to the layout, which is worse than having
+/// no guard at all.
+///
+/// The bug this protects against: the action row carries "+ ADD RPE", the
+/// "WARM-UP" pill, "+ ADD WARM-UP" and the LOG SET call-to-action. Those need
+/// 522pt. Every phone we support gives it less — an iPhone 16 Pro gives 393pt
+/// — so LOG SET, the primary action of the whole app, was clipped off the
+/// right edge and painted underneath the "Add Exercise" floating button.
+///
+/// It survived because every other widget test runs on the default 800x600
+/// test surface, which is wider than any phone we ship to. It was found by a
+/// screenshot taken for the user documentation, not by this suite.
+void main() {
+  testWidgets(
+      'the action row fits a 393pt phone when a warm-up ramp is offered',
+      (tester) async {
+    tester.view.physicalSize = const Size(393, 852);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: S.localizationsDelegates,
+        supportedLocales: S.supportedLocales,
+        home: Scaffold(
+          body: SetInputCard(
+            onLogSet: ({
+              required double weight,
+              required int reps,
+              double? rpe,
+              bool isWarmUp = false,
+            }) {},
+            // A non-null callback is what adds "+ ADD WARM-UP" to the row.
+            // It is supplied for every warm-up-rampable exercise — which is
+            // every barbell lift — so this is the common case, not an edge.
+            onAddWarmup: (_) {},
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+
+    // Belt and braces: the exception above proves the row overflowed, this
+    // proves the button a user must reach is actually on the screen.
+    final logSet = find.text('LOG SET');
+    expect(logSet, findsOneWidget);
+    expect(
+      tester.getBottomRight(logSet).dx,
+      lessThanOrEqualTo(393.0),
+      reason: 'LOG SET is clipped off the right edge of a 393pt phone',
+    );
+  });
+}


### PR DESCRIPTION
`SetInputCard`'s action row put four items in a single `Row`: `+ ADD RPE`, the `WARM-UP` pill, `+ ADD WARM-UP`, and the `LOG SET` call-to-action. Together they need **522pt**. An iPhone 16 Pro gives **393pt**.

The row overflowed by 129 pixels. `LOG SET` — the primary action of the entire app — was clipped off the right edge and painted underneath the "Add Exercise" floating button, so taps aimed at it landed on the FAB instead.

Only exercises offering a warm-up ramp were affected, because that is what adds the fourth item. `isWarmupRampable` covers every barbell lift.

## The fix

The three affordances move into a `Wrap` inside an `Expanded`. A `Wrap` cannot overflow horizontally — it reflows onto a second line instead, at any width, in any language, which also covers translations longer than English. The CTA stays outside the `Wrap` so it keeps the trailing edge on wide layouts; tablet and desktop are visually unchanged.

The explicit `SizedBox(width: 10)` separators and the `Spacer` are gone, replaced by the `Wrap`'s own `spacing`.

## Why the suite never caught it

Every widget test in the repo runs on the default **800x600** test surface — wider than any phone the app ships to. At 800pt the row has room, so 1316 green tests said nothing was wrong.

It was found by a screenshot taken for the user documentation, not by the suite.

## The guard, and why it lives alone in its own file

`test/features/workout/presentation/widgets/set_input_card_overflow_test.dart` sets a real 393x852 viewport and asserts both that no overflow is thrown and that `LOG SET`'s right edge is within the screen.

It is a separate file deliberately. Flutter lays the same overflowing `RenderFlex` out differently on a second build within one test run:

| Build | Reported `LOG SET` right edge | Exception |
|---|---|---|
| First in the run | 521.8 | overflow by 129px |
| Any later build | 393.0 | none |

So a layout guard sharing a file with other tests passes or fails according to its **position in the file** rather than according to the layout — worse than no guard, because it looks like coverage. My first attempt sat at the end of the existing `set_input_card_test.dart` and passed; it only failed once run in isolation.

The same effect makes width sweeps lie. Probing several widths in one file produced a nonsensical non-monotonic result (420pt overflow, 400pt "OK", 360pt overflow). Run one width per `flutter test` invocation, it is cleanly monotonic: 440→82px, 420→102px, 400→122px.

## Also fixed

`integration_test/flows/complete_workout_test.dart` was failing for two stacked reasons. The overflow meant the tap on `LOG SET` never landed, and underneath that was a stale assertion expecting `100.0kg`. The redesigned set chip renders through `WeightUnit.formatFromKg`, which drops a zero decimal — 100 kg reads `100kg`, 62.5 kg reads `62.5kg`. The app was right; the expectation was left behind by the Kinetic redesign.

That test now passes end to end.

## Verification

1316 tests passing, `dart analyze` clean, `dart format` clean.

Integration flow tests confirmed passing on the iPhone 16 Pro simulator: `analytics`, `body_metrics`, `cardio_session`, `complete_workout`.

**Not yet verified:** `exercise_management`, `history_browsing`, `programme_workflow`. These are unrelated to this change, but the integration suite has produced two real defects already, so they are worth a run before this merges.

## Worth a follow-up

The integration tests need a simulator and do not run in CI, which is the gap that let a clipped primary action ship. A phone-width viewport is now available as a pattern for any future layout guard.
