### PR TITLE
fix: make the Android release workflow able to start at all

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,21 +52,38 @@ jobs:
             echo "prerelease=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # `secrets` is not one of the contexts available to a step's `if:` —
+      # referencing it there is a workflow validation error that stops the
+      # whole file starting, which is what kept this workflow from ever
+      # running. The steps below branch on this boolean instead, so the
+      # signing key stays in the environment of the one step that decodes it
+      # rather than every step in the job.
+      - name: Detect signing configuration
+        id: signing
+        env:
+          KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+        run: |
+          if [ -n "$KEYSTORE_BASE64" ]; then
+            echo 'present=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'present=false' >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Require signing secrets for non-snapshot releases
-        if: ${{ steps.release_type.outputs.prerelease == 'false' && secrets.KEYSTORE_BASE64 == '' }}
+        if: ${{ steps.release_type.outputs.prerelease == 'false' && steps.signing.outputs.present == 'false' }}
         run: |
           echo "::error::KEYSTORE_BASE64 secret is not set — refusing to publish an unsigned release."
           exit 1
 
       - name: Decode keystore
-        if: ${{ secrets.KEYSTORE_BASE64 != '' }}
+        if: ${{ steps.signing.outputs.present == 'true' }}
         env:
           KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
         run: |
           echo "$KEYSTORE_BASE64" | base64 --decode > android/app/keystore.jks
 
       - name: Create key.properties
-        if: ${{ secrets.KEYSTORE_BASE64 != '' }}
+        if: ${{ steps.signing.outputs.present == 'true' }}
         env:
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}


### PR DESCRIPTION
The Android release workflow has never run. Not "fails sometimes" — never started, since July.

## What is wrong

Three step-level `if:` conditions reference the `secrets` context:

```yaml
if: ${{ steps.release_type.outputs.prerelease == 'false' && secrets.KEYSTORE_BASE64 == '' }}
if: ${{ secrets.KEYSTORE_BASE64 != '' }}
```

`secrets` is not one of the contexts available to `jobs.<job_id>.steps.if`. That is a workflow validation error, and an invalid workflow does not start — so no job is created, nothing is logged, and there is nothing to annotate.

Every symptom follows from that:

- runs complete with `conclusion=failure` and **zero jobs**
- `gh run view --log-failed` reports "log not found", because there is no log
- the commit has no failing check run to annotate
- the workflow is registered as `.github/workflows/release.yml` rather than its declared name, `Android APK Release` — GitHub falls back to the path when it cannot parse the file far enough to read `name:`

## How long, and how badly

| | |
|---|---|
| Runs to date | **80** |
| Successful | **0** |
| Tag-triggered | **0** |
| Introduced by | `9296376` "fix: apply pre-release code review fixes" (2 July 2026) |

Because the file is invalid, GitHub creates a failed run on *every* push to *any* branch, despite the trigger being `on: push: tags: ['v*']`. That is the noise you see on each merge to `main`.

The consequence that matters: **pushing a `v*` tag today builds no APK and creates no GitHub release.** It fails before the first step, and the only outward sign is a red mark with no log behind it.

## The fix

A preflight step publishes a boolean saying whether the signing secret is set; the later steps branch on `steps.signing.outputs.present`, which *is* a context a step `if:` may read.

Lifting the secret to a job-level `env` also fixes the validation error and is the more obvious change, but it puts the signing key into the environment of every step in the job — including `subosito/flutter-action` and `softprops/action-gh-release`. The preflight keeps the key in the two steps that genuinely need it: the one that tests for it and the one that decodes it.

Behaviour is otherwise unchanged: a non-snapshot tag without `KEYSTORE_BASE64` still fails loudly rather than publishing unsigned, and a snapshot tag still builds without signing.

## Verification

The proof is the absence of a run. Every push was creating a startup-failure run — including all five pushes made on this repository earlier today.

```
release.yml runs before pushing this branch:  80
release.yml runs after two pushes of the fix: 80
```

The newest release.yml run is still the `main` merge commit from before the fix. The file now validates, so it correctly does nothing on a branch push and will fire only on a `v*` tag.

**Not verified:** that the job itself succeeds end to end. That requires pushing a real `v*` tag, which builds and publishes a release — not something to do speculatively. The first tag after this merges is still the real test of the steps inside the job, which have never executed once.
